### PR TITLE
assign default values to all RT option parameters

### DIFF
--- a/lib/led-matrix-c.cc
+++ b/lib/led-matrix-c.cc
@@ -57,6 +57,8 @@ static struct RGBLedMatrix *led_matrix_create_from_options_optional_edit(
   rgb_matrix::RuntimeOptions default_rt;
   default_rt.drop_privileges = 0;  // Usually, this is on, but let user choose.
   default_rt.daemon = 0;
+  default_rt.gpio_slowdown = 0;
+  default_rt.do_gpio_init = false;  // Usually, this is on, but let user choose.
 
   rgb_matrix::RGBMatrix::Options default_opts;
 
@@ -96,6 +98,10 @@ static struct RGBLedMatrix *led_matrix_create_from_options_optional_edit(
       rgb_matrix::PrintMatrixFlags(stderr, default_opts, default_rt);
       return NULL;
     }
+  } else {
+    // CL args not provided. Assume defaults for RT options
+    runtime_opt.drop_privileges = 1;
+    runtime_opt.do_gpio_init = true;
   }
 
   if (opts) {

--- a/lib/led-matrix.cc
+++ b/lib/led-matrix.cc
@@ -514,6 +514,7 @@ FrameCanvas *RGBMatrix::Impl::CreateFrameCanvas() {
 FrameCanvas *RGBMatrix::Impl::SwapOnVSync(FrameCanvas *other,
                                           unsigned frame_fraction) {
   if (frame_fraction == 0) frame_fraction = 1; // correct user error.
+  if (!updater_) return NULL;
   FrameCanvas *const previous = updater_->SwapOnVSync(other, frame_fraction);
   if (other) active_ = other;
   return previous;


### PR DESCRIPTION
For other language bindings that utilize the C interface and do not rely on the C++ library for arg parsing, a few key runtime options are left uninitialized, resulting in sometimes the updater thread not starting and causing us to use a null pointer. We can see the use of these uninitialized values in valgrind (output slightly trimmed):
```
$ valgrind ./target/release/matrix-test
==10572== Memcheck, a memory error detector
==10572== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==10572== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==10572== Command: ./target/release/matrix-test
==10572==
==10572== Conditional jump or move depends on uninitialised value(s)
==10572==    at 0x157CB4: rgb_matrix::RGBMatrix::CreateFromOptions(rgb_matrix::RGBMatrix::Options const&, rgb_matrix::RuntimeOptions const&) (led-matrix.cc:635)
==10572==    by 0x1569B3: led_matrix_create_from_options_optional_edit(RGBLedMatrixOptions*, int*, char***, bool) (led-matrix-c.cc:126)
==10572==    by 0x130BEB: rpi_led_matrix::LedMatrix::new (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==    by 0x118867: matrix_test::main (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==    by 0x118BEF: std::rt::lang_start::{{closure}} (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==    by 0x13D157: {{closure}} (rt.rs:52)
==10572==    by 0x13D157: do_call<closure-0,i32> (panicking.rs:348)
==10572==    by 0x13D157: try<i32,closure-0> (panicking.rs:325)
==10572==    by 0x13D157: catch_unwind<closure-0,i32> (panic.rs:394)
==10572==    by 0x13D157: std::rt::lang_start_internal (rt.rs:51)
==10572==    by 0x118BDB: main (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==
==10572== Conditional jump or move depends on uninitialised value(s)
==10572==    at 0x157CE0: rgb_matrix::RGBMatrix::CreateFromOptions(rgb_matrix::RGBMatrix::Options const&, rgb_matrix::RuntimeOptions const&) (led-matrix.cc:648)
==10572==    by 0x1569B3: led_matrix_create_from_options_optional_edit(RGBLedMatrixOptions*, int*, char***, bool) (led-matrix-c.cc:126)
==10572==    by 0x130BEB: rpi_led_matrix::LedMatrix::new (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==    by 0x118867: matrix_test::main (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==    by 0x118BEF: std::rt::lang_start::{{closure}} (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==    by 0x13D157: {{closure}} (rt.rs:52)
==10572==    by 0x13D157: do_call<closure-0,i32> (panicking.rs:348)
==10572==    by 0x13D157: try<i32,closure-0> (panicking.rs:325)
==10572==    by 0x13D157: catch_unwind<closure-0,i32> (panic.rs:394)
==10572==    by 0x13D157: std::rt::lang_start_internal (rt.rs:51)
==10572==    by 0x118BDB: main (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==
==10572== Process terminating with default action of signal 11 (SIGSEGV)
==10572==  Access not within mapped region at address 0xE8
==10572==    at 0x4A0DD34: pthread_mutex_lock (pthread_mutex_lock.c:67)
==10572==    by 0x1573EB: Lock (thread.h:63)
==10572==    by 0x1573EB: MutexLock (thread.h:78)
==10572==    by 0x1573EB: SwapOnVSync (led-matrix.cc:232)
==10572==    by 0x1573EB: rgb_matrix::RGBMatrix::Impl::SwapOnVSync(rgb_matrix::FrameCanvas*, unsigned int) (led-matrix.cc:517)
==10572==    by 0x130D73: rpi_led_matrix::LedMatrix::swap (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==    by 0x1188D7: matrix_test::main (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==    by 0x118BEF: std::rt::lang_start::{{closure}} (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==    by 0x13D157: {{closure}} (rt.rs:52)
==10572==    by 0x13D157: do_call<closure-0,i32> (panicking.rs:348)
==10572==    by 0x13D157: try<i32,closure-0> (panicking.rs:325)
==10572==    by 0x13D157: catch_unwind<closure-0,i32> (panic.rs:394)
==10572==    by 0x13D157: std::rt::lang_start_internal (rt.rs:51)
==10572==    by 0x118BDB: main (in /home/pi/projects/rpi-matrix/matrix-test/target/release/matrix-test)
==10572==
==10572== ERROR SUMMARY: 6 errors from 5 contexts (suppressed: 0 from 0)
[1]    10572 segmentation fault  valgrind ./target/release/matrix-test
```