### PR TITLE
Adds new multiplex-mapper for QiangLi Q8  40x20 panel

### DIFF
--- a/lib/multiplex-mappers.cc
+++ b/lib/multiplex-mappers.cc
@@ -238,7 +238,20 @@ public:
     }
   }
 };
+class QiangLiQ8 : public MultiplexMapperBase {
+public:
+  QiangLiQ8() : MultiplexMapperBase("QiangLiQ8", 2) {}
 
+  void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
+	int collumn = x + (4+ 4*(x/4));
+	*matrix_x = collumn;
+	if((y >= 15 && y <=19)||(y>=5 && y <= 9)){
+	  	int reverseCollumn = x + (4*(x/4));
+		 *matrix_x = reverseCollumn;
+	}
+	*matrix_y = y % 5 + (y/10) *5 ;
+  }
+};
 /*
  * Here is where the registration happens.
  * If you add an instance of the mapper here, it will automatically be
@@ -257,7 +270,7 @@ static MuxMapperList *CreateMultiplexMapperList() {
   result->push_back(new Kaler2ScanMapper());
   result->push_back(new ZStripeMultiplexMapper("ZStripeUneven", 8, 0));
   result->push_back(new P10MapperZ());
-
+  result->push_back(new QiangLiQ8());
   return result;
 }
 


### PR DESCRIPTION

Panel [info page](http://www.qiangliled.com/products-85.html)
Got best work results with --led-slowdown-gpio 2
<details>
<summary> Here some panel identification photos</summary>

![IMG_20190823_152226](https://user-images.githubusercontent.com/35693519/64009013-c28dac00-cb1f-11e9-8a82-d5235bcd91b4.jpg)
![IMG_20190823_152232](https://user-images.githubusercontent.com/35693519/64009014-c3264280-cb1f-11e9-8df9-cfd82c7c2591.jpg)
![IMG_20190823_152240](https://user-images.githubusercontent.com/35693519/64009016-c3264280-cb1f-11e9-835b-a48e2715258c.jpg)
</details>
<details>
<summary> Pixel arrangement from colorlight calibration tool</summary>

![IMG_20190821_144635](https://user-images.githubusercontent.com/35693519/64009727-0df48a00-cb21-11e9-93dd-08bdd8e23aba.jpg)
</details>

<details>
<summary>mapper work result</summary>

![IMG_20190830_114230](https://user-images.githubusercontent.com/35693519/64009769-24024a80-cb21-11e9-85f3-ee02f784c621.jpg)

</details>