### PR TITLE
In imageScroller the variable horizontal_position_ will be to big for an int

### DIFF
--- a/demo-main.cc
+++ b/demo-main.cc
@@ -290,6 +290,8 @@ public:
       }
       offscreen_ = matrix_->SwapOnVSync(offscreen_);
       horizontal_position_ += scroll_jumps_;
+	  
+	  horizontal_position_%=matrix_->transformer()->Transform(offscreen_)->width();
       if (horizontal_position_ < 0) horizontal_position_ = current_image_.width;
       if (scroll_ms_ <= 0) {
         // No scrolling. We don't need the image anymore.


### PR DESCRIPTION
With the time, the variable horizontal_position_ in imageScroller will be to big for an
int and an unexpected behavior happen
