### PR TITLE
Add support for active high output enable

### DIFF
--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -460,6 +460,7 @@ Framebuffer::~Framebuffer() {
     if (b >= dither_bits) timing_ns *= 2;
   }
   sOutputEnablePulser = PinPulser::Create(io, h.output_enable,
+                                          h.output_polarity,
                                           allow_hardware_pulsing,
                                           bitplane_timings);
 }

--- a/lib/gpio-bits.h
+++ b/lib/gpio-bits.h
@@ -25,4 +25,10 @@ typedef uint64_t gpio_bits_t;
 typedef uint32_t gpio_bits_t;
 #endif
 
+typedef enum
+{
+    GPIO_ACTIVE_LOW = 0,
+    GPIO_ACTIVE_HIGH = 1,
+} gpio_active_t;
+
 #endif

--- a/lib/gpio.h
+++ b/lib/gpio.h
@@ -128,6 +128,7 @@ public:
   // "nano_wait_spec" contains a list of time periods we'd like
   //   invoke later. This can be used to pre-process timings if needed.
   static PinPulser *Create(GPIO *io, gpio_bits_t gpio_mask,
+                           gpio_active_t polarity,
                            bool allow_hardware_pulsing,
                            const std::vector<int> &nano_wait_spec);
 

--- a/lib/hardware-mapping.c
+++ b/lib/hardware-mapping.c
@@ -27,91 +27,94 @@ struct HardwareMapping matrix_hardware_mappings[] = {
    * by the adapter PCBs.
    */
   {
-    .name          = "regular",
+    .name            = "regular",
 
-    .output_enable = GPIO_BIT(18),
-    .clock         = GPIO_BIT(17),
-    .strobe        = GPIO_BIT(4),
+    .output_enable   = GPIO_BIT(18),
+    .output_polarity = GPIO_ACTIVE_LOW,
+    .clock           = GPIO_BIT(17),
+    .strobe          = GPIO_BIT(4),
 
     /* Address lines */
-    .a             = GPIO_BIT(22),
-    .b             = GPIO_BIT(23),
-    .c             = GPIO_BIT(24),
-    .d             = GPIO_BIT(25),
-    .e             = GPIO_BIT(15),  /* RxD kept free unless 1:64 */
+    .a               = GPIO_BIT(22),
+    .b               = GPIO_BIT(23),
+    .c               = GPIO_BIT(24),
+    .d               = GPIO_BIT(25),
+    .e               = GPIO_BIT(15),  /* RxD kept free unless 1:64 */
 
     /* Parallel chain 0, RGB for both sub-panels */
-    .p0_r1         = GPIO_BIT(11),  /* masks: SPI0_SCKL  */
-    .p0_g1         = GPIO_BIT(27),  /* Not on RPi1, Rev1; use "regular-pi1" instead */
-    .p0_b1         = GPIO_BIT(7),   /* masks: SPI0_CE1   */
-    .p0_r2         = GPIO_BIT(8),   /* masks: SPI0_CE0   */
-    .p0_g2         = GPIO_BIT(9),   /* masks: SPI0_MISO  */
-    .p0_b2         = GPIO_BIT(10),  /* masks: SPI0_MOSI  */
+    .p0_r1           = GPIO_BIT(11),  /* masks: SPI0_SCKL  */
+    .p0_g1           = GPIO_BIT(27),  /* Not on RPi1, Rev1; use "regular-pi1" instead */
+    .p0_b1           = GPIO_BIT(7),   /* masks: SPI0_CE1   */
+    .p0_r2           = GPIO_BIT(8),   /* masks: SPI0_CE0   */
+    .p0_g2           = GPIO_BIT(9),   /* masks: SPI0_MISO  */
+    .p0_b2           = GPIO_BIT(10),  /* masks: SPI0_MOSI  */
 
     /* All the following are only available with 40 GPIP pins, on A+/B+/Pi2,3 */
     /* Chain 1 */
-    .p1_r1         = GPIO_BIT(12),
-    .p1_g1         = GPIO_BIT(5),
-    .p1_b1         = GPIO_BIT(6),
-    .p1_r2         = GPIO_BIT(19),
-    .p1_g2         = GPIO_BIT(13),
-    .p1_b2         = GPIO_BIT(20),
+    .p1_r1           = GPIO_BIT(12),
+    .p1_g1           = GPIO_BIT(5),
+    .p1_b1           = GPIO_BIT(6),
+    .p1_r2           = GPIO_BIT(19),
+    .p1_g2           = GPIO_BIT(13),
+    .p1_b2           = GPIO_BIT(20),
 
     /* Chain 2 */
-    .p2_r1         = GPIO_BIT(14), /* masks TxD when parallel=3 */
-    .p2_g1         = GPIO_BIT(2),  /* masks SCL when parallel=3 */
-    .p2_b1         = GPIO_BIT(3),  /* masks SDA when parallel=3 */
-    .p2_r2         = GPIO_BIT(26),
-    .p2_g2         = GPIO_BIT(16),
-    .p2_b2         = GPIO_BIT(21),
+    .p2_r1           = GPIO_BIT(14), /* masks TxD when parallel=3 */
+    .p2_g1           = GPIO_BIT(2),  /* masks SCL when parallel=3 */
+    .p2_b1           = GPIO_BIT(3),  /* masks SDA when parallel=3 */
+    .p2_r2           = GPIO_BIT(26),
+    .p2_g2           = GPIO_BIT(16),
+    .p2_b2           = GPIO_BIT(21),
   },
 
   /*
    * This is used if you have an Adafruit HAT in the default configuration
    */
   {
-    .name          = "adafruit-hat",
+    .name            = "adafruit-hat",
 
-    .output_enable = GPIO_BIT(4),
-    .clock         = GPIO_BIT(17),
-    .strobe        = GPIO_BIT(21),
+    .output_enable   = GPIO_BIT(4),
+    .output_polarity = GPIO_ACTIVE_LOW,
+    .clock           = GPIO_BIT(17),
+    .strobe          = GPIO_BIT(21),
 
-    .a             = GPIO_BIT(22),
-    .b             = GPIO_BIT(26),
-    .c             = GPIO_BIT(27),
-    .d             = GPIO_BIT(20),
-    .e             = GPIO_BIT(24),  /* Needs manual wiring, see README.md */
+    .a               = GPIO_BIT(22),
+    .b               = GPIO_BIT(26),
+    .c               = GPIO_BIT(27),
+    .d               = GPIO_BIT(20),
+    .e               = GPIO_BIT(24),  /* Needs manual wiring, see README.md */
 
-    .p0_r1         = GPIO_BIT(5),
-    .p0_g1         = GPIO_BIT(13),
-    .p0_b1         = GPIO_BIT(6),
-    .p0_r2         = GPIO_BIT(12),
-    .p0_g2         = GPIO_BIT(16),
-    .p0_b2         = GPIO_BIT(23),
+    .p0_r1           = GPIO_BIT(5),
+    .p0_g1           = GPIO_BIT(13),
+    .p0_b1           = GPIO_BIT(6),
+    .p0_r2           = GPIO_BIT(12),
+    .p0_g2           = GPIO_BIT(16),
+    .p0_b2           = GPIO_BIT(23),
   },
 
   /*
    * An Adafruit HAT with the PWM modification
    */
   {
-    .name          = "adafruit-hat-pwm",
+    .name            = "adafruit-hat-pwm",
 
-    .output_enable = GPIO_BIT(18),  /* The only change compared to above */
-    .clock         = GPIO_BIT(17),
-    .strobe        = GPIO_BIT(21),
+    .output_enable   = GPIO_BIT(18),  /* The only change compared to above */
+    .output_polarity = GPIO_ACTIVE_LOW,
+    .clock           = GPIO_BIT(17),
+    .strobe          = GPIO_BIT(21),
 
-    .a             = GPIO_BIT(22),
-    .b             = GPIO_BIT(26),
-    .c             = GPIO_BIT(27),
-    .d             = GPIO_BIT(20),
-    .e             = GPIO_BIT(24),
+    .a               = GPIO_BIT(22),
+    .b               = GPIO_BIT(26),
+    .c               = GPIO_BIT(27),
+    .d               = GPIO_BIT(20),
+    .e               = GPIO_BIT(24),
 
-    .p0_r1         = GPIO_BIT(5),
-    .p0_g1         = GPIO_BIT(13),
-    .p0_b1         = GPIO_BIT(6),
-    .p0_r2         = GPIO_BIT(12),
-    .p0_g2         = GPIO_BIT(16),
-    .p0_b2         = GPIO_BIT(23),
+    .p0_r1           = GPIO_BIT(5),
+    .p0_g1           = GPIO_BIT(13),
+    .p0_b1           = GPIO_BIT(6),
+    .p0_r2           = GPIO_BIT(12),
+    .p0_g2           = GPIO_BIT(16),
+    .p0_b2           = GPIO_BIT(23),
   },
 
   /*
@@ -119,29 +122,30 @@ struct HardwareMapping matrix_hardware_mappings[] = {
    * the same pin for GPIO-21 as later Pis use GPIO-27. Make it work for both.
    */
   {
-    .name          = "regular-pi1",
+    .name            = "regular-pi1",
 
-    .output_enable = GPIO_BIT(18),
-    .clock         = GPIO_BIT(17),
-    .strobe        = GPIO_BIT(4),
+    .output_enable   = GPIO_BIT(18),
+    .output_polarity = GPIO_ACTIVE_LOW,
+    .clock           = GPIO_BIT(17),
+    .strobe          = GPIO_BIT(4),
 
     /* Address lines */
-    .a             = GPIO_BIT(22),
-    .b             = GPIO_BIT(23),
-    .c             = GPIO_BIT(24),
-    .d             = GPIO_BIT(25),
-    .e             = GPIO_BIT(15),  /* RxD kept free unless 1:64 */
+    .a               = GPIO_BIT(22),
+    .b               = GPIO_BIT(23),
+    .c               = GPIO_BIT(24),
+    .d               = GPIO_BIT(25),
+    .e               = GPIO_BIT(15),  /* RxD kept free unless 1:64 */
 
     /* Parallel chain 0, RGB for both sub-panels */
-    .p0_r1         = GPIO_BIT(11),  /* masks: SPI0_SCKL  */
+    .p0_r1           = GPIO_BIT(11),  /* masks: SPI0_SCKL  */
     /* On Pi1 Rev1, the pin other Pis have GPIO27, these have GPIO21. So make
      * this work for both Rev1 and Rev2.
      */
-    .p0_g1         = GPIO_BIT(21) | GPIO_BIT(27),
-    .p0_b1         = GPIO_BIT(7),   /* masks: SPI0_CE1   */
-    .p0_r2         = GPIO_BIT(8),   /* masks: SPI0_CE0   */
-    .p0_g2         = GPIO_BIT(9),   /* masks: SPI0_MISO  */
-    .p0_b2         = GPIO_BIT(10),  /* masks: SPI0_MOSI  */
+    .p0_g1           = GPIO_BIT(21) | GPIO_BIT(27),
+    .p0_b1           = GPIO_BIT(7),   /* masks: SPI0_CE1   */
+    .p0_r2           = GPIO_BIT(8),   /* masks: SPI0_CE0   */
+    .p0_g2           = GPIO_BIT(9),   /* masks: SPI0_MISO  */
+    .p0_b2           = GPIO_BIT(10),  /* masks: SPI0_MOSI  */
 
     /* No more chains - there are not enough GPIO */
   },
@@ -153,64 +157,66 @@ struct HardwareMapping matrix_hardware_mappings[] = {
    * Not used anymore.
    */
   {
-    .name          = "classic",
+    .name            = "classic",
 
-    .output_enable = GPIO_BIT(27),  /* Not available on RPi1, Rev 1 */
-    .clock         = GPIO_BIT(11),
-    .strobe        = GPIO_BIT(4),
+    .output_enable   = GPIO_BIT(27),  /* Not available on RPi1, Rev 1 */
+    .output_polarity = GPIO_ACTIVE_LOW,
+    .clock           = GPIO_BIT(11),
+    .strobe          = GPIO_BIT(4),
 
-    .a             = GPIO_BIT(7),
-    .b             = GPIO_BIT(8),
-    .c             = GPIO_BIT(9),
-    .d             = GPIO_BIT(10),
+    .a               = GPIO_BIT(7),
+    .b               = GPIO_BIT(8),
+    .c               = GPIO_BIT(9),
+    .d               = GPIO_BIT(10),
 
-    .p0_r1         = GPIO_BIT(17),
-    .p0_g1         = GPIO_BIT(18),
-    .p0_b1         = GPIO_BIT(22),
-    .p0_r2         = GPIO_BIT(23),
-    .p0_g2         = GPIO_BIT(24),
-    .p0_b2         = GPIO_BIT(25),
+    .p0_r1           = GPIO_BIT(17),
+    .p0_g1           = GPIO_BIT(18),
+    .p0_b1           = GPIO_BIT(22),
+    .p0_r2           = GPIO_BIT(23),
+    .p0_g2           = GPIO_BIT(24),
+    .p0_b2           = GPIO_BIT(25),
 
-    .p1_r1         = GPIO_BIT(12),
-    .p1_g1         = GPIO_BIT(5),
-    .p1_b1         = GPIO_BIT(6),
-    .p1_r2         = GPIO_BIT(19),
-    .p1_g2         = GPIO_BIT(13),
-    .p1_b2         = GPIO_BIT(20),
+    .p1_r1           = GPIO_BIT(12),
+    .p1_g1           = GPIO_BIT(5),
+    .p1_b1           = GPIO_BIT(6),
+    .p1_r2           = GPIO_BIT(19),
+    .p1_g2           = GPIO_BIT(13),
+    .p1_b2           = GPIO_BIT(20),
 
-    .p2_r1         = GPIO_BIT(14),   /* masks TxD if parallel = 3 */
-    .p2_g1         = GPIO_BIT(2),    /* masks SDA if parallel = 3 */
-    .p2_b1         = GPIO_BIT(3),    /* masks SCL if parallel = 3 */
-    .p2_r2         = GPIO_BIT(15),
-    .p2_g2         = GPIO_BIT(26),
-    .p2_b2         = GPIO_BIT(21),
+    .p2_r1           = GPIO_BIT(14),   /* masks TxD if parallel = 3 */
+    .p2_g1           = GPIO_BIT(2),    /* masks SDA if parallel = 3 */
+    .p2_b1           = GPIO_BIT(3),    /* masks SCL if parallel = 3 */
+    .p2_r2           = GPIO_BIT(15),
+    .p2_g2           = GPIO_BIT(26),
+    .p2_b2           = GPIO_BIT(21),
   },
 
   /*
    * Classic pin-out for Rev-A Raspberry Pi.
    */
   {
-    .name          = "classic-pi1",
+    .name            = "classic-pi1",
 
     /* The Revision-1 and Revision-2 boards have different GPIO mappings
      * on the P1-3 and P1-5. So we use both interpretations.
      * To keep the I2C pins free, we avoid these in later mappings.
      */
-    .output_enable = GPIO_BIT(0) | GPIO_BIT(2),
-    .clock         = GPIO_BIT(1) | GPIO_BIT(3),
-    .strobe        = GPIO_BIT(4),
+    .output_enable   = GPIO_BIT(0) | GPIO_BIT(2),
+    .output_polarity = GPIO_ACTIVE_LOW,
+    .clock           = GPIO_BIT(1) | GPIO_BIT(3),
+    .strobe          = GPIO_BIT(4),
 
-    .a             = GPIO_BIT(7),
-    .b             = GPIO_BIT(8),
-    .c             = GPIO_BIT(9),
-    .d             = GPIO_BIT(10),
+    .a               = GPIO_BIT(7),
+    .b               = GPIO_BIT(8),
+    .c               = GPIO_BIT(9),
+    .d               = GPIO_BIT(10),
 
-    .p0_r1         = GPIO_BIT(17),
-    .p0_g1         = GPIO_BIT(18),
-    .p0_b1         = GPIO_BIT(22),
-    .p0_r2         = GPIO_BIT(23),
-    .p0_g2         = GPIO_BIT(24),
-    .p0_b2         = GPIO_BIT(25),
+    .p0_r1           = GPIO_BIT(17),
+    .p0_g1           = GPIO_BIT(18),
+    .p0_b1           = GPIO_BIT(22),
+    .p0_r2           = GPIO_BIT(23),
+    .p0_g2           = GPIO_BIT(24),
+    .p0_b2           = GPIO_BIT(25),
   },
 
 #ifdef ENABLE_WIDE_GPIO_COMPUTE_MODULE
@@ -218,68 +224,69 @@ struct HardwareMapping matrix_hardware_mappings[] = {
    * Custom pin-out for compute-module
    */
   {
-    .name          = "compute-module",
+    .name            = "compute-module",
 
     /* This GPIO mapping is made for the official I/O development
      * board. No pin is left free when using 6 parallel chains.
      */
-    .output_enable = GPIO_BIT(18),
-    .clock         = GPIO_BIT(16),
-    .strobe        = GPIO_BIT(17),
+    .output_enable   = GPIO_BIT(18),
+    .output_polarity = GPIO_ACTIVE_LOW,
+    .clock           = GPIO_BIT(16),
+    .strobe          = GPIO_BIT(17),
 
-    .a             = GPIO_BIT(2),
-    .b             = GPIO_BIT(3),
-    .c             = GPIO_BIT(4),
-    .d             = GPIO_BIT(5),
-    .e             = GPIO_BIT(6),  /* RxD kept free unless 1:64 */
+    .a               = GPIO_BIT(2),
+    .b               = GPIO_BIT(3),
+    .c               = GPIO_BIT(4),
+    .d               = GPIO_BIT(5),
+    .e               = GPIO_BIT(6),  /* RxD kept free unless 1:64 */
 
     /* Chain 0 */
-    .p0_r1         = GPIO_BIT(7),
-    .p0_g1         = GPIO_BIT(8),
-    .p0_b1         = GPIO_BIT(9),
-    .p0_r2         = GPIO_BIT(10),
-    .p0_g2         = GPIO_BIT(11),
-    .p0_b2         = GPIO_BIT(12),
+    .p0_r1           = GPIO_BIT(7),
+    .p0_g1           = GPIO_BIT(8),
+    .p0_b1           = GPIO_BIT(9),
+    .p0_r2           = GPIO_BIT(10),
+    .p0_g2           = GPIO_BIT(11),
+    .p0_b2           = GPIO_BIT(12),
 
     /* Chain 1 */
-    .p1_r1         = GPIO_BIT(13),
-    .p1_g1         = GPIO_BIT(14),
-    .p1_b1         = GPIO_BIT(15),
-    .p1_r2         = GPIO_BIT(19),
-    .p1_g2         = GPIO_BIT(20),
-    .p1_b2         = GPIO_BIT(21),
+    .p1_r1           = GPIO_BIT(13),
+    .p1_g1           = GPIO_BIT(14),
+    .p1_b1           = GPIO_BIT(15),
+    .p1_r2           = GPIO_BIT(19),
+    .p1_g2           = GPIO_BIT(20),
+    .p1_b2           = GPIO_BIT(21),
 
     /* Chain 2 */
-    .p2_r1         = GPIO_BIT(22),
-    .p2_g1         = GPIO_BIT(23),
-    .p2_b1         = GPIO_BIT(24),
-    .p2_r2         = GPIO_BIT(25),
-    .p2_g2         = GPIO_BIT(26),
-    .p2_b2         = GPIO_BIT(27),
+    .p2_r1           = GPIO_BIT(22),
+    .p2_g1           = GPIO_BIT(23),
+    .p2_b1           = GPIO_BIT(24),
+    .p2_r2           = GPIO_BIT(25),
+    .p2_g2           = GPIO_BIT(26),
+    .p2_b2           = GPIO_BIT(27),
 
     /* Chain 3 */
-    .p3_r1         = GPIO_BIT(28),
-    .p3_g1         = GPIO_BIT(29),
-    .p3_b1         = GPIO_BIT(30),
-    .p3_r2         = GPIO_BIT(31),
-    .p3_g2         = GPIO_BIT(32),
-    .p3_b2         = GPIO_BIT(33),
+    .p3_r1           = GPIO_BIT(28),
+    .p3_g1           = GPIO_BIT(29),
+    .p3_b1           = GPIO_BIT(30),
+    .p3_r2           = GPIO_BIT(31),
+    .p3_g2           = GPIO_BIT(32),
+    .p3_b2           = GPIO_BIT(33),
 
     /* Chain 4 */
-    .p4_r1         = GPIO_BIT(34),
-    .p4_g1         = GPIO_BIT(35),
-    .p4_b1         = GPIO_BIT(36),
-    .p4_r2         = GPIO_BIT(37),
-    .p4_g2         = GPIO_BIT(38),
-    .p4_b2         = GPIO_BIT(39),
+    .p4_r1           = GPIO_BIT(34),
+    .p4_g1           = GPIO_BIT(35),
+    .p4_b1           = GPIO_BIT(36),
+    .p4_r2           = GPIO_BIT(37),
+    .p4_g2           = GPIO_BIT(38),
+    .p4_b2           = GPIO_BIT(39),
 
     /* Chain 5 */
-    .p5_r1         = GPIO_BIT(40),
-    .p5_g1         = GPIO_BIT(41),
-    .p5_b1         = GPIO_BIT(42),
-    .p5_r2         = GPIO_BIT(43),
-    .p5_g2         = GPIO_BIT(44),
-    .p5_b2         = GPIO_BIT(45),
+    .p5_r1           = GPIO_BIT(40),
+    .p5_g1           = GPIO_BIT(41),
+    .p5_b1           = GPIO_BIT(42),
+    .p5_r2           = GPIO_BIT(43),
+    .p5_g2           = GPIO_BIT(44),
+    .p5_b2           = GPIO_BIT(45),
   },
 #endif
 

--- a/lib/hardware-mapping.c
+++ b/lib/hardware-mapping.c
@@ -219,6 +219,42 @@ struct HardwareMapping matrix_hardware_mappings[] = {
     .p0_b2           = GPIO_BIT(25),
   },
 
+  /*
+   * Maximus64's LED cube hat
+   */
+  {
+    .name            = "cubie-hat",
+
+    .output_enable   = GPIO_BIT(12), /* swap 18 -> 12 from regular */
+    .output_polarity = GPIO_ACTIVE_HIGH,
+    .clock           = GPIO_BIT(17),
+    .strobe          = GPIO_BIT(4),
+
+    /* Address lines */
+    .a               = GPIO_BIT(22),
+    .b               = GPIO_BIT(23),
+    .c               = GPIO_BIT(24),
+    .d               = GPIO_BIT(25),
+    .e               = GPIO_BIT(15),  /* RxD kept free unless 1:64 */
+
+    /* Chain 0 */
+    .p0_r1           = GPIO_BIT(14), /* masks: SPI0_CE1 swap 12 -> 14 from regular */
+    .p0_g1           = GPIO_BIT(5),
+    .p0_b1           = GPIO_BIT(6),
+    .p0_r2           = GPIO_BIT(16), /* swap 19 -> 16 from regular */
+    .p0_g2           = GPIO_BIT(13),
+    .p0_b2           = GPIO_BIT(26), /* swap 20 -> 26 from regular */
+
+    /* Chain 1 */
+    .p1_r1           = GPIO_BIT(11),  /* masks: SPI0_SCKL  */
+    .p1_g1           = GPIO_BIT(27),
+    .p1_b1           = GPIO_BIT(7),   /* masks: SPI0_CE1   */
+    .p1_r2           = GPIO_BIT(8),   /* masks: SPI0_CE0   */
+    .p1_g2           = GPIO_BIT(9),   /* masks: SPI0_MISO  */
+    .p1_b2           = GPIO_BIT(10),  /* masks: SPI0_MOSI  */
+  },
+
+
 #ifdef ENABLE_WIDE_GPIO_COMPUTE_MODULE
   /*
    * Custom pin-out for compute-module

--- a/lib/hardware-mapping.h
+++ b/lib/hardware-mapping.h
@@ -27,6 +27,7 @@ struct HardwareMapping {
   int max_parallel_chains;
 
   gpio_bits_t output_enable;
+  gpio_active_t output_polarity;
   gpio_bits_t clock;
   gpio_bits_t strobe;
 


### PR DESCRIPTION
This change added support for active high output signal for OE and also bring in support for my custom LED matrix cube hat name `cubie-hat`. The output enable pin on this hat is inverted to avoid glitch on initial power on. 

Background:
The 3.3v power rail on Raspberry Pi 4 comes on later than the 5v input supply and since the OE is pulled up to the 3.3v rail on the active3 hat, there will be a short glitch on the OE signal at powering up causing unwanted flicker on the LED panel. To fix this issue, I added an NPN transistor to drive the OE signal on my custom hat and that fixed the issue.
![image](https://user-images.githubusercontent.com/10281972/145562425-9400fc14-f5c1-478e-84e7-0624f9eb2821.png)
