### PR TITLE
examples: Update .gitignore

### DIFF
--- a/examples-api-use/.gitignore
+++ b/examples-api-use/.gitignore
@@ -5,3 +5,5 @@ c-example
 clock
 scrolling-text-example
 ledcat
+input-example
+pixel-mover


### PR DESCRIPTION
`input-example`, and `pixel-mover` are built files, so we ignore them.