### PR TITLE
fix intriguing problem for utilisation with nodejs

### DIFF
--- a/lib/gpio.cc
+++ b/lib/gpio.cc
@@ -117,7 +117,7 @@ static bool IsRaspberryPi2() {
   buffer[r >= 0 ? r : 0] = '\0';
   close(fd);
   const char *mem_size_key;
-  off_t mem_size;
+  off_t mem_size = 0;
   if ((mem_size_key = strstr(buffer, "mem_size=")) != NULL
       && (sscanf(mem_size_key + strlen("mem_size="), "%lx", &mem_size) == 1)
       && (mem_size == 0x3F000000)) {


### PR DESCRIPTION
In nodejs utilisation, into the `IsRaspberryPi2` function, the `sscanf` fonction does not set correctly the `mem_size` variable if it does not iniatialize to 0. So the `IsRaspberryPi2` function return `false` and ledmatrix doest not update.