### PR TITLE
Add free-i2c mapping  and rename "U-mapper" to "Snake" with extra lines param

### DIFF
--- a/examples-api-use/README.md
+++ b/examples-api-use/README.md
@@ -21,8 +21,8 @@ Options:
         --led-parallel=<parallel> : Parallel chains. range=1..3 (Default: 1).
         --led-multiplexing=<0..6> : Mux type: 0=direct; 1=Stripe; 2=Checkered; 3=Spiral; 4=ZStripe; 5=ZnMirrorZStripe; 6=coreman (Default: 0)
         --led-pixel-mapper        : Semicolon-separated list of pixel-mappers to arrange pixels.
-                                    Optional params after a colon e.g. "U-mapper;Rotate:90"
-                                    Available: "Rotate", "U-mapper". Default: ""
+                                    Optional params after a colon e.g. "Snake:3;Rotate:90"
+                                    Available: "Rotate", "Snake". Default: ""
         --led-pwm-bits=<1..11>    : PWM bits (Default: 11).
         --led-brightness=<percent>: Brightness in percent (Default: 100).
         --led-scan-mode=<0..1>    : 0 = progressive; 1 = interlaced (Default: 0).
@@ -220,11 +220,11 @@ some re-mapping options, and also programmatic ways to do so.
 
 ### Standard mappers
 
-#### U-mapper
+#### Snake
 Say you have 4 displays with 32x32 and only a single output
 like with a Raspberry Pi 1 or the Adafruit HAT -- if we chain
 them, we get a display 32 pixel high, (4*32)=128 pixel long. If we arrange
-the boards in a U-shape so that they form a square, we get a logical display
+the boards in a snake so that they form a square, we get a logical display
 of 64x64 pixels:
 
 <img src="../img/chained-64x64.jpg" width="400px"> In action:
@@ -232,34 +232,41 @@ of 64x64 pixels:
 
 ```
 So the following chain
-    [<][<][<][<] }- Raspbery Pi connector
+    [<][<][<][<] }-- Pi connector
 
-is arranged in this U-shape (on its side)
-    [<][<] }----- Raspberry Pi connector
+is arranged in this Snake (previously called "U-shape")
+    [<][<] }-- Pi connector
     [>][>]
+or this with "Snake:4":
+    [<] }-- Pi connector
+    [>]
+    [<]
+    [>]
 ```
 
 Now we need to internally map pixels the pixels so that the 'folded' 128x32
 screen behaves like a 64x64 screen.
 
-There is a pixel-mapper that can help with this "U-Arrangement", you choose
-it with `--led-pixel-mapper=U-mapper`. So in this particular case,
+There is a pixel-mapper that can help with this "Snake-Arrangement", you choose
+it with `--led-pixel-mapper=Snake`. So in this particular case,
 
 ```
-  ./demo --led-chain=4 --led-pixel-mapper="U-mapper"
+  ./demo --led-chain=4 --led-pixel-mapper="Snake"
 ```
 
 This works for longer and more than one chain as well. Here an arrangement with
-two chains with 8 panels each
+two chains with 9 panels each
 
 ```
-   [<][<][<][<]  }--- Pi connector #1
-   [>][>][>][>]
-   [<][<][<][<]  }--- Pi connector #2
-   [>][>][>][>]
+    [<][<][<]  }-- Pi connector #1
+    [>][>][>]
+    [<][<][<]
+    [<][<][<]  }-- Pi connector #2
+    [>][>][>]
+    [<][<][<]
 ```
 
-(`--led-chain=8 --led-parallel=2 --led-pixel-mapper="U-mapper"`).
+(`--led-chain=9 --led-parallel=2 --led-pixel-mapper="Snake:3"`).
 
 #### Rotate
 
@@ -274,11 +281,11 @@ as parameter after a colon:
 
 You can chain multiple mappers in the configuration, by separating them
 with a semicolon. The mappers are applied in the sequence you give them, so
-if you want to arrange a couple of panels with the U-arrangement, and then
-rotate the resulting screen, use
+if you want to arrange a couple of panels with the Snake-arrangement, and
+then rotate the resulting screen, use
 
 ```
-  ./demo --led-chain=8 --led-parallel=3 --led-pixel-mapper="U-mapper;Rotate:90"
+  ./demo --led-chain=8 --led-parallel=3 --led-pixel-mapper="Snake;Rotate:90"
 ```
 
 Here, we first create a 128x192 screen (4 panels wide (`4*32=128`),
@@ -319,7 +326,7 @@ provided in the `--led-pixel-mapper` command line option:
 ```
 
 Now your mapper can be used alongside (and combined with) the standard
-mappers already there (e.g. "U-mapper" or "Rotate"). Your mapper can have
+mappers already there (e.g. "Snake" or "Rotate"). Your mapper can have
 parameters: In the command-line flag, parameters provided after `:` are passed
 as-is to your `SetParameters()` implementation
 (e.g. using `--led-pixel-mapper="Rotate:90"`, the `Rotate` mapper

--- a/examples-api-use/demo-main.cc
+++ b/examples-api-use/demo-main.cc
@@ -1091,7 +1091,7 @@ int main(int argc, char *argv[]) {
       break;
 
     case 'L':
-      fprintf(stderr, "-L is deprecated. Use\n\t--led-pixel-mapper=\"U-mapper\" --led-chain=4\ninstead.\n");
+      fprintf(stderr, "-L is deprecated. Use\n\t--led-pixel-mapper=\"Snake\" --led-chain=4\ninstead.\n");
       return 1;
       break;
 

--- a/lib/hardware-mapping.c
+++ b/lib/hardware-mapping.c
@@ -213,5 +213,47 @@ struct HardwareMapping matrix_hardware_mappings[] = {
     .p0_b2         = GPIO_BIT(25),
   },
 
+  /*
+   * The regular hardware mapping without i2c pins (sda and scl),
+   * route p2_g1 p2_b1 to address lines d and e.
+   */
+  {
+    .name          = "free-i2c",
+
+    .output_enable = GPIO_BIT(18),
+    .clock         = GPIO_BIT(17),
+    .strobe        = GPIO_BIT(4),
+
+    /* Address lines */
+    .a             = GPIO_BIT(22),
+    .b             = GPIO_BIT(23),
+    .c             = GPIO_BIT(24),
+
+    /* Parallel chain 0, RGB for both sub-panels */
+    .p0_r1         = GPIO_BIT(11),  /* masks: SPI0_SCKL  */
+    .p0_g1         = GPIO_BIT(27),  /* Not on RPi1, Rev1; use "regular-pi1" instead */
+    .p0_b1         = GPIO_BIT(7),   /* masks: SPI0_CE1   */
+    .p0_r2         = GPIO_BIT(8),   /* masks: SPI0_CE0   */
+    .p0_g2         = GPIO_BIT(9),   /* masks: SPI0_MISO  */
+    .p0_b2         = GPIO_BIT(10),  /* masks: SPI0_MOSI  */
+
+    /* All the following are only available with 40 GPIP pins, on A+/B+/Pi2,3 */
+    /* Chain 1 */
+    .p1_r1         = GPIO_BIT(12),
+    .p1_g1         = GPIO_BIT(5),
+    .p1_b1         = GPIO_BIT(6),
+    .p1_r2         = GPIO_BIT(19),
+    .p1_g2         = GPIO_BIT(13),
+    .p1_b2         = GPIO_BIT(20),
+
+    /* Chain 2 */
+    .p2_r1         = GPIO_BIT(14), /* masks TxD when parallel=3 */
+    .p2_g1         = GPIO_BIT(25),
+    .p2_b1         = GPIO_BIT(15),
+    .p2_r2         = GPIO_BIT(26),
+    .p2_g2         = GPIO_BIT(16),
+    .p2_b2         = GPIO_BIT(21),
+  },
+
   {0}
 };

--- a/lib/options-initialize.cc
+++ b/lib/options-initialize.cc
@@ -382,7 +382,7 @@ void PrintMatrixFlags(FILE *out, const RGBMatrix::Options &d,
           "(Default: %d).\n"
           "\t--led-multiplexing=<0..%d> : Mux type: 0=direct; %s (Default: 0)\n"
           "\t--led-pixel-mapper        : Semicolon-separated list of pixel-mappers to arrange pixels.\n"
-          "\t                            Optional params after a colon e.g. \"U-mapper;Rotate:90\"\n"
+          "\t                            Optional params after a colon e.g. \"Snake:3;Rotate:90\"\n"
           "\t                            Available: %s. Default: \"\"\n"
           "\t--led-pwm-bits=<1..11>    : PWM bits (Default: %d).\n"
           "\t--led-brightness=<percent>: Brightness in percent (Default: %d).\n"

--- a/utils/README.md
+++ b/utils/README.md
@@ -52,8 +52,8 @@ General LED matrix options:
         --led-parallel=<parallel> : Parallel chains. range=1..3 (Default: 1).
         --led-multiplexing=<0..6> : Mux type: 0=direct; 1=Stripe; 2=Checkered; 3=Spiral; 4=ZStripe; 5=ZnMirrorZStripe; 6=coreman (Default: 0)
         --led-pixel-mapper        : Semicolon-separated list of pixel-mappers to arrange pixels.
-                                    Optional params after a colon e.g. "U-mapper;Rotate:90"
-                                    Available: "Rotate", "U-mapper". Default: ""
+                                    Optional params after a colon e.g. "Snake:3;Rotate:90"
+                                    Available: "Rotate", "Snake". Default: ""
         --led-pwm-bits=<1..11>    : PWM bits (Default: 11).
         --led-brightness=<percent>: Brightness in percent (Default: 100).
         --led-scan-mode=<0..1>    : 0 = progressive; 1 = interlaced (Default: 0).
@@ -147,8 +147,8 @@ General LED matrix options:
         --led-parallel=<parallel> : Parallel chains. range=1..3 (Default: 1).
         --led-multiplexing=<0..6> : Mux type: 0=direct; 1=Stripe; 2=Checkered; 3=Spiral; 4=ZStripe; 5=ZnMirrorZStripe; 6=coreman (Default: 0)
         --led-pixel-mapper        : Semicolon-separated list of pixel-mappers to arrange pixels.
-                                    Optional params after a colon e.g. "U-mapper;Rotate:90"
-                                    Available: "Rotate", "U-mapper". Default: ""
+                                    Optional params after a colon e.g. "Snake:3;Rotate:90"
+                                    Available: "Rotate", "Snake". Default: ""
         --led-pwm-bits=<1..11>    : PWM bits (Default: 11).
         --led-brightness=<percent>: Brightness in percent (Default: 100).
         --led-scan-mode=<0..1>    : 0 = progressive; 1 = interlaced (Default: 0).

--- a/utils/led-image-viewer.cc
+++ b/utils/led-image-viewer.cc
@@ -315,7 +315,7 @@ int main(int argc, char *argv[]) {
       matrix_options.parallel = atoi(optarg);
       break;
     case 'L':
-      fprintf(stderr, "-L is deprecated. Use\n\t--led-pixel-mapper=\"U-mapper\" --led-chain=4\ninstead.\n");
+      fprintf(stderr, "-L is deprecated. Use\n\t--led-pixel-mapper=\"Snake\" --led-chain=4\ninstead.\n");
       return 1;
       break;
     case 'R':

--- a/utils/video-viewer.cc
+++ b/utils/video-viewer.cc
@@ -90,7 +90,7 @@ int main(int argc, char *argv[]) {
       stream_output = strdup(optarg);
       break;
     case 'L':
-      fprintf(stderr, "-L is deprecated. Use\n\t--led-pixel-mapper=\"U-mapper\" --led-chain=4\ninstead.\n");
+      fprintf(stderr, "-L is deprecated. Use\n\t--led-pixel-mapper=\"Snake\" --led-chain=4\ninstead.\n");
       return 1;
       break;
     case 'R':


### PR DESCRIPTION
Add "free-i2c" gpio-mapping for using 3 parallel chains among i2c bus.
Add "lines" param to new "Snake" pixel-mapper instead of old "U-mapper",
the default lines value is 2- like the old "U-mapper",
but it can be changed like "Snake:4" for a 4 panels height display..!