### PR TITLE
Automatic cross-compilation for arm-linux-gnueabihf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+TARGET_SYS?=arm-linux-gnueabihf
+SYS:=$(shell $(CXX) -dumpmachine)
+ifneq ($(SYS),$(TARGET_SYS))
+	CXX:=$(TARGET_SYS)-c++
+	AR:=$(TARGET_SYS)-ar
+endif
+
 CXXFLAGS=-Wall -O3 -g
 OBJECTS=demo-main.o minimal-example.o text-example.o led-image-viewer.o
 BINARIES=led-matrix minimal-example text-example
@@ -20,7 +27,7 @@ MAGICK_LDFLAGS=`GraphicsMagick++-config --ldflags --libs`
 all : $(BINARIES)
 
 $(RGB_LIBRARY): FORCE
-	$(MAKE) -C $(RGB_LIBDIR)
+	CXX=$(CXX) AR=$(AR) $(MAKE) -C $(RGB_LIBDIR)
 
 led-matrix : demo-main.o $(RGB_LIBRARY)
 	$(CXX) $(CXXFLAGS) demo-main.o -o $@ $(LDFLAGS)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -84,10 +84,10 @@ CXXFLAGS=-Wall -O3 -g -fPIC $(DEFINES)
 all : $(TARGET).a $(TARGET).so.1
 
 $(TARGET).a : $(OBJECTS)
-	ar rcs $@ $^
+	$(AR) rcs $@ $^
 
 $(TARGET).so.1 : $(OBJECTS)
-	gcc -shared -Wl,-soname,$@ -o $@ $^ -lpthread  -lrt -lm -lpthread
+	$(CXX) -shared -Wl,-soname,$@ -o $@ $^ -lpthread  -lrt -lm -lpthread
 
 led-matrix.o: led-matrix.cc $(INCDIR)/led-matrix.h
 thread.o : thread.cc $(INCDIR)/thread.h


### PR DESCRIPTION
A couple of changes I've been using in my project to cross-compile the library instead of building it on the device itself.

If the automatic detection isn't desired, I can resubmit with only the first commit so that the library can be used in the context of cross-compilation without any modifications.
