### PR TITLE
Change default delay_time to 10 milliseconds

### DIFF
--- a/led-image-viewer.cc
+++ b/led-image-viewer.cc
@@ -53,7 +53,7 @@ public:
                     rgb_matrix::FrameCanvas *output)
     : canvas_(output) {
     int delay_time = img.animationDelay();  // in 1/100s of a second.
-    if (delay_time < 1) delay_time = 1;
+    if (delay_time < 1) delay_time = 10;
     delay_micros_ = delay_time * 10000;
 
     Canvas *const transformed_draw_canvas = transformer->Transform(output);


### PR DESCRIPTION
If no delay time is specified in an animated GIF (which happens quite often) the default delay time seems way to fast. I've checked different browsers and image viewers and they seem to use about 10 milliseconds as a default delay. Animated GIFs without a delay set now seem to play properly.

Example GIF for testing: http://66.media.tumblr.com/a354a37a064d24e8dc085b22955a43e5/tumblr_lsqlvv3Qs11r0ralmo1_r2_500.gif

As far as I could see this won't break anything, please correct me if I am wrong!
