### PR TITLE
Adding a MultiplexMapper for a 32x16 1/2 scan panel brand Kaler

### DIFF
--- a/bindings/python/samples/samplebase.py
+++ b/bindings/python/samples/samplebase.py
@@ -26,7 +26,7 @@ class SampleBase(object):
         self.parser.add_argument("--led-rgb-sequence", action="store", help="Switch if your matrix has led colors swapped. Default: RGB", default="RGB", type=str)
         self.parser.add_argument("--led-pixel-mapper", action="store", help="Apply pixel mappers. e.g \"Rotate:90\"", default="", type=str)
         self.parser.add_argument("--led-row-addr-type", action="store", help="0 = default; 1=AB-addressed panels", default=0, type=int, choices=[0,1])
-        self.parser.add_argument("--led-multiplexing", action="store", help="Multiplexing type: 0=direct; 1=strip; 2=checker; 3=spiral; 4=ZStripe; 5=ZnMirrorZStripe; 6=coreman;7=Kaler2Scan (Default: 0)", default=0, type=int, choices=[0,1,2,3,4,5,6,7])
+        self.parser.add_argument("--led-multiplexing", action="store", help="Multiplexing type: 0=direct; 1=strip; 2=checker; 3=spiral; 4=ZStripe; 5=ZnMirrorZStripe; 6=coreman; 7=Kaler2Scan (Default: 0)", default=0, type=int, choices=[0,1,2,3,4,5,6,7])
 
     def usleep(self, value):
         time.sleep(value / 1000000.0)

--- a/bindings/python/samples/samplebase.py
+++ b/bindings/python/samples/samplebase.py
@@ -26,7 +26,7 @@ class SampleBase(object):
         self.parser.add_argument("--led-rgb-sequence", action="store", help="Switch if your matrix has led colors swapped. Default: RGB", default="RGB", type=str)
         self.parser.add_argument("--led-pixel-mapper", action="store", help="Apply pixel mappers. e.g \"Rotate:90\"", default="", type=str)
         self.parser.add_argument("--led-row-addr-type", action="store", help="0 = default; 1=AB-addressed panels", default=0, type=int, choices=[0,1])
-        self.parser.add_argument("--led-multiplexing", action="store", help="Multiplexing type: 0=direct; 1=strip; 2=checker; 3=spiral; 4=ZStripe; 5=ZnMirrorZStripe; 6=coreman (Default: 0)", default=0, type=int, choices=[0,1,2,3,4,5,6])
+        self.parser.add_argument("--led-multiplexing", action="store", help="Multiplexing type: 0=direct; 1=strip; 2=checker; 3=spiral; 4=ZStripe; 5=ZnMirrorZStripe; 6=coreman;7=Kaler2Scan (Default: 0)", default=0, type=int, choices=[0,1,2,3,4,5,6,7])
 
     def usleep(self, value):
         time.sleep(value / 1000000.0)

--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -208,7 +208,7 @@ Framebuffer::Framebuffer(int rows, int columns, int parallel,
     shared_mapper_(mapper) {
   assert(hardware_mapping_ != NULL);   // Called InitHardwareMapping() ?
   assert(shared_mapper_ != NULL);  // Storage should be provided by RGBMatrix.
-  assert(rows_ >=8 && rows_ <= 64 && rows_ % 2 == 0);
+  assert(rows_ >=4 && rows_ <= 64 && rows_ % 2 == 0);
   if (parallel > hardware_mapping_->max_parallel_chains) {
     fprintf(stderr, "The %s GPIO mapping only supports %d parallel chain%s, "
             "but %d was requested.\n", hardware_mapping_->name,

--- a/lib/multiplex-mappers.cc
+++ b/lib/multiplex-mappers.cc
@@ -178,6 +178,22 @@ public:
   }
 };
 
+class Kaler2ScanMapper : public MultiplexMapperBase {
+public:
+  Kaler2ScanMapper() : MultiplexMapperBase("Kaler2Scan", 4) {}
+
+  void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
+    // Now we have a 128x4 matrix
+    int offset = ((y%4)/2) == 0 ? -1 : 1;// Add o substract
+    int deltaOffset = offset < 0 ? 7:8;
+    int deltaColumn = ((y%8)/4)== 0 ? 64 : 0;
+    
+    *matrix_y = (y%2+(y/8)*2);
+    *matrix_x = deltaColumn + (16 * (x/8)) + deltaOffset + ((x%8) * offset);
+
+  }
+};
+
 /*
  * Here is where the registration happens.
  * If you add an instance of the mapper here, it will automatically be
@@ -193,6 +209,7 @@ static MuxMapperList *CreateMultiplexMapperList() {
   result->push_back(new ZStripeMultiplexMapper("ZStripe", 0, 8));
   result->push_back(new ZStripeMultiplexMapper("ZnMirrorZStripe", 4, 4));
   result->push_back(new CoremanMapper());
+  result->push_back(new Kaler2ScanMapper());
 
   return result;
 }


### PR DESCRIPTION
Add a MultiplexMapper for a 32x16 1/2 scan panel brand Kaler, change the assert on framebuffer to allow a matrix of 4 rows. Changes on the python bindings to allow the new MultipleMapper on the examples. This MultiplexMapper works on scan_mode = 1 or 0 and row_address_type = 0