### PR TITLE
fix: auto `b` variable in loop is shadowning `b` fcn argument

### DIFF
--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -649,15 +649,15 @@ void Framebuffer::Fill(uint8_t r, uint8_t g, uint8_t b) {
   MapColors(r, g, b, &red, &green, &blue);
   const PixelDesignator &fill = (*shared_mapper_)->GetFillColorBits();
 
-  for (int b = kBitPlanes - pwm_bits_; b < kBitPlanes; ++b) {
-    uint16_t mask = 1 << b;
+  for (int bits = kBitPlanes - pwm_bits_; bits < kBitPlanes; ++bits) {
+    uint16_t mask = 1 << bits;
     gpio_bits_t plane_bits = 0;
     plane_bits |= ((red & mask) == mask)   ? fill.r_bit : 0;
     plane_bits |= ((green & mask) == mask) ? fill.g_bit : 0;
     plane_bits |= ((blue & mask) == mask)  ? fill.b_bit : 0;
 
     for (int row = 0; row < double_rows_; ++row) {
-      gpio_bits_t *row_data = ValueAt(row, 0, b);
+      gpio_bits_t *row_data = ValueAt(row, 0, bits);
       for (int col = 0; col < columns_; ++col) {
         *row_data++ = plane_bits;
       }

--- a/lib/led-matrix.cc
+++ b/lib/led-matrix.cc
@@ -412,17 +412,17 @@ RGBMatrix::~RGBMatrix() {
 }
 
 uint64_t RGBMatrix::Impl::RequestInputs(uint64_t bits) {
-  return io_->RequestInputs(bits);
+  return io_->RequestInputs(static_cast<gpio_bits_t>(bits));
 }
 
 uint64_t RGBMatrix::Impl::RequestOutputs(uint64_t output_bits) {
-  uint64_t success_bits = io_->InitOutputs(output_bits);
+  uint64_t success_bits = io_->InitOutputs(static_cast<gpio_bits_t>(output_bits));
   user_output_bits_ |= success_bits;
   return success_bits;
 }
 
 void RGBMatrix::Impl::OutputGPIO(uint64_t output_bits) {
-  io_->WriteMaskedBits(output_bits, user_output_bits_);
+  io_->WriteMaskedBits(static_cast<gpio_bits_t>(output_bits), static_cast<gpio_bits_t>(user_output_bits_));
 }
 
 void RGBMatrix::Impl::ApplyNamedPixelMappers(const char *pixel_mapper_config,


### PR DESCRIPTION
1. Minor fix that changes a variable name. Some compilers options (such as what I'm using) don't like that.
2. Explicit type casting on a few led-matrix.cc methods