### PR TITLE
Add scrolling-text-example

### DIFF
--- a/examples-api-use/Makefile
+++ b/examples-api-use/Makefile
@@ -1,7 +1,7 @@
 CFLAGS=-Wall -O3 -g -Wextra -Wno-unused-parameter
 CXXFLAGS=$(CFLAGS)
-OBJECTS=demo-main.o minimal-example.o c-example.o text-example.o clock.o
-BINARIES=demo minimal-example c-example text-example clock
+OBJECTS=demo-main.o minimal-example.o c-example.o text-example.o scrolling-text-example.o clock.o
+BINARIES=demo minimal-example c-example text-example scrolling-text-example clock
 
 # Where our library resides. You mostly only need to change the
 # RGB_LIB_DISTRIBUTION, this is where the library is checked out.
@@ -22,6 +22,7 @@ demo : demo-main.o $(RGB_LIBRARY)
 
 minimal-example : minimal-example.o
 text-example: text-example.o
+scrolling-text-example : scrolling-text-example.o
 clock : clock.o
 
 # All the binaries that have the same name as the object file.q

--- a/examples-api-use/scrolling-text-example.cc
+++ b/examples-api-use/scrolling-text-example.cc
@@ -1,0 +1,189 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+// Small example how to scroll text.
+//
+// This code is public domain
+// (but note, that the led-matrix library this depends on is GPL v2)
+
+#include "led-matrix.h"
+#include "graphics.h"
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+using namespace rgb_matrix;
+
+static int usage(const char *progname) {
+  fprintf(stderr, "usage: %s [options]\n", progname);
+  fprintf(stderr, "Reads text from the -t command line argument and scrolls it.\n");
+  fprintf(stderr, "Options:\n");
+  rgb_matrix::PrintMatrixFlags(stderr);
+  fprintf(stderr,
+          "\t-f <font-file>    : Use given font.\n"
+          "\t-b <brightness>   : Sets brightness percent. Default: 100.\n"
+          "\t-x <x-origin>     : X-Origin of displaying text (Default: 0)\n"
+          "\t-y <y-origin>     : Y-Origin of displaying text (Default: 0)\n"
+          "\t-S <spacing>      : Spacing pixels between letters (Default: 0)\n"
+          "\t-C <r,g,b>        : Color. Default 255,255,0\n"
+          "\t-B <r,g,b>        : Background-Color. Default 0,0,0\n"
+          "\t-O <r,g,b>        : Outline-Color, e.g. to increase contrast.\n"
+          "\t-t <text>         : Text to display.\n"
+          );
+  return 1;
+}
+
+static bool parseColor(Color *c, const char *str) {
+  return sscanf(str, "%hhu,%hhu,%hhu", &c->r, &c->g, &c->b) == 3;
+}
+
+static bool FullSaturation(const Color &c) {
+    return (c.r == 0 || c.r == 255)
+        && (c.g == 0 || c.g == 255)
+        && (c.b == 0 || c.b == 255);
+}
+
+int main(int argc, char *argv[]) {
+  RGBMatrix::Options matrix_options;
+  rgb_matrix::RuntimeOptions runtime_opt;
+  if (!rgb_matrix::ParseOptionsFromFlags(&argc, &argv,
+                                         &matrix_options, &runtime_opt)) {
+    return usage(argv[0]);
+  }
+
+  Color color(255, 255, 0);
+  Color bg_color(0, 0, 0);
+  Color outline_color(0,0,0);
+  bool with_outline = false;
+
+  const char *bdf_font_file = NULL;
+  const char *line = NULL;
+  /* x_origin is set to be off the screen, chain length * number of rows
+     we pad a small gap, 5 below, to create a gap after the text before the text is re-scrolled */
+  int x_orig = (matrix_options.chain_length * matrix_options.rows) + 5;
+  int y_orig = 0;
+  int brightness = 100;
+  int letter_spacing = 0;
+
+  int opt;
+  while ((opt = getopt(argc, argv, "x:y:f:C:B:O:b:S:t:")) != -1) {
+    switch (opt) {
+    case 'b': brightness = atoi(optarg); break;
+    case 'x': x_orig = atoi(optarg); break;
+    case 'y': y_orig = atoi(optarg); break;
+    case 'f': bdf_font_file = strdup(optarg); break;
+    case 'S': letter_spacing = atoi(optarg); break;
+    case 't': line = strdup(optarg); break;
+    case 'C':
+      if (!parseColor(&color, optarg)) {
+        fprintf(stderr, "Invalid color spec: %s\n", optarg);
+        return usage(argv[0]);
+      }
+      break;
+    case 'B':
+      if (!parseColor(&bg_color, optarg)) {
+        fprintf(stderr, "Invalid background color spec: %s\n", optarg);
+        return usage(argv[0]);
+      }
+      break;
+    case 'O':
+      if (!parseColor(&outline_color, optarg)) {
+        fprintf(stderr, "Invalid outline color spec: %s\n", optarg);
+        return usage(argv[0]);
+      }
+      with_outline = true;
+      break;
+    default:
+      return usage(argv[0]);
+    }
+  }
+
+  if (line == NULL) {
+    fprintf(stderr, "Need to specify some text to scroll with -t\n");
+    return usage(argv[0]);
+  }
+
+  if (bdf_font_file == NULL) {
+    fprintf(stderr, "Need to specify BDF font-file with -f\n");
+    return usage(argv[0]);
+  }
+
+  /*
+   * Load font. This needs to be a filename with a bdf bitmap font.
+   */
+  rgb_matrix::Font font;
+  if (!font.LoadFont(bdf_font_file)) {
+    fprintf(stderr, "Couldn't load font '%s'\n", bdf_font_file);
+    return 1;
+  }
+
+  /*
+   * If we want an outline around the font, we create a new font with
+   * the original font as a template that is just an outline font.
+   */
+  rgb_matrix::Font *outline_font = NULL;
+  if (with_outline) {
+      outline_font = font.CreateOutlineFont();
+  }
+
+  if (brightness < 1 || brightness > 100) {
+    fprintf(stderr, "Brightness is outside usable range.\n");
+    return 1;
+  }
+
+  RGBMatrix *canvas = rgb_matrix::CreateMatrixFromOptions(matrix_options,
+                                                          runtime_opt);
+  if (canvas == NULL)
+    return 1;
+
+  canvas->SetBrightness(brightness);
+
+  const bool all_extreme_colors = (brightness == 100)
+      && FullSaturation(color)
+      && FullSaturation(bg_color)
+      && FullSaturation(outline_color);
+  if (all_extreme_colors)
+    canvas->SetPWMBits(1);
+
+  int x = x_orig;
+  int y = y_orig;
+  int length = 0;
+
+  printf("CTRL-C for exit.\n");
+
+  // Create a new canvas to be used with led_matrix_swap_on_vsync
+  FrameCanvas *offscreen_canvas = canvas->CreateFrameCanvas();
+
+  // infinte loop
+  while (1){
+    offscreen_canvas->Clear(); // clear canvas
+
+    if (outline_font) {
+      // The outline font, we need to write with a negative (-2) text-spacing,
+      // as we want to have the same letter pitch as the regular text that
+      // we then write on top.
+      rgb_matrix::DrawText(offscreen_canvas, *outline_font,
+                           x - 1, y + font.baseline(),
+                           outline_color, &bg_color, line, letter_spacing - 2);
+    }
+
+    // length = holds how many pixels our text takes up
+    length = rgb_matrix::DrawText(offscreen_canvas, font,
+                               x, y + font.baseline(),
+                               color, outline_font ? NULL : &bg_color, line, letter_spacing);
+
+    if (--x + length < 0)
+      x = x_orig;
+
+    usleep(20000);
+    // Swap the offscreen_canvas with canvas on vsync, avoids flickering
+    offscreen_canvas = canvas->SwapOnVSync(offscreen_canvas);
+  }
+
+  // Finished. Shut down the RGB matrix.
+  canvas->Clear();
+  delete canvas;
+
+  return 0;
+}


### PR DESCRIPTION
C/C++ scrolling text example. I adapted the text-example file to create one which scrolls text by adding a "-t <text to scroll>" argument. 

When getting my LED matrix it would have helped if there was an example scrolling text, all the code I could find were scrolling ppm files.