### PR TITLE
Pi4 gpio timing experiment 

### DIFF
--- a/examples-api-use/minimal-example.cc
+++ b/examples-api-use/minimal-example.cc
@@ -33,7 +33,7 @@ static void DrawOnCanvas(Canvas *canvas) {
   float angle_step = 1.0 / 360;
   for (float a = 0, r = 0; r < radius_max; a += angle_step, r += angle_step) {
     if (interrupt_received)
-      return;
+    return;
     float dot_x = cos(a * 2 * M_PI) * r;
     float dot_y = sin(a * 2 * M_PI) * r;
     canvas->SetPixel(center_x + dot_x, center_y + dot_y,

--- a/lib/led-matrix.cc
+++ b/lib/led-matrix.cc
@@ -618,7 +618,9 @@ RGBMatrix *RGBMatrix::CreateFromOptions(const RGBMatrix::Options &options,
   }
 
   // For the Pi4, we might need 2, maybe up to 4. Let's open up to 5.
-  if (runtime_options.gpio_slowdown < 0 || runtime_options.gpio_slowdown > 5) {
+  // on supproted architectures, -1 will emit memory barier (DSB ST) after GPIO write
+  if (runtime_options.gpio_slowdown < (__ARM_ARCH >= 7 ? -1 : 0)
+      || runtime_options.gpio_slowdown > 5) {
     fprintf(stderr, "--led-slowdown-gpio=%d is outside usable range\n",
             runtime_options.gpio_slowdown);
     return NULL;


### PR DESCRIPTION
(for discussion, do not merge)

This PR uses DSB memory barrier that forces AXI transaction to complete before next instruction. 

Pros:
- You get very accurate timing, RGB data and clock are almost perfectly synchronized. Absolutely no ghosting
- possibly slightly lower power consumption (5% ? core is stalled, not busy waiting)

Cons:
- Clock frequency si limited, to about 6MHz on non-overclocked PI4 
  - about half vs using --led-gpio-slowdown. 
  - Overclocking does change timing, but I did not investigate it yet. 
-  Memory access from other threads will slow serial speed down a bit (but timing is not degraded as in --led-gpio-slowdown case)

It may be very useful with long/noisy cables or slow matrices. Timing margins are much beter

![dsb-st-clock](https://user-images.githubusercontent.com/2318015/200669788-f138876a-0ea0-4290-adc1-b57906213701.PNG)


