### PR TITLE
Expose runtime options to C API

### DIFF
--- a/include/led-matrix-c.h
+++ b/include/led-matrix-c.h
@@ -29,6 +29,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #ifdef  __cplusplus
 extern "C" {
@@ -247,7 +248,6 @@ struct RGBLedMatrix *led_matrix_create_from_options_const_argv(
  *   rt_options.gpio_slowdown = 4;
  *   struct RGBLedMatrix *matrix = led_matrix_create_from_options_and_rt_options(&options, &rt_options);
  *   if (matrix == NULL) {
- *      led_matrix_print_flags(stderr);
  *      return 1;
  *   }
  *   // do additional commandline handling; then use matrix...

--- a/lib/options-initialize.cc
+++ b/lib/options-initialize.cc
@@ -38,7 +38,8 @@ RuntimeOptions::RuntimeOptions() :
   gpio_slowdown(1),
 #endif
   daemon(0),            // Don't become a daemon by default.
-  drop_privileges(1)    // Encourage good practice: drop privileges by default.
+  drop_privileges(1),   // Encourage good practice: drop privileges by default.
+  do_gpio_init(true)
 {
   // Nothing to see here.
 }


### PR DESCRIPTION
In other language bindings (rust in my case), I'd like to fully control how the matrix is initialized without relying on argc/argv, as rust doesn't even give an easy way to access this C-like representation of command line input. Rather, I'd like to do my own command line parsing and fully control the options.

I think this might fulfill the needs of #1045 (cc. @gingters)

Breakdown of changes:
- add RGBLedRuntimeOptions struct to C header
- add `static_assert`'s to make sure C/C++ structures are at least the same size
- Add new C API that creates an `RGBLedMatrix` just from the given options & runtime options if they're non-NULL, without argc/argv at all
- Adds missing `do_gpio_init` initializer to C++ `RuntimeOptions` constructor
- fix apparent bug/typo in the copy back of options (`matrix_options` vs `default_opts` in `led_matrix_create_from_options_optional_edit`)