### PR TITLE
Swap options parameter for RGBMatrix constructor

### DIFF
--- a/bindings/python/rgbmatrix/core.pyx
+++ b/bindings/python/rgbmatrix/core.pyx
@@ -184,8 +184,8 @@ cdef class RGBMatrixOptions:
         def __set__(self, uint8_t value): self.__runtime_options.drop_privileges = value
 
 cdef class RGBMatrix(Canvas):
-    def __cinit__(self, int rows = 0, int chains = 0, int parallel = 0,
-        RGBMatrixOptions options = None):
+    def __cinit__(self, RGBMatrixOptions options = None,
+                  int rows = 0, int chains = 0, int parallel = 0):
 
         # If RGBMatrixOptions not provided, create defaults and set any optional
         # parameters supplied


### PR DESCRIPTION
This PR makes a small change to the constructor of the `RGBMatrix` class by shifting the kwarg to specify the options to the front.
IMO, this implementation makes more sense since using an `RGBMatrixOptions` object is the main way to specify your layout and other options, and this would allow you to initialize your matrix object like this:
```python
options = RGBMatrixOptions()
options.rows = 64
matrix = RGBMatrix(options)
```
which was previously not possible as doing this would pass your options as the `rows` kwarg and cause a segfault.