### PR TITLE
Introduce --led-no-drop-privs for Python samples

### DIFF
--- a/bindings/python/samples/samplebase.py
+++ b/bindings/python/samples/samplebase.py
@@ -28,6 +28,8 @@ class SampleBase(object):
         self.parser.add_argument("--led-row-addr-type", action="store", help="0 = default; 1=AB-addressed panels; 2=row direct; 3=ABC-addressed panels; 4 = ABC Shift + DE direct", default=0, type=int, choices=[0,1,2,3,4])
         self.parser.add_argument("--led-multiplexing", action="store", help="Multiplexing type: 0=direct; 1=strip; 2=checker; 3=spiral; 4=ZStripe; 5=ZnMirrorZStripe; 6=coreman; 7=Kaler2Scan; 8=ZStripeUneven... (Default: 0)", default=0, type=int)
         self.parser.add_argument("--led-panel-type", action="store", help="Needed to initialize special panels. Supported: 'FM6126A'", default="", type=str)
+        self.parser.add_argument("--led-no-drop-privs", dest="drop_privileges", help="Don't drop privileges from 'root' after initializing the hardware.", action='store_false')
+        self.parser.set_defaults(drop_privileges=True)
 
     def usleep(self, value):
         time.sleep(value / 1000000.0)
@@ -55,6 +57,7 @@ class SampleBase(object):
         options.pixel_mapper_config = self.args.led_pixel_mapper
         options.panel_type = self.args.led_panel_type
 
+
         if self.args.led_show_refresh:
           options.show_refresh_rate = 1
 
@@ -62,6 +65,8 @@ class SampleBase(object):
             options.gpio_slowdown = self.args.led_slowdown_gpio
         if self.args.led_no_hardware_pulse:
           options.disable_hardware_pulsing = True
+        if not self.args.drop_privileges:
+          options.drop_privileges=False
 
         self.matrix = RGBMatrix(options = options)
 


### PR DESCRIPTION
* introduce `--led-no-drop-privs` to *samplebase.py* so that it is possible to keep root permissions in the python samples if needed