### PR TITLE
Updated ZStripeMultiplexMapper to support variable tile sizes

### DIFF
--- a/lib/multiplex-mappers.cc
+++ b/lib/multiplex-mappers.cc
@@ -153,14 +153,16 @@ public:
 
 class ZStripeMultiplexMapper : public MultiplexMapperBase {
 public:
-  ZStripeMultiplexMapper(const char *name, int even_vblock_offset, int odd_vblock_offset)
+  ZStripeMultiplexMapper(const char *name, int even_vblock_offset, int odd_vblock_offset, int width, int height)
   : MultiplexMapperBase(name, 2),
     even_vblock_offset_(even_vblock_offset),
-    odd_vblock_offset_(odd_vblock_offset) {}
+    odd_vblock_offset_(odd_vblock_offset),
+    width_(width),
+    height_(height) {}
 
   void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
-    static const int tile_width = 8;
-    static const int tile_height = 4;
+    static const int tile_width = width_;
+    static const int tile_height = height_;
 
     const int vert_block_is_odd = ((y / tile_height) % 2);
 
@@ -174,6 +176,8 @@ public:
 private:
   const int even_vblock_offset_;
   const int odd_vblock_offset_;
+  const int width_;
+  const int height_;
 };
 
 class CoremanMapper : public MultiplexMapperBase {
@@ -466,11 +470,11 @@ static MuxMapperList *CreateMultiplexMapperList() {
   result->push_back(new StripeMultiplexMapper());
   result->push_back(new CheckeredMultiplexMapper());
   result->push_back(new SpiralMultiplexMapper());
-  result->push_back(new ZStripeMultiplexMapper("ZStripe", 0, 8));
-  result->push_back(new ZStripeMultiplexMapper("ZnMirrorZStripe", 4, 4));
+  result->push_back(new ZStripeMultiplexMapper("ZStripe", 0, 8, 8, 4));
+  result->push_back(new ZStripeMultiplexMapper("ZnMirrorZStripe", 4, 4, 8, 4));
   result->push_back(new CoremanMapper());
   result->push_back(new Kaler2ScanMapper());
-  result->push_back(new ZStripeMultiplexMapper("ZStripeUneven", 8, 0));
+  result->push_back(new ZStripeMultiplexMapper("ZStripeUneven", 8, 0, 8, 4));
   result->push_back(new P10MapperZ());
   result->push_back(new QiangLiQ8());
   result->push_back(new InversedZStripe());
@@ -481,6 +485,7 @@ static MuxMapperList *CreateMultiplexMapperList() {
   result->push_back(new P8Outdoor1R1G1BMultiplexMapper());
   result->push_back(new FlippedStripeMultiplexMapper());
   result->push_back(new P10Outdoor32x16HalfScanMapper());
+  result->push_back(new ZStripeMultiplexMapper("P3Outdoor104x52", 4, 4, 8, 13)); //note: 13 tile height needed for this
   return result;
 }
 


### PR DESCRIPTION
This change allowed me to use the ZStripeMultiplexMapper with a tile height of 13, for an LED panel that required this change for the mapping to work

I decided to update ZStripeMultiplexMapper - rather than make a new mapping - because this change may be helpful for future panels that require different tile heights or widths, like mine.

I've updated the existing mappings so that their original tile size values (8 and 4) are accounted for.