### PR TITLE
Added HalfTransformer

### DIFF
--- a/include/transformer.h
+++ b/include/transformer.h
@@ -82,6 +82,19 @@ private:
   TransformCanvas *const canvas_;
 };
 
+class HalfTransformer : public CanvasTransformer {
+public:
+  HalfTransformer();
+  virtual ~HalfTransformer();
+
+  virtual Canvas *Transform(Canvas *output);
+
+private:
+  class TransformCanvas;
+
+  TransformCanvas *const canvas_;
+};
+
 } // namespace rgb_matrix
 
 #endif // RPI_TRANSFORMER_H

--- a/lib/transformer.cc
+++ b/lib/transformer.cc
@@ -224,4 +224,68 @@ Canvas *LargeSquare64x64Transformer::Transform(Canvas *output) {
   return canvas_;
 }
 
+/***********************************/
+/* Half Transformer Canvas */
+/***********************************/
+class HalfTransformer::TransformCanvas : public Canvas {
+public:
+  TransformCanvas() : delegatee_(NULL) {}
+
+  void SetDelegatee(Canvas* delegatee);
+
+  virtual void Clear();
+  virtual void Fill(uint8_t red, uint8_t green, uint8_t blue);
+  virtual int width() const;
+  virtual int height() const;
+  virtual void SetPixel(int x, int y, uint8_t red, uint8_t green, uint8_t blue);
+
+private:
+  Canvas *delegatee_;
+};
+
+void HalfTransformer::TransformCanvas::SetDelegatee(Canvas* delegatee) {
+  // Our assumptions of the underlying geometry:
+  assert(delegatee->height() % 2 == 0);
+
+  delegatee_ = delegatee;
+}
+
+void HalfTransformer::TransformCanvas::Clear() {
+  delegatee_->Clear();
+}
+
+void HalfTransformer::TransformCanvas::Fill(uint8_t red, uint8_t green, uint8_t blue) {
+  delegatee_->Fill(red, green, blue);
+}
+
+int HalfTransformer::TransformCanvas::width() const {
+  return delegatee_->width();
+}
+
+int HalfTransformer::TransformCanvas::height() const {
+  return delegatee_->height() / 2;
+}
+
+void HalfTransformer::TransformCanvas::SetPixel(int x, int y, uint8_t red, uint8_t green, uint8_t blue) {
+  delegatee_->SetPixel(x, y, red, green, blue);
+}
+
+/****************************/
+/* Half Transformer */
+/****************************/
+HalfTransformer::HalfTransformer()
+  : canvas_(new TransformCanvas()) {
+}
+
+HalfTransformer::~HalfTransformer() {
+  delete canvas_;
+}
+
+Canvas *HalfTransformer::Transform(Canvas *output) {
+  assert(output != NULL);
+
+  canvas_->SetDelegatee(output);
+  return canvas_;
+}
+
 } // namespace rgb_matrix


### PR DESCRIPTION
`HalfTransformer` wraps the canvas exposing only the top half to work with my 16x64 LED display.

Using this API with my display required me to specify `chain=2` and `rows=32` in order for all pixels to be addressable. This however leaves the bottom-half of the canvas addressing non-existent pixels. Using this transformer fixes that.