### PR TITLE
 Brightness Control

### DIFF
--- a/demo-main.cc
+++ b/demo-main.cc
@@ -96,6 +96,7 @@ public:
       off_screen_canvas_ = matrix_->SwapOnVSync(off_screen_canvas_);
     }
   }
+
 private:
   RGBMatrix *const matrix_;
   FrameCanvas *off_screen_canvas_;
@@ -106,7 +107,7 @@ class BrightnessPulseGenerator : public ThreadedCanvasManipulator {
 public:
   BrightnessPulseGenerator(RGBMatrix *m) : ThreadedCanvasManipulator(m), matrix_(m) {}
   void Run() {
-    uint8_t max_brightness = matrix_->brightness();
+    const uint8_t max_brightness = matrix_->brightness();
     uint8_t count = 0;
     uint8_t c = 255;
 
@@ -128,6 +129,7 @@ public:
       usleep(20 * 1000);
     }
   }
+
 private:
   RGBMatrix *const matrix_;
 };
@@ -1057,7 +1059,7 @@ static int usage(const char *progname) {
           "\t                   terminal (e.g. cron).\n"
           "\t-t <seconds>     : Run for these number of seconds, then exit.\n"
           "\t                   (if neither -d nor -t are supplied, waits for <RETURN>)\n"
-          "\t-b <brightness>  : Sets brightness level. Default: 1. Range: 1..100\n");
+          "\t-b <brightness>  : Sets brightness level. Default: 100. Range: 1..100\n");
   fprintf(stderr, "Demos, choosen with -D\n");
   fprintf(stderr, "\t0  - some rotating square\n"
           "\t1  - forward scrolling an image (-m <scroll-ms>)\n"

--- a/demo-main.cc
+++ b/demo-main.cc
@@ -101,6 +101,37 @@ private:
   FrameCanvas *off_screen_canvas_;
 };
 
+// Simple generator that pulses through brightness on red, green, blue and white 
+class BrightnessPulseGenerator : public ThreadedCanvasManipulator {
+public:
+  BrightnessPulseGenerator(RGBMatrix *m) : ThreadedCanvasManipulator(m), matrix_(m) {}
+  void Run() {
+    uint8_t max_brightness = matrix_->brightness();
+    uint8_t count = 0;
+    uint8_t c = 255;
+
+    while (running()) {
+      if (matrix_->brightness() < 1) {
+        matrix_->SetBrightness(max_brightness);
+        count++;
+      } else {
+        matrix_->SetBrightness(matrix_->brightness() - 1);
+      }
+
+      switch (count % 4) {
+        case 0: matrix_->Fill(c, 0, 0); break;
+        case 1: matrix_->Fill(0, c, 0); break;
+        case 2: matrix_->Fill(0, 0, c); break;
+        case 3: matrix_->Fill(c, c, c); break;
+      }
+
+      usleep(20 * 1000);
+    }
+  }
+private:
+  RGBMatrix *const matrix_;
+};
+
 class SimpleSquare : public ThreadedCanvasManipulator {
 public:
   SimpleSquare(Canvas *m) : ThreadedCanvasManipulator(m) {}
@@ -1016,17 +1047,17 @@ static int usage(const char *progname) {
           "Default: 32\n"
           "\t-P <parallel> : For Plus-models or RPi2: parallel chains. 1..3. "
           "Default: 1\n"
-          "\t-c <chained>  : Daisy-chained boards. Default: 1.\n"
-          "\t-L            : 'Large' display, composed out of 4 times 32x32\n"
-          "\t-p <pwm-bits> : Bits used for PWM. Something between 1..11\n"
-          "\t-j            : Low jitter. Experimental. Only RPi2\n"
-          "\t-l            : Don't do luminance correction (CIE1931)\n"
-          "\t-D <demo-nr>  : Always needs to be set\n"
-          "\t-d            : run as daemon. Use this when starting in\n"
-          "\t                /etc/init.d, but also when running without\n"
-          "\t                terminal (e.g. cron).\n"
-          "\t-t <seconds>  : Run for these number of seconds, then exit.\n"
-          "\t       (if neither -d nor -t are supplied, waits for <RETURN>)\n");
+          "\t-c <chained>     : Daisy-chained boards. Default: 1.\n"
+          "\t-L               : 'Large' display, composed out of 4 times 32x32\n"
+          "\t-p <pwm-bits>    : Bits used for PWM. Something between 1..11\n"
+          "\t-l               : Don't do luminance correction (CIE1931)\n"
+          "\t-D <demo-nr>     : Always needs to be set\n"
+          "\t-d               : run as daemon. Use this when starting in\n"
+          "\t                   /etc/init.d, but also when running without\n"
+          "\t                   terminal (e.g. cron).\n"
+          "\t-t <seconds>     : Run for these number of seconds, then exit.\n"
+          "\t                   (if neither -d nor -t are supplied, waits for <RETURN>)\n"
+          "\t-b <brightness>  : Sets brightness level. Default: 1. Range: 1..100\n");
   fprintf(stderr, "Demos, choosen with -D\n");
   fprintf(stderr, "\t0  - some rotating square\n"
           "\t1  - forward scrolling an image (-m <scroll-ms>)\n"
@@ -1038,7 +1069,8 @@ static int usage(const char *progname) {
           "\t7  - Conway's game of life (-m <time-step-ms>)\n"
           "\t8  - Langton's ant (-m <time-step-ms>)\n"
           "\t9  - Volume bars (-m <time-step-ms>)\n"
-          "\t10 - Evolution of color (-m <time-step-ms>)\n");
+          "\t10 - Evolution of color (-m <time-step-ms>)\n"
+          "\t11 - Brightness pulse generator\n");
   fprintf(stderr, "Example:\n\t%s -t 10 -D 1 runtext.ppm\n"
           "Scrolls the runtext for 10 seconds\n", progname);
   return 1;
@@ -1054,6 +1086,7 @@ int main(int argc, char *argv[]) {
   int parallel = 1;
   int scroll_ms = 30;
   int pwm_bits = -1;
+  int brightness = 100;
   bool large_display = false;
   bool do_luminance_correct = true;
 
@@ -1085,7 +1118,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   int opt;
-  while ((opt = getopt(argc, argv, "dlD:t:r:P:c:p:m:L")) != -1) {
+  while ((opt = getopt(argc, argv, "dlD:t:r:P:c:p:b:m:L")) != -1) {
     switch (opt) {
     case 'D':
       demo = atoi(optarg);
@@ -1117,6 +1150,10 @@ int main(int argc, char *argv[]) {
 
     case 'p':
       pwm_bits = atoi(optarg);
+      break;
+
+    case 'b':
+      brightness = atoi(optarg);
       break;
 
     case 'l':
@@ -1167,6 +1204,11 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
+  if (brightness < 1 || brightness > 100) {
+    fprintf(stderr, "Brightness is oudside usable range.\n");
+    return 1;
+  }
+
   // Initialize GPIO pins. This might fail when we don't have permissions.
   if (!io.Init())
     return 1;
@@ -1183,6 +1225,7 @@ int main(int argc, char *argv[]) {
   // The matrix, our 'frame buffer' and display updater.
   RGBMatrix *matrix = new RGBMatrix(&io, rows, chain, parallel);
   matrix->set_luminance_correct(do_luminance_correct);
+  matrix->SetBrightness(brightness);
   if (pwm_bits >= 0 && !matrix->SetPWMBits(pwm_bits)) {
     fprintf(stderr, "Invalid range of pwm-bits\n");
     return 1;
@@ -1248,6 +1291,10 @@ int main(int argc, char *argv[]) {
 
   case 10:
     image_gen = new GeneticColors(canvas, scroll_ms);
+    break;
+
+  case 11:
+    image_gen = new BrightnessPulseGenerator(matrix);
     break;
   }
 

--- a/include/led-matrix.h
+++ b/include/led-matrix.h
@@ -84,6 +84,9 @@ public:
   void set_luminance_correct(bool on);
   bool luminance_correct() const;
 
+  void SetBrightness(uint8_t brightness);
+  uint8_t brightness();
+
   //-- Double- and Multibuffering.
 
   // Create a new buffer to be used for multi-buffering. The returned new
@@ -126,6 +129,7 @@ private:
 
   uint8_t pwm_bits_;
   bool do_luminance_correct_;
+  float brightness_;
 
   FrameCanvas *active_;
 

--- a/include/led-matrix.h
+++ b/include/led-matrix.h
@@ -129,7 +129,7 @@ private:
 
   uint8_t pwm_bits_;
   bool do_luminance_correct_;
-  float brightness_;
+  uint8_t brightness_;
 
   FrameCanvas *active_;
 

--- a/lib/framebuffer-internal.h
+++ b/lib/framebuffer-internal.h
@@ -43,6 +43,9 @@ public:
   void set_luminance_correct(bool on) { do_luminance_correct_ = on; }
   bool luminance_correct() const { return do_luminance_correct_; }
 
+  void SetBrightness(uint8_t brightness) {  brightness_ = brightness; }
+  uint8_t brightness() { return brightness_; }
+
   void DumpToMatrix(GPIO *io);
 
   // Canvas-inspired methods, but we're not implementing this interface to not
@@ -66,6 +69,7 @@ private:
 
   uint8_t pwm_bits_;   // PWM bits to display.
   bool do_luminance_correct_;
+  uint8_t brightness_;
 
   const int double_rows_;
   const uint8_t row_mask_;

--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -151,7 +151,7 @@ inline Framebuffer::IoBits *Framebuffer::ValueAt(int double_row,
 // Do CIE1931 luminance correction and scale to output bitplanes
 static uint16_t luminance_cie1931(uint8_t c, uint8_t brigtness) {
   float out_factor = ((1 << kBitPlanes) - 1);
-  float v = c * (float)brigtness / 255.0;
+  float v = c * brigtness / 255.0;
   return out_factor * ((v <= 8) ? v / 902.3 : pow((v + 16) / 116.0, 3));
 }
 

--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -176,7 +176,7 @@ inline uint16_t Framebuffer::MapColor(uint8_t c) {
     return COLOR_OUT_BITS(luminance_lookup[c * 256 + brightness_ - 1]);
   } else {
     // simple scale down the color value
-    c *= (brightness_ / 100);
+    c = c * brightness_ / 100;
 
     enum {shift = kBitPlanes - 8};  //constexpr; shift to be left aligned.
     return COLOR_OUT_BITS((shift > 0) ? (c << shift) : (c >> -shift));

--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -61,7 +61,7 @@ Framebuffer::Framebuffer(int rows, int columns, int parallel)
 #endif
     height_(rows * parallel),
     columns_(columns),
-    pwm_bits_(kBitPlanes), do_luminance_correct_(true),
+    pwm_bits_(kBitPlanes), do_luminance_correct_(true), brightness_(100),
     double_rows_(rows / 2), row_mask_(double_rows_ - 1) {
   bitplane_buffer_ = new IoBits [double_rows_ * columns_ * kBitPlanes];
   Clear();
@@ -149,16 +149,18 @@ inline Framebuffer::IoBits *Framebuffer::ValueAt(int double_row,
 }
 
 // Do CIE1931 luminance correction and scale to output bitplanes
-static uint16_t luminance_cie1931(uint8_t c) {
+static uint16_t luminance_cie1931(uint8_t c, uint8_t brigtness) {
   float out_factor = ((1 << kBitPlanes) - 1);
-  float v = c * 100.0 / 255.0;
+  float v = c * (float)brigtness / 255.0;
   return out_factor * ((v <= 8) ? v / 902.3 : pow((v + 16) / 116.0, 3));
 }
 
 static uint16_t *CreateLuminanceCIE1931LookupTable() {
-  uint16_t *result = new uint16_t [ 256 ];
+  uint16_t *result = new uint16_t[256 * 100];
   for (int i = 0; i < 256; ++i)
-    result[i] = luminance_cie1931(i);
+    for (int j = 0; j < 100; ++j)
+      result[i * 256 + j] = luminance_cie1931(i, j + 1);
+
   return result;
 }
 
@@ -170,10 +172,12 @@ inline uint16_t Framebuffer::MapColor(uint8_t c) {
 #endif
 
   if (do_luminance_correct_) {
-    // We're leaking this table. So be it :)
     static uint16_t *luminance_lookup = CreateLuminanceCIE1931LookupTable();
-    return COLOR_OUT_BITS(luminance_lookup[c]);
+    return COLOR_OUT_BITS(luminance_lookup[c * 256 + brightness_ - 1]);
   } else {
+    // simple scale down the color value
+    c *= (brightness_ / 100);
+
     enum {shift = kBitPlanes - 8};  //constexpr; shift to be left aligned.
     return COLOR_OUT_BITS((shift > 0) ? (c << shift) : (c >> -shift));
   }

--- a/lib/led-matrix.cc
+++ b/lib/led-matrix.cc
@@ -161,7 +161,7 @@ bool RGBMatrix::SetPWMBits(uint8_t value) {
   }
   return success;
 }
-uint8_t RGBMatrix::pwmbits() { return active_->framebuffer()->pwmbits(); }
+uint8_t RGBMatrix::pwmbits() { return pwm_bits_; }
 
 // Map brightness of output linearly to input with CIE1931 profile.
 void RGBMatrix::set_luminance_correct(bool on) {
@@ -169,7 +169,7 @@ void RGBMatrix::set_luminance_correct(bool on) {
   do_luminance_correct_ = on;
 }
 bool RGBMatrix::luminance_correct() const {
-  return active_->framebuffer()->luminance_correct();
+  return do_luminance_correct_;
 }
 
 void RGBMatrix::SetBrightness(uint8_t brightness) {
@@ -178,7 +178,7 @@ void RGBMatrix::SetBrightness(uint8_t brightness) {
 }
 
 uint8_t RGBMatrix::brightness() {
-  return active_->framebuffer()->brightness();
+  return brightness_;
 }
 
 // -- Implementation of RGBMatrix Canvas: delegation to ContentBuffer

--- a/lib/led-matrix.cc
+++ b/lib/led-matrix.cc
@@ -140,9 +140,11 @@ FrameCanvas *RGBMatrix::CreateFrameCanvas() {
     // First time. Get defaults from initial Framebuffer.
     pwm_bits_ = result->framebuffer()->pwmbits();
     do_luminance_correct_ = result->framebuffer()->luminance_correct();
+    brightness_ = result->framebuffer()->brightness();
   } else {
     result->framebuffer()->SetPWMBits(pwm_bits_);
     result->framebuffer()->set_luminance_correct(do_luminance_correct_);
+    result->framebuffer()->SetBrightness(brightness_);
   }
   created_frames_.push_back(result);
   return result;
@@ -168,6 +170,15 @@ void RGBMatrix::set_luminance_correct(bool on) {
 }
 bool RGBMatrix::luminance_correct() const {
   return active_->framebuffer()->luminance_correct();
+}
+
+void RGBMatrix::SetBrightness(uint8_t brightness) {
+  active_->framebuffer()->SetBrightness(brightness);
+  brightness_ = brightness;
+}
+
+uint8_t RGBMatrix::brightness() {
+  return active_->framebuffer()->brightness();
 }
 
 // -- Implementation of RGBMatrix Canvas: delegation to ContentBuffer

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,4 +1,5 @@
 PYTHON     ?= python
+CYTHON     ?= cython
 SETUP      := setup.py
 BUILD_ARGS := build
 INST_ARGS  := install
@@ -66,6 +67,12 @@ install-python:
 clean-python:
 	$(PYTHON) $(SETUP) $(CLEAN_ARGS)
 endif
+
+# For updating the generated code (not a direct dependency of build-python
+# as the generated file is included in the distribution)
+rgbmatrix.cpp : rgbmatrix.pyx
+%.cpp : %.pyx
+	$(CYTHON) --cplus -o $@ $^
 
 build-man: $(MANPAGES:%=build-man-%)
 build-man-%: %.txt

--- a/python/rgbmatrix.pyx
+++ b/python/rgbmatrix.pyx
@@ -30,6 +30,8 @@ cdef extern from "led-matrix.h" namespace "rgb_matrix":
         void SetPixel(int, int, uint8_t, uint8_t, uint8_t)
         void Clear()
         void Fill(uint8_t, uint8_t, uint8_t)
+        void SetBrightness(uint8_t)
+        uint8_t brightness()
         CPPFrameCanvas *CreateFrameCanvas()
         CPPFrameCanvas *SwapOnVSync(CPPFrameCanvas*)
 
@@ -121,6 +123,10 @@ cdef class RGBMatrix:
     property pwmBits:
         def __get__(self): return self.__matrix.pwmbits()
         def __set__(self, pwmBits): self.__matrix.SetPWMBits(pwmBits)
+
+    property brightness:
+        def __get__(self): return self.__matrix.brightness()
+        def __set__(self, brightness): self.__matrix.SetBrightness(brightness)
 
     property height:
         def __get__(self): return self.__matrix.height()

--- a/python/samples/pulsing-brightness.py
+++ b/python/samples/pulsing-brightness.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+from samplebase import SampleBase
+import time
+
+class GrayscaleBlock(SampleBase):
+    def __init__(self, *args, **kwargs):
+        super(GrayscaleBlock, self).__init__(*args, **kwargs)
+
+    def Run(self):
+        max_brightness = self.matrix.brightness
+        count = 0
+        c = 255
+
+        while (True):
+            if self.matrix.brightness < 1:
+                self.matrix.brightness = max_brightness
+                count += 1
+            else:
+                self.matrix.brightness -= 1
+
+            if count % 4 == 0:
+                self.matrix.Fill(c, 0, 0)
+            elif count % 4 == 1:
+                self.matrix.Fill(0, c, 0)
+            elif count % 4 == 2:
+                self.matrix.Fill(0, 0, c)
+            elif count % 4 == 3:
+                self.matrix.Fill(c, c, c)
+
+            self.usleep(20 * 1000)
+
+# Main function
+if __name__ == "__main__":
+    parser = GrayscaleBlock()
+    if (not parser.process()):
+        parser.print_help()

--- a/python/samples/samplebase.py
+++ b/python/samples/samplebase.py
@@ -10,6 +10,7 @@ class SampleBase(argparse.ArgumentParser):
         self.add_argument("-c", "--chain", action = "store", help = "Daisy-chained boards. Default: 1.", default = 1, type = int)
         self.add_argument("-p", "--pwmbits", action = "store", help = "Bits used for PWM. Something between 1..11. Default: 11", default = 11, type = int)
         self.add_argument("-l", "--luminance", action = "store_true", help = "Don't do luminance correction (CIE1931)")
+        self.add_argument("-b", "--brightness", action = "store", help = "Sets brightness level. Default: 1. Range: 1..100", default = 100, type = int)
 
         self.args = {}
 
@@ -39,6 +40,7 @@ class SampleBase(argparse.ArgumentParser):
 
         self.matrix = RGBMatrix(self.args["rows"], self.args["chain"], self.args["parallel"])
         self.matrix.pwmBits = self.args["pwmbits"]
+        self.matrix.brightness = self.args["brightness"]
 
         if self.args["luminance"]:
             self.matrix.luminanceCorrect = False

--- a/python/samples/samplebase.py
+++ b/python/samples/samplebase.py
@@ -10,7 +10,7 @@ class SampleBase(argparse.ArgumentParser):
         self.add_argument("-c", "--chain", action = "store", help = "Daisy-chained boards. Default: 1.", default = 1, type = int)
         self.add_argument("-p", "--pwmbits", action = "store", help = "Bits used for PWM. Something between 1..11. Default: 11", default = 11, type = int)
         self.add_argument("-l", "--luminance", action = "store_true", help = "Don't do luminance correction (CIE1931)")
-        self.add_argument("-b", "--brightness", action = "store", help = "Sets brightness level. Default: 1. Range: 1..100", default = 100, type = int)
+        self.add_argument("-b", "--brightness", action = "store", help = "Sets brightness level. Default: 100. Range: 1..100", default = 100, type = int)
 
         self.args = {}
 


### PR DESCRIPTION
Added functions to control brightness of LED Matrix

Currently SetBrightness() has to be called BEFORE you create a FrameCanvas and BEFORE you draw anything on this FrameCanvas (or the matrix).
Next step will be to make a dynamic brightness control without the need to redraw manually (maybe it will be better to store the RGB data additionally in the canvas and reset the bitplane data after a change on the brightness. So it also will be possible to copy a canvas for better front- and backbuffer handling)