### PR TITLE
C# binding: Fix field order of InternalRGBLedMatrixOptions

### DIFF
--- a/bindings/c#/RGBLedMatrix.cs
+++ b/bindings/c#/RGBLedMatrix.cs
@@ -54,6 +54,7 @@ namespace rpi_rgb_led_matrix_sharp
                 opt.multiplexing = options.Multiplexing;
                 opt.pwm_bits = options.PwmBits;
                 opt.pwm_lsb_nanoseconds = options.PwmLsbNanoseconds;
+                opt.pwm_dither_bits = options.PwmDitherBits;
                 opt.scan_mode = options.ScanMode;
                 opt.show_refresh_rate = (uint)(options.ShowRefreshRate ? 0 : 1);
                 opt.brightness = options.Brightness;
@@ -122,17 +123,18 @@ namespace rpi_rgb_led_matrix_sharp
             public int cols;
             public int chain_length;
             public int parallel;
-            public int multiplexing;
             public int pwm_bits;
             public int pwm_lsb_nanoseconds;
+            public int pwm_dither_bits;
             public int brightness;
             public int scan_mode;
+            public int row_address_type;
+            public int multiplexing;
             public IntPtr led_rgb_sequence;
             public IntPtr pixel_mapper_config; 
             public uint disable_hardware_pulsing;
             public uint show_refresh_rate;
             public uint inverse_colors;
-            public int row_address_type;
         };
         #endregion
     }
@@ -185,6 +187,11 @@ namespace rpi_rgb_led_matrix_sharp
         /// ghosting), but have a negative impact on the frame rate.
         /// </summary>
         public int PwmLsbNanoseconds;
+
+        /// <summary>
+        /// The lower bits can be time-dithered for higher refresh rate.
+        /// </summary>
+        public int PwmDitherBits;
 
         /// <summary>
         /// The initial brightness of the panel in percent. Valid range is 1..100


### PR DESCRIPTION
The field order of C# struct InternalRGBLedMatrixOptions is incorrect.
I've faced with same issue as #628.

With current implementation, if I set value to RGBLedMatrixOptions.DisableHardwarePulsing via C# code, the value will be set to C-struct RGBLedMatrixOptions.led_rgb_sequence because of difference between C#-struct and C-struct's field order.
Also a field for pwm_dither_bits is missing in C#-struct.

Minimal repro code:

```cs
using System;
using rpi_rgb_led_matrix_sharp;

class Repro {
  static void Main()
  {
    var options = new RGBLedMatrixOptions {
      Rows = 32,
      Cols = 64,
      DisableHardwarePulsing = true, // this will set 1(true) to led_rgb_sequence, not to disable_hardware_pulsing.
    };

    var matrix = new RGBLedMatrix(options); // will crash
  }
}
```

Difference of C# and C struct is as below:

        [led-matrix-c.h]                        [RGBLedMatrix.cs]
        struct RGBLedMatrixOptions              internal struct InternalRGBLedMatrixOptions
          const char *hardware_mapping;           public IntPtr hardware_mapping;
          int rows;                               public int rows;
          int cols;                               public int cols;
          int chain_length;                       public int chain_length;
          int parallel;                           public int parallel;
          int pwm_bits;                           public int multiplexing; // <<<<< incorrect from here
          int pwm_lsb_nanoseconds;                public int pwm_bits;
          int pwm_dither_bits;                    public int pwm_lsb_nanoseconds;
          int brightness;                         public int brightness;
          int scan_mode;                          public int scan_mode;
          int row_address_type;                   public IntPtr led_rgb_sequence;
          int multiplexing;                       public IntPtr pixel_mapper_config; 
          const char *led_rgb_sequence;           public uint disable_hardware_pulsing;
          const char *pixel_mapper_config;        public uint show_refresh_rate;
          unsigned disable_hardware_pulsing:1;    public uint inverse_colors;
          unsigned show_refresh_rate:1;           public int row_address_type;
          unsigned inverse_colors:1;
