### PR TITLE
Fix broken links to Python directory and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ to control these. You can use this as a library in your own projects or just
 use the demo binary provided here which provides some useful examples.
 
 Check out [utils/ directory for some ready-made tools](./utils) to get started
-using the library, or the [example-api-use/](./example-api-use) directory if
+using the library, or the [example-api-use/](./examples-api-use) directory if
 you want to get started programming your own utils.
 
 All Raspberry Pi versions supported
@@ -118,8 +118,8 @@ The library comes as an API that you can use for your own utilities and use-case
     directory.
   * If you prefer to program in C, there is also a
     [C API](./include/led-matrix-c.h).
-  * In the [python](./python) subdirectory, you find a Python API including a
-    couple of [examples](./python/samples) to get started.
+  * In the [python](./bindings/python) subdirectory, you find a Python API including a
+    couple of [examples](./bindings/python/samples) to get started.
   * There are a couple of external bindings, such as
       * [Nodejs binding] by Maxime Journaux.
       * [Go binding] by Máximo Cuadros

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ to control these. You can use this as a library in your own projects or just
 use the demo binary provided here which provides some useful examples.
 
 Check out [utils/ directory for some ready-made tools](./utils) to get started
-using the library, or the [example-api-use/](./examples-api-use) directory if
+using the library, or the [examples-api-use/](./examples-api-use) directory if
 you want to get started programming your own utils.
 
 All Raspberry Pi versions supported


### PR DESCRIPTION
Fixes #409 