### PR TITLE
Add outline font creation to exported methods

### DIFF
--- a/include/led-matrix-c.h
+++ b/include/led-matrix-c.h
@@ -301,6 +301,9 @@ int baseline_font(struct LedFont *font);
 // Read the height of a font
 int height_font(struct LedFont *font);
 
+// Creates an outline font based on an existing font instance
+struct LedFont *create_outline_font(struct LedFont *font);
+
 // Delete a font originally created from load_font.
 void delete_font(struct LedFont *font);
 

--- a/lib/led-matrix-c.cc
+++ b/lib/led-matrix-c.cc
@@ -217,10 +217,14 @@ int height_font(struct LedFont * font) {
   return to_font(font)->height();
 }
 
+struct LedFont *create_outline_font(struct LedFont * font) {
+  rgb_matrix::Font* outlineFont = to_font(font)->CreateOutlineFont();
+  return from_font(outlineFont);
+}
+
 void delete_font(struct LedFont *font) {
   delete to_font(font);
 }
-
 
 // -- Some utility functions.
 


### PR DESCRIPTION
Also export the create_outline_font method to the .so for consumption by the wrappers.