### PR TITLE
Re-use CreateFrameCanvas() in samples/gif-viewer.py

### DIFF
--- a/bindings/python/samples/gif-viewer.py
+++ b/bindings/python/samples/gif-viewer.py
@@ -30,16 +30,16 @@ options.hardware_mapping = 'regular'  # If you have an Adafruit HAT: 'adafruit-h
 matrix = RGBMatrix(options = options)
 
 # Preprocess the gifs frames into canvases to improve playback performance
-canvases = []
+frames = []
+canvas = matrix.CreateFrameCanvas()
 print("Preprocessing gif, this may take a moment depending on the size of the gif...")
 for frame_index in range(0, num_frames):
     gif.seek(frame_index)
     # must copy the frame out of the gif, since thumbnail() modifies the image in-place
     frame = gif.copy()
     frame.thumbnail((matrix.width, matrix.height), Image.ANTIALIAS)
-    canvas = matrix.CreateFrameCanvas()
-    canvas.SetImage(frame.convert("RGB"))
-    canvases.append(canvas)
+    
+    frames.append(frame.convert("RGB"))
 # Close the gif file to save memory now that we have copied out all of the frames
 gif.close()
 
@@ -51,7 +51,8 @@ try:
     # Infinitely loop through the gif
     cur_frame = 0
     while(True):
-        matrix.SwapOnVSync(canvases[cur_frame], framerate_fraction=10)
+        canvas.SetImage(frames[cur_frame])
+        matrix.SwapOnVSync(canvas, framerate_fraction=10)
         if cur_frame == num_frames - 1:
             cur_frame = 0
         else:


### PR DESCRIPTION
I used the original sample to display a list of GIF files.  
After a few minutes I got this warning:  
```
CreateFrameCanvas() called 500 times. Usually you only want to call it once (or at most a few times) for double-buffering...
```
I modified the sample and re-use the canvas instead.