### PR TITLE
Added define "EXPERIMENTAL_BITPLANES"

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -56,13 +56,6 @@ DEFINES+=-DEXPERIMENTAL_NEW_PINOUT
 # If the new pinout is used we should be able to set the maximum available
 # PWM bits. Lower available PMW bits will result in better refresh rate.
 # Little sideffect: the smaller the value the darker the LEDs will be.
-# 
-# Testing commandline:
-#    ./led-matrix -r 32 -P 1 -c 1 -p 4 -D 4
-#
-# Results with EXPERIMENTAL_BITPLANES 4
-# Results with EXPERIMENTAL_BITPLANES 8
-# Results with EXPERIMENTAL_BITPLANES 11
 DEFINES+=-DEXPERIMENTAL_BITPLANES=4
 
 INCDIR=../include

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -52,6 +52,19 @@ TARGET=librgbmatrix.a
 # while working on the new pinout.
 DEFINES+=-DEXPERIMENTAL_NEW_PINOUT
 
+# !!! Only tested with new pinout !!!
+# If the new pinout is used we should be able to set the maximum available
+# PWM bits. Lower available PMW bits will result in better refresh rate.
+# Little sideffect: the smaller the value the darker the LEDs will be.
+# 
+# Testing commandline:
+#    ./led-matrix -r 32 -P 1 -c 1 -p 4 -D 4
+#
+# Results with EXPERIMENTAL_BITPLANES 4
+# Results with EXPERIMENTAL_BITPLANES 8
+# Results with EXPERIMENTAL_BITPLANES 11
+DEFINES+=-DEXPERIMENTAL_BITPLANES=4
+
 INCDIR=../include
 CXXFLAGS=-Wall -O3 -g $(DEFINES)
 

--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -30,7 +30,11 @@
 namespace rgb_matrix {
 namespace internal {
 enum {
+#if defined(EXPERIMENTAL_NEW_PINOUT) && defined(EXPERIMENTAL_BITPLANES)
+  kBitPlanes = EXPERIMENTAL_BITPLANES  // maximum usable bitplanes.
+#else
   kBitPlanes = 11  // maximum usable bitplanes.
+#endif
 };
 
 static const long kBaseTimeNanos = 200;


### PR DESCRIPTION
If the new pinout is used we should be able to set the maximum available
PWM bits. Lower available PMW bits will result in better refresh rate.
Little sideffect: the smaller the value the darker the LEDs will be.

(Tested with stock Rasbian kernel - no RT patch)
Testing commandline:
    
    ./led-matrix -r 32 -P 1 -c 1 -p 4 -D 4
    ./led-matrix -r 32 -P 1 -c 1 -p 8 -D 4
    ./led-matrix -r 32 -P 1 -c 1 -p 11 -D 4

Results with EXPERIMENTAL_BITPLANES=4

    With 4 active bitplanes
        Brightness: low (but viewable) - you can see the white LED chips
        Refreshrate: ~ 450Hz
        No flickering seeable
    With 8 active bitplanes
        not possible
    With 11 active bitplanes
        not possible

Results with EXPERIMENTAL_BITPLANES=8

    With 4 active bitplanes
        Brightness: bright (you don't the white LED chips)
        Refreshrate: ~ 350Hz
        Flickers a little bit
    With 8 active bitplanes
        Brightness: bright (you don't the white LED chips)
        Refreshrate: ~ 200Hz
        No flickering seeable
    With 11 active bitplanes
        not possible

Results with EXPERIMENTAL_BITPLANES=11

    With 4 active bitplanes
        Brightness: bright (you don't the white LED chips)
        Refreshrate: ~ 100Hz
        Flickers a little bit
    With 8 active bitplanes
        Brightness: bright (you don't the white LED chips)
        Refreshrate: ~ 80Hz
        Flickers a little bit
    With 11 active bitplanes
        Brightness: low (but viewable) - you can see the white LED chips
        Refreshrate: ~ 75Hz
        Flickers a little bit

Conclusion:
The lower the maximum available bitplanes the darker the LEDs are. But the better the refresh rate will be.
So the user should experiment with this parameter to get the best value for his own needs.
For me for example I think the value 5 or 6 will be the best choice between number of colors, brightness of the LEDs (with 8 or 11 bitplanes my panel is too bright) and refreshrate