### PR TITLE
secure radius-max

### DIFF
--- a/examples-api-use/minimal-example.cc
+++ b/examples-api-use/minimal-example.cc
@@ -30,7 +30,7 @@ static void DrawOnCanvas(Canvas *canvas) {
 
   int center_x = canvas->width() / 2;
   int center_y = canvas->height() / 2;
-  float radius_max = canvas->width() / 2;
+  float radius_max = fmin (canvas->width(),canvas->height()) / 2;
   float angle_step = 1.0 / 360;
   for (float a = 0, r = 0; r < radius_max; a += angle_step, r += angle_step) {
     if (interrupt_received)


### PR DESCRIPTION
Hello, just a little proposition to secure radius_max value that hang and reboot my raspberry PI because I have 64 cols*32 rows and radius_max was computed to 32 and this value is outside of my dot matrix display.