### PR TITLE
Allow to sleep instead of busy waiting when limiting refresh rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ to debug if it has something to do with the sound subsystem (see Troubleshooting
 section). This is really only recommended for debugging; typically you actually
 want the hardware pulses as it results in a much more stable picture.
 
-<a name="no-drop-priv"/>
+<a name="no-drop-priv"></a>
 
 ```
 --led-no-drop-privs       : Don't drop privileges from 'root' after initializing the hardware.

--- a/README.md
+++ b/README.md
@@ -381,6 +381,20 @@ the vsync-multiple flag `-V` in the [led-image-viewer] or
 [video-viewer] utility programs.
 
 ```
+--led-no-busy-waiting     : Don't use busy waiting when limiting refresh rate.
+```
+
+This allows to switch from busy waiting to sleep waiting when limiting the
+refresh rate (`--led-limit-refresh`).
+
+By default, refresh rate limiting uses busy waiting, which is CPU intensive but
+gives most accurate timings. This is fine for multi-core boards.
+
+On single core boards (e.g.: Raspberry Pi Zero) busy waiting makes the system
+unresponsive for other/background tasks. There, sleep waiting improves the
+system's responsiveness at the cost of slightly less accurate timings.
+
+```
 --led-scan-mode=<0..1>    : 0 = progressive; 1 = interlaced (Default: 0).
 ```
 

--- a/include/led-matrix-c.h
+++ b/include/led-matrix-c.h
@@ -152,6 +152,12 @@ struct RGBLedMatrixOptions {
    * to keep a constant refresh rate. <= 0 for no limit.
    */
   int limit_refresh_rate_hz;     /* Corresponding flag: --led-limit-refresh */
+
+  /* Sleep instead of busy waiting when limiting refresh rate. This gives
+   * slightly less accurate frame timing, but lets the CPU work on other
+   * processes when waiting and renders single core boards more responsive.
+   */
+  bool disable_busy_waiting;     /* Corresponding flag: --led-busy-waiting */
 };
 
 /**

--- a/include/led-matrix.h
+++ b/include/led-matrix.h
@@ -155,6 +155,10 @@ public:
     // Limit refresh rate of LED panel. This will help on a loaded system
     // to keep a constant refresh rate. <= 0 for no limit.
     int limit_refresh_rate_hz;   // Flag: --led-limit-refresh
+
+    // Sleep instead of busy wait to free CPU cycles but get slightly less
+    // accurate frame timing.
+    bool disable_busy_waiting;   // Flag: --led-busy-waiting
   };
 
   // Factory to create a matrix. Additional functionality includes dropping

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -129,6 +129,13 @@ HARDWARE_DESC?=regular
 # Flag: --led-limit-refresh
 #DEFINES+=-DFIXED_FRAME_MICROSECONDS=5000
 
+# When limiting refrash rate, a CPU core is busy waiting to get accurate
+# timing. On single board systems, this results in an unresponsive system.
+# By disabling busy waiting, CPU cycles are freed up, leading to a more
+# responsive system at the cost of slightly less accurate frame timing.
+# Flag: --led-no-busy-waiting
+#DEFINES+=-DDISABLE_BUSY_WAITING
+
 # Enable wide 64 bit GPIO offered with the compute module.
 # This will use more memory to internally represent the frame buffer, so
 # caches can't be utilized as much.

--- a/lib/gpio.cc
+++ b/lib/gpio.cc
@@ -814,4 +814,9 @@ uint32_t GetMicrosecondCounter() {
   return epoch_usec & 0xFFFFFFFF;
 }
 
+// For external use, e.g. to lessen busy waiting.
+void SleepMicroseconds(long t) {
+  Timers::sleep_nanos(t * 1000);
+}
+
 } // namespace rgb_matrix

--- a/lib/gpio.h
+++ b/lib/gpio.h
@@ -144,6 +144,8 @@ public:
 // if possible and a terrible slow fallback otherwise.
 uint32_t GetMicrosecondCounter();
 
+void SleepMicroseconds(long);
+
 }  // end namespace rgb_matrix
 
 #endif  // RPI_GPIO_INGERNALH

--- a/lib/led-matrix-c.cc
+++ b/lib/led-matrix-c.cc
@@ -88,6 +88,7 @@ static struct RGBLedMatrix *led_matrix_create_from_options_optional_edit(
     OPT_COPY_IF_SET(pixel_mapper_config);
     OPT_COPY_IF_SET(panel_type);
     OPT_COPY_IF_SET(limit_refresh_rate_hz);
+    OPT_COPY_IF_SET(disable_busy_waiting);
 #undef OPT_COPY_IF_SET
   }
 
@@ -134,6 +135,7 @@ static struct RGBLedMatrix *led_matrix_create_from_options_optional_edit(
     ACTUAL_VALUE_BACK_TO_OPT(pixel_mapper_config);
     ACTUAL_VALUE_BACK_TO_OPT(panel_type);
     ACTUAL_VALUE_BACK_TO_OPT(limit_refresh_rate_hz);
+    ACTUAL_VALUE_BACK_TO_OPT(disable_busy_waiting);
 #undef ACTUAL_VALUE_BACK_TO_OPT
   }
 

--- a/lib/options-initialize.cc
+++ b/lib/options-initialize.cc
@@ -209,6 +209,12 @@ static bool FlagInit(int &argc, char **&argv,
         continue;
       }
 
+      bool allow_busy_waiting = !mopts->disable_busy_waiting;
+      if (ConsumeBoolFlag("busy-waiting", it, &allow_busy_waiting)) {
+        mopts->disable_busy_waiting = !allow_busy_waiting;
+        continue;
+      }
+
       bool request_help = false;
       if (ConsumeBoolFlag("help", it, &request_help) && request_help) {
         // In that case, we pretend to have failure in parsing, which will
@@ -338,7 +344,8 @@ void PrintMatrixFlags(FILE *out, const RGBMatrix::Options &d,
           "\t--led-pwm-dither-bits=<0..2> : Time dithering of lower bits "
           "(Default: 0)\n"
           "\t--led-%shardware-pulse   : %sse hardware pin-pulse generation.\n"
-          "\t--led-panel-type=<name>   : Needed to initialize special panels. Supported: 'FM6126A', 'FM6127'\n",
+          "\t--led-panel-type=<name>   : Needed to initialize special panels. Supported: 'FM6126A', 'FM6127'\n"
+          "\t--led-%sbusy-waiting     : %sse busy waiting when limiting refresh rate.\n",
           d.hardware_mapping,
           d.rows, d.cols, d.chain_length, d.parallel,
           (int) muxers.size(), CreateAvailableMultiplexString(muxers).c_str(),
@@ -350,7 +357,9 @@ void PrintMatrixFlags(FILE *out, const RGBMatrix::Options &d,
           d.inverse_colors ? "no-" : "",    d.inverse_colors ? "off" : "on",
           d.pwm_lsb_nanoseconds,
           !d.disable_hardware_pulsing ? "no-" : "",
-          !d.disable_hardware_pulsing ? "Don't u" : "U");
+          !d.disable_hardware_pulsing ? "Don't u" : "U",
+          !d.disable_busy_waiting ? "no-" : "",
+          !d.disable_busy_waiting ? "Don't u" : "U");
 
   fprintf(out, "\t--led-slowdown-gpio=<0..4>: "
           "Slowdown GPIO. Needed for faster Pis/slower panels "


### PR DESCRIPTION
On single core boards, busy waiting renders the system unresponsive. We add the --led-no-busy-waiting flag, to allow the process to sleep instead of busy waiting, thereby freeing up CPU cycles for other processes at the cost of slightly less accurate frame timing.

On a Raspberry Pi 3B on two 32x32 panels, busy waiting keeps a core 98% busy. Sleeping reduces it to 14%.

On a Raspberry Zero on two 32x32 panels, busy waiting keeps the single core 95% busy and gives an unresponsive system. Sleeping reduces it to 32% and keeps the system responsive.

Sleeping degrades the timing accuracy a bit, but is still good enough by a far margin for many uses. The following numbers are for driving two 32x32 panels and averaging the refresh rate across a minute (the 1kHz refresh rate limit is of course not reached, and is only there to make sure that the relevant code path is taken):

                                                   +--------------+-----------+
                                                   | busy waiting | sleeping  |
+--------------------------------------------------+--------------+-----------+
| Raspberry Pi 3B, limit 70Hz, hardw. pulsing      |  70.000Hz    |  69.977Hz |
| Raspberry Pi 3B, limit 70Hz, no hardw. pulsing   |  70.000Hz    |  69.977Hz |
| Raspberry Pi 3B, limit 1kHz, hardw. pulsing      | 430.824Hz    | 430.855Hz |
| Raspberry Pi 3B, limit 1kHz, no hardw. pulsing   | 365.498Hz    | 365.456Hz |
| Raspberry Pi Zero, limit 70Hz, hardw. pulsing    |  69.986Hz    |  69.643Hz |
| Raspberry Pi Zero, limit 70Hz, no hardw. pulsing |  69.986Hz    |  69.638Hz |
| Raspberry Pi Zero, limit 1kHz, hardw. pulsing    | 263.877Hz    | 264.538Hz |
| Raspberry Pi Zero, limit 1kHz, no hardw. pulsing | 233.166Hz    | 231.650Hz |
+--------------------------------------------------+--------------+-----------+