### PR TITLE
HARDWARE_DESC is not respected by a few of the examples

### DIFF
--- a/examples-api-use/README.md
+++ b/examples-api-use/README.md
@@ -121,7 +121,6 @@ using rgb_matrix::RGBMatrix;
 int main(int argc, char **argv) {
   // Set some defaults
   RGBMatrix::Options my_defaults;
-  my_defaults.hardware_mapping = "regular";  // or e.g. "adafruit-hat" or "adafruit-hat-pwm"
   my_defaults.chain_length = 3;
   my_defaults.show_refresh_rate = true;
   rgb_matrix::RuntimeOptions runtime_defaults;

--- a/examples-api-use/input-example.cc
+++ b/examples-api-use/input-example.cc
@@ -21,7 +21,6 @@ static void InterruptHandler(int signo) {
 
 int main(int argc, char *argv[]) {
   RGBMatrix::Options defaults;
-  defaults.hardware_mapping = "regular";  // or e.g. "adafruit-hat"
   defaults.rows = 32;
   defaults.chain_length = 1;
   defaults.parallel = 1;

--- a/examples-api-use/ledcat.cc
+++ b/examples-api-use/ledcat.cc
@@ -25,7 +25,6 @@ static void InterruptHandler(int signo) {
 
 int main(int argc, char *argv[]) {
   RGBMatrix::Options defaults;
-  defaults.hardware_mapping = "regular"; // or e.g. "adafruit-hat"
   defaults.rows = 32;
   defaults.chain_length = 1;
   defaults.parallel = 1;

--- a/examples-api-use/minimal-example.cc
+++ b/examples-api-use/minimal-example.cc
@@ -44,7 +44,6 @@ static void DrawOnCanvas(Canvas *canvas) {
 
 int main(int argc, char *argv[]) {
   RGBMatrix::Options defaults;
-  defaults.hardware_mapping = "regular";  // or e.g. "adafruit-hat"
   defaults.rows = 32;
   defaults.chain_length = 1;
   defaults.parallel = 1;


### PR DESCRIPTION
A few of the provided examples still hardcode the default hardware. Also the example in the README still does it. The rest have already modernized, so this is just consistent and now all of the examples work if any of them do.