### PR TITLE
Add font height and baseline to exported methods

### DIFF
--- a/include/led-matrix-c.h
+++ b/include/led-matrix-c.h
@@ -295,6 +295,12 @@ void set_image(struct LedCanvas *c, int canvas_offset_x, int canvas_offset_y,
 // Load a font given a path to a font file containing a bdf font.
 struct LedFont *load_font(const char *bdf_font_file);
 
+// Read the baseline of a font
+int baseline_font(struct LedFont *font);
+
+// Read the height of a font
+int height_font(struct LedFont *font);
+
 // Delete a font originally created from load_font.
 void delete_font(struct LedFont *font);
 

--- a/lib/led-matrix-c.cc
+++ b/lib/led-matrix-c.cc
@@ -209,6 +209,14 @@ struct LedFont *load_font(const char *bdf_font_file) {
   return from_font(font);
 }
 
+int baseline_font(struct LedFont * font) {
+  return to_font(font)->baseline();
+}
+
+int height_font(struct LedFont * font) {
+  return to_font(font)->height();
+}
+
 void delete_font(struct LedFont *font) {
   delete to_font(font);
 }


### PR DESCRIPTION
Add additional methods of the font class to the exported functions in in the .so so that they can be consumed in the C# wrapper.