### PR TITLE
Add a link to the V2 version of the Active-3 board.

### DIFF
--- a/adapter/README.md
+++ b/adapter/README.md
@@ -14,6 +14,8 @@ with the wiring when using the `rpi-rgb-led-matrix` code.
      They are given to help you locate premade boards but no guarantees are given or implied:
      * https://www.electrodragon.com/product/rgb-matrix-panel-drive-board-raspberry-pi/
        ($3/board, but fairly long and/or expensive shipping from HKG)
+       
+       * https://www.electrodragon.com/product/rgb-matrix-panel-drive-board-for-raspberry-pi-v2/ (V2 of the above board, better design and no battery required.)
      * Seller #2 (fill me)
    * The [Passive-RPi1](./passive-rpi1) adapter board is to connect one panel to
      Raspberry Pi 1 with 26 GPIO pins.


### PR DESCRIPTION
Sorry this doesn't have full details. I'm unsure the V2 implementation is REALLY the full implementation of the Active3 board, but it's the one I FAR prefer for all my projects, and the one I always am looking for when I come to this page.