### PR TITLE
Fix animation by clearing matrix canvas every frame

### DIFF
--- a/examples-api-use/image-example.cc
+++ b/examples-api-use/image-example.cc
@@ -102,6 +102,7 @@ void ShowAnimatedImage(const ImageVector &images, RGBMatrix *matrix) {
   while (!interrupt_received) {
     for (const auto &image : images) {
       if (interrupt_received) break;
+      offscreen_canvas->Clear();
       CopyImageToCanvas(image, offscreen_canvas);
       offscreen_canvas = matrix->SwapOnVSync(offscreen_canvas);
       usleep(image.animationDelay() * 10000);  // 1/100s converted to usec


### PR DESCRIPTION
Found a bug displaying animated images (GIFs).