### PR TITLE
Add GitHub actions CI to ensure PRs compile

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,17 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make


### PR DESCRIPTION
It compiles on ubuntu so it obviously isn't perfect (there seems to be a few extra warnings), but it can at least be a sanity check on PRs.