### PR TITLE
utils/text-scroller.cc: replace uint

### DIFF
--- a/utils/text-scroller.cc
+++ b/utils/text-scroller.cc
@@ -21,6 +21,7 @@
 #include <getopt.h>
 #include <math.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -217,12 +218,12 @@ int main(int argc, char *argv[]) {
 
   struct timespec next_frame = {0, 0};
 
-  uint frame_counter = 0;
+  uint64_t frame_counter = 0;
   while (!interrupt_received && loops != 0) {
     ++frame_counter;
     offscreen_canvas->Fill(bg_color.r, bg_color.g, bg_color.b);
     const bool draw_on_frame = (blink_on <= 0)
-      || (frame_counter % (blink_on + blink_off) < (uint)blink_on);
+      || (frame_counter % (blink_on + blink_off) < (uint64_t)blink_on);
 
     if (draw_on_frame) {
       if (outline_font) {


### PR DESCRIPTION
Replace `uint` by `uint64_t` to avoid the following build failure on musl:

```
text-scroller.cc: In function 'int main(int, char**)':
text-scroller.cc:220:3: error: 'uint' was not declared in this scope; did you mean 'rint'?
  220 |   uint frame_counter = 0;
      |   ^~~~
      |   rint
```

Fixes:
 - http://autobuild.buildroot.org/results/1a230bd46eac35081bdb6fe9aaacbb7b62ea6b73

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>