### PR TITLE
Imported Configuration File capabilities from adafruit/rpi-fb-matrix

### DIFF
--- a/utils/Config.cpp
+++ b/utils/Config.cpp
@@ -1,0 +1,135 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+// Matrix configuration parsing class implementation.
+// Author: Tony DiCola
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+#include <iostream>
+#include <string>
+
+#include <libconfig.h++>
+
+#include "Config.h"
+
+using namespace std;
+
+// Get value if it exists, otherwise return default.
+static int getWithDefault(const libconfig::Setting& root, const char *key,
+                          int default_value) {
+  return root.exists(key) ? root[key] : default_value;
+}
+
+Config::Config(rgb_matrix::RGBMatrix::Options *options,
+               const string& filename)
+  : _moptions(options),
+    _display_width(-1),
+    _display_height(-1),
+    _panel_width(-1)
+{
+  try {
+    // Load config file with libconfig.
+    libconfig::Config cfg;
+    cfg.readFile(filename.c_str());
+    libconfig::Setting& root = cfg.getRoot();
+    // Parse out the matrix configuration values. If not given, we use
+    // reasonable defaults or defaults provided by the flags.
+    _panel_width = getWithDefault(root, "panel_width", 32);
+    _moptions->rows = getWithDefault(root, "panel_height", _moptions->rows);
+    _chain_length = getWithDefault(root, "chain_length",
+                                   _moptions->chain_length);
+    // While all the code for the transformer assumes number of panels, for
+    // the internal representation for the matrix code, we need to normalize
+    // that to 32 wide panels.
+    _moptions->chain_length = _chain_length * (_panel_width / 32);
+
+    _moptions->parallel = getWithDefault(root, "parallel_count",
+                                         _moptions->parallel);
+
+    _display_width = getWithDefault(root, "display_width",
+                                    getPanelWidth() * getChainLength());
+    _display_height = getWithDefault(root, "display_height",
+                                     getPanelHeight() * getParallelCount());
+
+    // Do basic validation of configuration.
+    if (_panel_width % 32 != 0) {
+      throw invalid_argument("Panel width must be multiple of 32. Typically that is 32, but sometimes 64.");
+    }
+
+    if (_display_width % _panel_width != 0) {
+      throw invalid_argument("display_width must be a multiple of panel_width!");
+    }
+    if (_display_height % getPanelHeight() != 0) {
+      throw invalid_argument("display_height must be a multiple of panel_height!");
+    }
+    std::string message;
+    if (!_moptions->Validate(&message)) {
+      throw invalid_argument(message);
+    }
+
+    // Parse out the individual panel configurations.
+    if (root.exists("panels")) {
+      libconfig::Setting& panels_config = root["panels"];
+      for (int i = 0; i < panels_config.getLength(); ++i) {
+        libconfig::Setting& row = panels_config[i];
+        for (int j = 0; j < row.getLength(); ++j) {
+          GridTransformer::Panel panel;
+          // Read panel order (required setting for each panel).
+          panel.order = row[j]["order"];
+          // Set default values for rotation and parallel chain, then override
+          // them with any panel-specific configuration values.
+          panel.rotate = 0;
+          panel.parallel = 0;
+          row[j].lookupValue("rotate", panel.rotate);
+          row[j].lookupValue("parallel", panel.parallel);
+          // Perform validation of panel values.
+          // If panels are square allow rotations that are a multiple of 90, otherwise
+          // only allow a rotation of 180 degrees.
+          if ((_panel_width == getPanelHeight()) && (panel.rotate % 90 != 0)) {
+            stringstream error;
+            error << "Panel " << i << "," << j << " rotation must be a multiple of 90 degrees!";
+            throw invalid_argument(error.str());
+          }
+          else if ((_panel_width != getPanelHeight()) && (panel.rotate % 180 != 0)) {
+            stringstream error;
+            error << "Panel row " << j << ", column " << i << " can only be rotated 180 degrees!";
+            throw invalid_argument(error.str());
+          }
+          // Check that parallel is value between 0 and 2 (up to 3 parallel chains).
+          if ((panel.parallel < 0) || (panel.parallel > 2)) {
+            stringstream error;
+            error << "Panel row " << j << ", column " << i << " parallel value must be 0, 1, or 2!";
+            throw invalid_argument(error.str());
+          }
+          // Add the panel to the list of panel configurations.
+          _panels.push_back(panel);
+        }
+      }
+      // Check the number of configured panels matches the expected number
+      // of panels (# of panel columns * # of panel rows).
+      const int expected = (getDisplayWidth() / getPanelWidth())
+        * (getDisplayHeight() / getPanelHeight());
+      if (_panels.size() != (unsigned int)expected) {
+        stringstream error;
+        error << "Expected " << expected << " panels in configuration but found " << _panels.size() << "!";
+        throw invalid_argument(error.str());
+      }
+    }
+  }
+  catch (const libconfig::FileIOException& fioex) {
+      throw runtime_error("IO error while reading configuration file.  Does the file exist?");
+    }
+  catch (const libconfig::ParseException& pex) {
+      stringstream error;
+      error << "Config file error at " << pex.getFile() << ":" << pex.getLine()
+            << " - " << pex.getError();
+      throw invalid_argument(error.str());
+    }
+  catch (const libconfig::SettingNotFoundException& nfex) {
+      stringstream error;
+      error << "Expected to find setting: " << nfex.getPath();
+      throw invalid_argument(error.str());
+    }
+  catch (const libconfig::ConfigException& ex) {
+    throw runtime_error("Error loading configuration!");
+  }
+}

--- a/utils/Config.h
+++ b/utils/Config.h
@@ -1,0 +1,57 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+// Matrix configuration parsing class declaration.
+// Author: Tony DiCola
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <string>
+#include <vector>
+
+#include "GridTransformer.h"
+#include "led-matrix.h"
+
+class Config {
+public:
+  Config(rgb_matrix::RGBMatrix::Options *options,
+         const std::string& filename);
+
+  // Attribute accessors:
+  int getDisplayWidth() const {
+    return (_display_width < 0)
+      ? getPanelWidth() * getChainLength()
+      : _display_width;
+  }
+  int getDisplayHeight() const {
+    return (_display_height < 0)
+      ? getPanelHeight() * getParallelCount()
+      : _display_height;
+  }
+  int getPanelWidth() const {
+    return (_panel_width) < 0 ? 32 : _panel_width;
+  }
+  int getPanelHeight() const {
+    return _moptions->rows;
+  }
+  int getChainLength() const {
+    return _chain_length;
+  }
+  int getParallelCount() const {
+    return _moptions->parallel;
+  }
+  bool hasTransformer() const { return !_panels.empty(); }
+  GridTransformer getGridTransformer() const {
+    return GridTransformer(getDisplayWidth(), getDisplayHeight(),
+                           getPanelWidth(), getPanelHeight(),
+                           getChainLength(), _panels);
+  }
+
+private:
+  rgb_matrix::RGBMatrix::Options* const _moptions;
+  int _display_width,
+      _display_height,
+      _panel_width,
+      _chain_length;
+  std::vector<GridTransformer::Panel> _panels;
+};
+
+#endif

--- a/utils/GridTransformer.cpp
+++ b/utils/GridTransformer.cpp
@@ -1,0 +1,87 @@
+// LED matrix library transformer to map a rectangular canvas onto a complex
+// chain of matrices.
+// Author: Tony DiCola
+#include "GridTransformer.h"
+
+using namespace rgb_matrix;
+using namespace std;
+
+GridTransformer::GridTransformer(int width, int height, int panel_width, int panel_height,
+                                 int chain_length, const std::vector<Panel>& panels):
+  _width(width),
+  _height(height),
+  _panel_width(panel_width),
+  _panel_height(panel_height),
+  _chain_length(chain_length),
+  _source(NULL),
+  _panels(panels)
+{
+  // Display width must be a multiple of the panel pixel column count.
+  assert(_width % _panel_width == 0);
+  // Display height must be a multiple of the panel pixel row count.
+  assert(_height % _panel_height == 0);
+  // Compute number of rows and columns of panels.
+  _rows = _height / _panel_height;
+  _cols = _width / _panel_width;
+  // Check panel definition list has exactly the expected number of panels.
+  assert((_rows * _cols) == (int)_panels.size());
+}
+
+void GridTransformer::SetPixel(int x, int y, uint8_t red, uint8_t green, uint8_t blue) {
+  assert(_source != NULL);
+  if ((x < 0) || (y < 0) || (x >= _width) || (y >= _height)) {
+    return;
+  }
+
+  // Figure out what row and column panel this pixel is within.
+  int row = y / _panel_height;
+  int col = x / _panel_width;
+
+  // Get the panel information for this pixel.
+  Panel panel = _panels[_cols*row + col];
+
+  // Compute location of the pixel within the panel.
+  x = x % _panel_width;
+  y = y % _panel_height;
+
+  // Perform any panel rotation to the pixel.
+  // NOTE: 90 and 270 degree rotation only possible on 32 row (square) panels.
+  if (panel.rotate == 90) {
+    assert(_panel_height == _panel_width);
+    int old_x = x;
+    x = (_panel_height-1)-y;
+    y = old_x;
+  }
+  else if (panel.rotate == 180) {
+    x = (_panel_width-1)-x;
+    y = (_panel_height-1)-y;
+  }
+  else if (panel.rotate == 270) {
+    assert(_panel_height == _panel_width);
+    int old_y = y;
+    y = (_panel_width-1)-x;
+    x = old_y;
+  }
+
+  // Determine x offset into the source panel based on its order along the chain.
+  // The order needs to be inverted because the matrix library starts with the
+  // origin of an image at the end of the chain and not at the start (where
+  // ordering begins for this transformer).
+  int x_offset = ((_chain_length-1)-panel.order)*_panel_width;
+
+  // Determine y offset into the source panel based on its parrallel chain value.
+  int y_offset = panel.parallel*_panel_height;
+
+  _source->SetPixel(x_offset + x,
+                    y_offset + y,
+                    red, green, blue);
+}
+
+Canvas* GridTransformer::Transform(Canvas* source) {
+  assert(source != NULL);
+  int swidth = source->width();
+  int sheight = source->height();
+  assert((_width * _height) == (swidth * sheight));
+  _source = source;
+  return this;
+}

--- a/utils/GridTransformer.h
+++ b/utils/GridTransformer.h
@@ -1,0 +1,65 @@
+// LED matrix library transformer to map a rectangular canvas onto a complex
+// chain of matrices.
+// Author: Tony DiCola
+#ifndef GRIDTRANSFORMER_H
+#define GRIDTRANSFORMER_H
+
+#include <cassert>
+#include <vector>
+
+#include "led-matrix.h"
+
+
+class GridTransformer: public rgb_matrix::Canvas, public rgb_matrix::CanvasTransformer {
+public:
+  struct Panel {
+    int order;
+    int rotate;
+    int parallel;
+  };
+
+  GridTransformer(int width, int height, int panel_width, int panel_height,
+                  int chain_length, const std::vector<Panel>& panels);
+  virtual ~GridTransformer() {}
+
+  // Canvas interface implementation:
+  virtual int width() const {
+    return _width;
+  }
+  virtual int height() const {
+    return _height;
+  }
+  virtual void Clear() {
+    assert(_source != NULL);
+    _source->Clear();
+  }
+  virtual void Fill(uint8_t red, uint8_t green, uint8_t blue) {
+    assert(_source != NULL);
+    _source->Fill(red, green, blue);
+  }
+  virtual void SetPixel(int x, int y, uint8_t red, uint8_t green, uint8_t blue);
+
+  // Transformer interface implementation:
+  virtual rgb_matrix::Canvas* Transform(rgb_matrix::Canvas* source);
+
+  // Other attribute accessors.
+  int getRows() const {
+    return _rows;
+  }
+  int getColumns() const {
+    return _cols;
+  }
+
+private:
+  int _width,
+      _height,
+      _panel_width,
+      _panel_height,
+      _chain_length,
+      _rows,
+      _cols;
+  rgb_matrix::Canvas* _source;
+  std::vector<Panel> _panels;
+};
+
+#endif

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -24,8 +24,8 @@ all : $(BINARIES)
 $(RGB_LIBRARY): FORCE
 	$(MAKE) -C $(RGB_LIBDIR)
 
-led-image-viewer: led-image-viewer.o $(RGB_LIBRARY)
-	$(CXX) $(CXXFLAGS) led-image-viewer.o -o $@ $(LDFLAGS) $(MAGICK_LDFLAGS)
+led-image-viewer: led-image-viewer.o GridTransformer.o Config.o $(RGB_LIBRARY)
+	$(CXX) $(CXXFLAGS) -I$(RGB_INCDIR) -L$(RGB_LIBDIR) -lconfig++ led-image-viewer.o GridTransformer.o Config.o -o $@ $(LDFLAGS) $(MAGICK_LDFLAGS)
 
 video-viewer: video-viewer.o $(RGB_LIBRARY)
 	$(CXX) $(CXXFLAGS) video-viewer.o -o $@ $(LDFLAGS) `pkg-config --cflags --libs  libavcodec libavformat libswscale libavutil`
@@ -33,8 +33,11 @@ video-viewer: video-viewer.o $(RGB_LIBRARY)
 %.o : %.cc
 	$(CXX) -I$(RGB_INCDIR) $(CXXFLAGS) -c -o $@ $<
 
-led-image-viewer.o : led-image-viewer.cc
-	$(CXX) -I$(RGB_INCDIR) $(CXXFLAGS) $(MAGICK_CXXFLAGS) -c -o $@ $<
+%.o : %.cpp
+	$(CXX) -I$(RGB_INCDIR) $(CXXFLAGS) -lconfig++ -c -o $@ $<
+
+led-image-viewer.o : led-image-viewer.cc GridTransformer.o Config.o
+	$(CXX) -I$(RGB_INCDIR) $(CXXFLAGS) -L$(RGB_LIBDIR) -lconfig++ $(MAGICK_CXXFLAGS) -c -o $@ $<
 
 # We're using a couple of deprecated functions. Pull request to update this to
 # the latest libraries is welcome.
@@ -42,7 +45,7 @@ video-viewer.o: video-viewer.cc
 	$(CXX) -I$(RGB_INCDIR) $(CXXFLAGS) -Wno-deprecated-declarations -c -o $@ $<
 
 clean:
-	rm -f $(OBJECTS) $(BINARIES) $(OPTIONAL_OBJECTS) $(OPTIONAL_BINARIES)
+	rm -f $(OBJECTS) $(BINARIES) $(OPTIONAL_OBJECTS) $(OPTIONAL_BINARIES) Config.o GridTransformer.o
 
 FORCE:
 .PHONY: FORCE

--- a/utils/README.md
+++ b/utils/README.md
@@ -19,7 +19,7 @@ To compile, you first need to install the GraphicsMagick dependencies first:
 
 ```
 sudo apt-get update
-sudo apt-get install libgraphicsmagick++-dev libwebp-dev -y
+sudo apt-get install libgraphicsmagick++-dev libwebp-dev libconfig++-dev -y
 make led-image-viewer
 ```
 

--- a/utils/matrix.cfg
+++ b/utils/matrix.cfg
@@ -1,0 +1,66 @@
+// LED Matrix Display Configuration
+
+// Define the entire width and height of the display in pixels.
+// This is the _total_ width and height of the rectangle defined by all the
+// chained panels.  The width should be a multiple of the panel pixel width (32),
+// and the height should be a multiple of the panel pixel height (8, 16, or 32).
+display_width = 64;
+display_height = 64;
+
+// Define the width of each panel in pixels.  This should always be 32 (but can
+// in theory be changed).
+panel_width = 32;
+
+// Define the height of each panel in pixels.  This is typically 8, 16, or 32.
+// NOTE: Each panel in the display _must_ be the same height!  You cannot mix
+// 16 and 32 pixel high panels for example.
+panel_height = 32;
+
+// Define the total number of panels in each chain.  Count up however many
+// panels are connected together and put that value here.  If you're using
+// multiple parallel chains count each one up separately and pick the largest
+// value for this configuration.
+chain_length = 4;
+
+// Define the total number of parallel chains.  If using the Adafruit HAT you
+// can only have one chain so stick with the value 1.  The Pi 2 can support up
+// to 3 parallel chains, see the rpi-rgb-led-matrix library for more information:
+//   https://github.com/hzeller/rpi-rgb-led-matrix#chaining-parallel-chains-and-coordinate-system
+parallel_count = 1;
+
+// Configure each LED matrix panel.
+// This is a two-dimensional array with an entry for each panel.  The array
+// defines the grid that will subdivide the display, so for example a 64x64 size
+// display with 32x32 pixel panels would be a 2x2 array of panel configurations.
+//
+// For each panel you must set the order that it is within its chain, i.e. the
+// first panel in a chain is order = 0, the next one is order = 1, etc.  You can
+// also set a rotation for each panel to account for changes in panel orientation
+// (like when 'snaking' a series of panels end to end for shorter wire runs).
+//
+// For example the configuration below defines this grid display of panels and
+// their wiring (starting from the upper right panel and snaking left, down, and
+// right to the bottom right panel):
+//       ______________    ______________
+//      |    Panel     |  |    Panel     |
+//   /==| order  = 1   |<=| order  = 0   |<= Chain start (from Pi)
+//   |  | rotate = 0   |  | rotate = 0   |
+//   |  |______________|  |______________|
+//   |   ______________    ______________
+//   |  |    Panel     |  |    Panel     |
+//   \==| order  = 2   |=>| order  = 3   |
+//      | rotate = 180 |  | rotate = 180 |
+//      |______________|  |______________|
+//
+// Notice the chain starts in the upper right and snakes around to the bottom
+// right.  The order of each panel is set as its position along the chain,
+// and rotation is applied to the lower panels that are flipped around relative
+// to the panels above them.
+//
+// Not shown but if you're using parallel chains you can specify for each entry
+// in the panels list a 'parallel = x;' option where x is the ID of a parallel
+// chain (0, 1, or 2).
+panels = (
+  ( { order = 1; rotate =   0; }, { order = 0; rotate =   0; } ),
+  ( { order = 2; rotate = 180; }, { order = 3; rotate = 180; } )
+)


### PR DESCRIPTION
By importing the configuration file capabilities from the adafruit/rpi-fb-matrix repo into the led-image-viewer example, much more complex panel arrangements are supported without requiring any coding. It is also fully backwards compatible.