### PR TITLE
Proposal: Brightness accessor for C# binding

### DIFF
--- a/bindings/c#/RGBLedMatrix.cs
+++ b/bindings/c#/RGBLedMatrix.cs
@@ -30,6 +30,12 @@ namespace rpi_rgb_led_matrix_sharp
 
         [DllImport("librgbmatrix.so")]
         internal static extern IntPtr led_matrix_get_canvas(IntPtr matrix);
+
+        [DllImport("librgbmatrix.so")]
+        internal static extern byte led_matrix_get_brightness(IntPtr matrix);
+
+        [DllImport("librgbmatrix.so")]
+        internal static extern void led_matrix_set_brightness(IntPtr matrix, byte brightness);
         #endregion
 
         public RGBLedMatrix(int rows, int chained, int parallel)
@@ -60,7 +66,6 @@ namespace rpi_rgb_led_matrix_sharp
                 opt.brightness = options.Brightness;
                 opt.disable_hardware_pulsing = (uint)(options.DisableHardwarePulsing ? 1 : 0);
                 opt.row_address_type = options.RowAddressType;
-
                 // dont care about these
                 var argc = IntPtr.Zero;
                 var argv = IntPtr.Zero;
@@ -93,6 +98,13 @@ namespace rpi_rgb_led_matrix_sharp
             canvas._canvas = led_matrix_swap_on_vsync(matrix, canvas._canvas);
             return canvas;
         }
+
+        public byte Brightness
+        {
+          get { return led_matrix_get_brightness(matrix); }
+          set { led_matrix_set_brightness(matrix, value); }
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/bindings/c#/examples/Makefile
+++ b/bindings/c#/examples/Makefile
@@ -13,6 +13,7 @@ all: $(CSHARP_LIB)
 	$(CSHARP_COMPILER) -r:$(CSHARP_LIB) -out:minimal-example.exe minimal-example.cs
 	$(CSHARP_COMPILER) -r:$(CSHARP_LIB) -out:matrix-rain.exe matrix-rain.cs
 	$(CSHARP_COMPILER) -r:$(CSHARP_LIB) -out:font-example.exe font-example.cs
+	$(CSHARP_COMPILER) -r:$(CSHARP_LIB) -out:pulsing-brightness.exe pulsing-brightness.cs
 
 minimal-example.exe: $(CSHARP_LIB)
 	cp $(RGB_LIBRARY) $(RGB_LIBRARY_NAME).so
@@ -28,6 +29,11 @@ font-example.exe: $(CSHARP_LIB)
 	cp $(RGB_LIBRARY) $(RGB_LIBRARY_NAME).so
 	cp $(CSHARP_LIBRARY) $(CSHARP_LIB)
 	$(CSHARP_COMPILER) -r:$(CSHARP_LIB) -out:font-example.exe font-example.cs
+
+pulsing-brightness.exe: $(CSHARP_LIB)
+	cp $(RGB_LIBRARY) $(RGB_LIBRARY_NAME).so
+	cp $(CSHARP_LIBRARY) $(CSHARP_LIB)
+	$(CSHARP_COMPILER) -r:$(CSHARP_LIB) -out:pulsing-brightness.exe pulsing-brightness.cs
 
 $(CSHARP_LIB) :
 	$(MAKE) -C $(CSHARP_LIBDIR)

--- a/bindings/c#/examples/pulsing-brightness.cs
+++ b/bindings/c#/examples/pulsing-brightness.cs
@@ -1,0 +1,54 @@
+using rpi_rgb_led_matrix_sharp;
+using System;
+using System.Threading;
+
+namespace pulsing_brightness
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            var matrix = new RGBLedMatrix(new RGBLedMatrixOptions {Rows = 32, Cols = 64});
+            var canvas = matrix.CreateOffscreenCanvas();
+            var maxBrightness = matrix.Brightness;
+            var count = 0;
+            const int c = 255;
+
+            while (!Console.KeyAvailable)
+            {
+                if (matrix.Brightness < 1)
+                {
+                    matrix.Brightness = maxBrightness;
+                    count += 1;
+                }
+                else
+                {
+                    matrix.Brightness -= 1;
+                }
+
+                switch (count % 4)
+                {
+                    case 0:
+                        canvas.Fill(new Color(c, 0, 0));
+                        break;
+                    case 1:
+                        canvas.Fill(new Color(0, c, 0));
+                        break;
+                    case 2:
+                        canvas.Fill(new Color(0, 0, c));
+                        break;
+                    case 3:
+                        canvas.Fill(new Color(c, c, c));
+                        break;
+                }
+
+                canvas = matrix.SwapOnVsync(canvas);
+
+                Thread.Sleep(20);
+            }
+
+            return 0;
+        }
+    }
+}
+

--- a/include/led-matrix-c.h
+++ b/include/led-matrix-c.h
@@ -253,6 +253,8 @@ struct LedCanvas *led_matrix_create_offscreen_canvas(struct RGBLedMatrix *matrix
 struct LedCanvas *led_matrix_swap_on_vsync(struct RGBLedMatrix *matrix,
                                            struct LedCanvas *canvas);
 
+uint8_t led_matrix_get_brightness(struct RGBLedMatrix *matrix);
+void led_matrix_set_brightness(struct RGBLedMatrix *matrix, uint8_t brightness);
 
 struct LedFont *load_font(const char *bdf_font_file);
 void delete_font(struct LedFont *font);

--- a/lib/led-matrix-c.cc
+++ b/lib/led-matrix-c.cc
@@ -155,6 +155,15 @@ struct LedCanvas *led_matrix_swap_on_vsync(struct RGBLedMatrix *matrix,
   return from_canvas(to_matrix(matrix)->SwapOnVSync(to_canvas(canvas)));
 }
 
+void led_matrix_set_brightness(struct RGBLedMatrix *matrix,
+                               uint8_t brightness) {
+  to_matrix(matrix)->SetBrightness(brightness);
+}
+
+uint8_t led_matrix_get_brightness(struct RGBLedMatrix *matrix) {
+  return to_matrix(matrix)->brightness();
+}
+
 void led_canvas_get_size(const struct LedCanvas *canvas,
                          int *width, int *height) {
   rgb_matrix::FrameCanvas *c = to_canvas((struct LedCanvas*)canvas);


### PR DESCRIPTION
I want to set matrix brightness via C# binding.

Python binding has property `matrix.brightness`, but C# does not. ☹
This is a proposal adding accessors for brightness to C# binding.

Summary:
+ Add C-function `led_matrix_set_brightness()` and `led_matrix_get_brightness()`, C-bridge of `RGBMatrix::SetBrightness()` and `RGBMatrix::brightness()`
+ Add C#-property `RGBLedMatrix.Brightness`, accessor to C-function above

Also added `bindings/c#/examples/pulsing-brightness.cs`, a C# porting of `bindings/python/samples/pulsing-brightness.py`

Thanks.