### PR TITLE
Allow Hardware PWM with Adafruit HAT

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -37,6 +37,10 @@ TARGET=librgbmatrix.a
 # Uncomment the following line for Adafruit Matrix HAT gpio mappings
 #DEFINES+=-DADAFRUIT_RGBMATRIX_HAT
 
+# Uncomment the following line for Adafruit Matrix HAT gpio mappings with GPIO
+# 4 and 18 connected to enable using the Raspberry Pi PWM hardware.
+#DEFINES+=-DADAFRUIT_RGBMATRIX_HAT_PWM
+
 # If you have used this library before July 2015 and have wired it up, then
 # you need to define RGB_CLASSIC_PINOUT for your panel to work. The standard
 # pinout changed so that we can make use of the PWM pin for much more stable

--- a/lib/framebuffer-internal.h
+++ b/lib/framebuffer-internal.h
@@ -72,15 +72,21 @@ private:
   const int double_rows_;
   const uint8_t row_mask_;
 
-#ifdef ADAFRUIT_RGBMATRIX_HAT
+#if defined(ADAFRUIT_RGBMATRIX_HAT) || defined(ADAFRUIT_RGBMATRIX_HAT_PWM)
   // Adafruit made a HAT to work with this library, but it has a slightly
-  // different GPIO mapping. This is this mapping. See #else for regular mapping.
+  // different GPIO mapping. This is this mapping. A variant of this mapping
+  // allows using the Raspberry Pi PWM hardware. This requires modifying the
+  // HAT to connect GPIO 4 and 18. See #else for regular mapping.
   union IoBits {
     struct {
       // This bitset reflects the GPIO mapping. The naming of the
       // pins of type 'p0_r1' means 'first parallel chain, red-bit one'
       unsigned int unused_0_3         : 4;  // 0..3
+#ifdef ADAFRUIT_RGBMATRIX_HAT_PWM      
+      unsigned int unused_4           : 1;  // 4
+#else
       unsigned int output_enable      : 1;  // 4
+#endif
       unsigned int p0_r1              : 1;  // 5
       unsigned int p0_b1              : 1;  // 6
       unsigned int unused_7_11        : 5;  // 7..11
@@ -89,7 +95,12 @@ private:
       unsigned int unused_14_15       : 2;  // 14,15
       unsigned int p0_g2              : 1;  // 16
       unsigned int clock              : 1;  // 17
+#ifdef ADAFRUIT_RGBMATRIX_HAT_PWM      
+      unsigned int output_enable      : 1;  // 18
+      unsigned int unused_19          : 1;  // 19
+#else
       unsigned int unused_18_19       : 2;  // 18,19
+#endif
       unsigned int d                  : 1;  // 20
       unsigned int strobe             : 1;  // 21
       unsigned int a                  : 1;  // 22

--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -42,7 +42,7 @@ static const long kBaseTimeNanos = 130;
 static PinPulser *sOutputEnablePulser = NULL;
 
 // The Adafruit HAT only supports one chain.
-#if defined(ADAFRUIT_RGBMATRIX_HAT)
+#if defined(ADAFRUIT_RGBMATRIX_HAT) || defined(ADAFRUIT_RGBMATRIX_HAT_PWM)
 #  define ONLY_SINGLE_CHAIN 1
 #endif
 


### PR DESCRIPTION
I connected GPIO 4 and 18 on the Adafruit HAT (see the holes at the top, below the pin header http://www.adafruit.com/images/970x728/2345-04.jpg), now hardware PWM seems to work with these changes.