### PR TITLE
ENH: -f flag to flip botton and up in large 64x64 display

### DIFF
--- a/demo-main.cc
+++ b/demo-main.cc
@@ -1016,6 +1016,7 @@ static int usage(const char *progname) {
           "Default: 1\n"
           "\t-c <chained>  : Daisy-chained boards. Default: 1.\n"
           "\t-L            : 'Large' display, composed out of 4 times 32x32\n"
+          "\t-f            : Flip bottom and up in large 64x64 display\n"
           "\t-p <pwm-bits> : Bits used for PWM. Something between 1..11\n"
           "\t-l            : Don't do luminance correction (CIE1931)\n"
           "\t-D <demo-nr>  : Always needs to be set\n"
@@ -1057,12 +1058,13 @@ int main(int argc, char *argv[]) {
   int brightness = 100;
   int rotation = 0;
   bool large_display = false;
+  bool flip_large = false;
   bool do_luminance_correct = true;
 
   const char *demo_parameter = NULL;
 
   int opt;
-  while ((opt = getopt(argc, argv, "dlD:t:r:P:c:p:b:m:LR:")) != -1) {
+  while ((opt = getopt(argc, argv, "dlD:t:r:P:c:p:b:m:LfR:")) != -1) {
     switch (opt) {
     case 'D':
       demo = atoi(optarg);
@@ -1109,6 +1111,10 @@ int main(int argc, char *argv[]) {
       chain = 4;
       rows = 32;
       large_display = true;
+      break;
+
+    case 'f':
+      flip_large = true;
       break;
 
     case 'R':
@@ -1191,6 +1197,10 @@ int main(int argc, char *argv[]) {
   if (large_display) {
     // Mapping the coordinates of a 32x128 display mapped to a square of 64x64
     transformer->AddTransformer(new LargeSquare64x64Transformer());
+  }
+
+  if (flip_large) {
+      transformer->AddTransformer(new rgb_matrix::FlipTopBottomTransformer());
   }
 
   if (rotation > 0) {

--- a/include/transformer.h
+++ b/include/transformer.h
@@ -43,6 +43,20 @@ private:
   TransformCanvas *const canvas_;
 };
 
+// Transformer to flip top/bottom
+class FlipTopBottomTransformer : public CanvasTransformer {
+public:
+  FlipTopBottomTransformer();
+  virtual ~FlipTopBottomTransformer();
+
+  virtual Canvas *Transform(Canvas *output);
+
+private:
+  class TransformCanvas;
+
+  TransformCanvas *const canvas_;
+};
+
 // Transformer for linked transformer objects
 // First transformer added will be considered last
 // (so it would the transformer that gets the original Canvas object)

--- a/led-image-viewer.cc
+++ b/led-image-viewer.cc
@@ -155,6 +155,7 @@ static int usage(const char *progname) {
           "Default: 1\n"
           "\t-c <chained>  : Daisy-chained boards. Default: 1.\n"
           "\t-L            : Large 64x64 display made from four 32x32 in a chain\n"
+          "\t-f            : Flip bottom and up in large 64x64 display\n"
           "\t-d            : Run as daemon.\n"
           "\t-b <brightnes>: Sets brightness percent. Default: 100.\n");
   return 1;
@@ -170,9 +171,10 @@ int main(int argc, char *argv[]) {
   int brightness = 100;
   bool large_display = false;  // example for using Transformers
   bool as_daemon = false;
+  bool flip_large = false;
 
   int opt;
-  while ((opt = getopt(argc, argv, "r:P:c:p:b:dL")) != -1) {
+  while ((opt = getopt(argc, argv, "r:P:c:p:b:dLf")) != -1) {
     switch (opt) {
     case 'r': rows = atoi(optarg); break;
     case 'P': parallel = atoi(optarg); break;
@@ -184,6 +186,9 @@ int main(int argc, char *argv[]) {
       chain = 4;
       rows = 32;
       large_display = true;
+      break;
+    case 'f':
+      flip_large = true;
       break;
     default:
       return usage(argv[0]);
@@ -248,8 +253,15 @@ int main(int argc, char *argv[]) {
   // just to the chain-of-four-32x32 => 64x64 transformer, but just use any
   // of the transformers in transformer.h or write your own.
   if (large_display) {
+    rgb_matrix::LinkedTransformer *transformer = new rgb_matrix::LinkedTransformer();
+
     // Mapping the coordinates of a 32x128 display mapped to a square of 64x64
-    matrix->SetTransformer(new rgb_matrix::LargeSquare64x64Transformer());
+    matrix->SetTransformer(transformer);
+    transformer->AddTransformer(new rgb_matrix::LargeSquare64x64Transformer());
+
+    if (flip_large) {
+      transformer->AddTransformer(new rgb_matrix::FlipTopBottomTransformer());
+    }
   }
 
   std::vector<Magick::Image> sequence_pics;

--- a/lib/transformer.cc
+++ b/lib/transformer.cc
@@ -124,6 +124,72 @@ void RotateTransformer::SetAngle(int angle) {
   angle_ = angle;
 }
 
+/************************************/
+/* FlipTopBottom Transformer Canvas */
+/************************************/
+class FlipTopBottomTransformer::TransformCanvas : public Canvas {
+public:
+  TransformCanvas();
+
+  void SetDelegatee(Canvas* delegatee);
+
+  virtual int width() const;
+  virtual int height() const;
+  virtual void SetPixel(int x, int y, uint8_t red, uint8_t green, uint8_t blue);
+  virtual void Clear();
+  virtual void Fill(uint8_t red, uint8_t green, uint8_t blue);
+
+private:
+  Canvas *delegatee_;
+};
+
+FlipTopBottomTransformer::TransformCanvas::TransformCanvas()
+  : delegatee_(NULL) {
+
+}
+
+void FlipTopBottomTransformer::TransformCanvas::SetDelegatee(Canvas* delegatee) {
+  delegatee_ = delegatee;
+}
+
+void FlipTopBottomTransformer::TransformCanvas::SetPixel(int x, int y, uint8_t red, uint8_t green, uint8_t blue) {
+  // translate point to origin
+  int half = delegatee_->height() / 2;
+  delegatee_->SetPixel(x, y < half ? y + half : y - half, red, green, blue);
+}
+
+int FlipTopBottomTransformer::TransformCanvas::width() const { 
+  return delegatee_->width();
+}
+
+int FlipTopBottomTransformer::TransformCanvas::height() const { 
+  return delegatee_->height();
+}
+
+void FlipTopBottomTransformer::TransformCanvas::Clear() { 
+  delegatee_->Clear();
+}
+
+void FlipTopBottomTransformer::TransformCanvas::Fill(uint8_t red, uint8_t green, uint8_t blue) {
+  delegatee_->Fill(red, green, blue);
+}
+
+FlipTopBottomTransformer::FlipTopBottomTransformer()
+  : canvas_(new TransformCanvas()) {
+}
+
+FlipTopBottomTransformer::~FlipTopBottomTransformer() {
+  delete canvas_;
+}
+
+Canvas *FlipTopBottomTransformer::Transform(Canvas *output) {
+  assert(output != NULL);
+
+  canvas_->SetDelegatee(output);
+  return canvas_;
+}
+
+
 /**********************/
 /* Linked Transformer */
 /**********************/


### PR DESCRIPTION
I have 4 32x32 panels but no long DB9 cables so while arranging them in a square display I couldn't do that long junction as in https://github.com/hzeller/rpi-rgb-led-matrix/raw/master/img/chained-64x64.jpg -- I had to position "right" two pannels to the left which is effectively flipping top and bottom rows from as "-L" arrangement does.  So I have added additional FlipTopBottomTransformer and -f cmdline option to make use of it.
