### PR TITLE
Feature remap mapper

### DIFF
--- a/include/pixel-mapper.h
+++ b/include/pixel-mapper.h
@@ -80,6 +80,14 @@ public:
   virtual void MapVisibleToMatrix(int matrix_width, int matrix_height,
                                   int visible_x, int visible_y,
                                   int *matrix_x, int *matrix_y) const = 0;
+
+  virtual bool MapMatrixToVisible(int matrix_width, int matrix_height,
+                                  int matrix_x, int matrix_y,
+                                  int *visible_x, int *visible_y) const { return false; };
+  enum MappingType {
+    VisibleToMatrix, MatrixToVisible
+  };
+  virtual MappingType GetMappingType() const { return VisibleToMatrix; }
 };
 
 // This is a place to register PixelMappers globally. If you register your


### PR DESCRIPTION
(for discussion, needs some polishing, needs testing)

This PR implements universal mapper - each segment is mapped to arbitrary position and orientation on canvas

My use case is two separate displays connected as chains, each with different geometry. But it shall handle almost all possible panel configuration

Syntax is:
```
--led-pixel-mapper='Remap:<new_width>,<new_height>|<panel0_x>,<panel0_y><panel0_orientation>|<panel1_x>,<panel1_y><panel1_orientation>'
```
new_width, new_height - size of created canvas. It can be both larger and smaller than old canvas.
panel0_x, panel0_y - upper-left corner of remapped panel
panel0_orientation - `n`,`s`,`e`,`w` for panel orientation, `x` to discard panel

Exactly one entry must be specified for each LED panel (chain * parallel entries). 
Mapping may be partially outside new canvas (maybe useful for something?)
Unused positions must be discarded (`0,0x`) - useful if chains are of different length
It is possible let some canvas space unused (no panel mapped to it). Writes to this area will be ignored.

For example:
```
 --led-cols=16 --led-rows=8 --led-chain=5 --led-parallel=2 --led-pixel-mapper='Remap:40,32|0,0e|8,0e|16,0e|24,0e|32,0e|0,16n|16,16n|0,24n|16,24n|0,0x'
```
First chain is 5 panels in line, top of the panel is pointing right, 40x16 pixels
Second chain is 2x2 square, panels pointing up, 32x16 pixels, top-left is 0,16 in canvas
Last panel on second chain is not used
```
1 2 3 4 5
1 2 3 4 5
6 6 7 7 
8 8 9 9
```

I'll add some documentation if there is interest in this feature 


