### PR TITLE
P3 RGB 64x64 1/16 scan Outdoor led panel multiplexer added

### DIFF
--- a/lib/multiplex-mappers.cc
+++ b/lib/multiplex-mappers.cc
@@ -481,9 +481,9 @@ class P3Outdoor64x64MultiplexMapper : public MultiplexMapperBase {
 public:
   P3Outdoor64x64MultiplexMapper() : MultiplexMapperBase("P3Outdoor64x64MultiplexMapper", 2) {}
   // P3 RGB panel 64x64
-  // with pattern   [1] [3] [4] [7]
-  //                   |   /   |
-  //                [0] [2] [5] [6]
+  // with pattern   [1] [3]
+  //                 | \ |
+  //                [0] [2]
 
   void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
     const bool is_top_stripe = (y % (panel_rows_/2)) < panel_rows_/4;

--- a/lib/multiplex-mappers.cc
+++ b/lib/multiplex-mappers.cc
@@ -487,11 +487,7 @@ public:
 
   void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
     const bool is_top_stripe = (y % (panel_rows_/2)) < panel_rows_/4;
-    const int quarter = x;
-    *matrix_x = ((2*quarter)
-                 + (is_top_stripe
-                    ? 1
-                    : 0));
+    *matrix_x = ((x*2) + (is_top_stripe ? 1 : 0));
     *matrix_y = ((y / (panel_rows_/2)) * (panel_rows_/4)
                  + y % (panel_rows_/4));
   }

--- a/lib/multiplex-mappers.cc
+++ b/lib/multiplex-mappers.cc
@@ -477,6 +477,27 @@ public:
 };
 
 
+class P3Outdoor64x64MultiplexMapper : public MultiplexMapperBase {
+public:
+  P3Outdoor64x64MultiplexMapper() : MultiplexMapperBase("P3Outdoor64x64MultiplexMapper", 2) {}
+  // P3 RGB panel 64x64
+  // with pattern   [1] [3] [4] [7]
+  //                   |   /   |
+  //                [0] [2] [5] [6]
+
+  void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
+    const bool is_top_stripe = (y % (panel_rows_/2)) < panel_rows_/4;
+    const int quarter = x;
+    *matrix_x = ((2*quarter)
+                 + (is_top_stripe
+                    ? 1
+                    : 0));
+    *matrix_y = ((y / (panel_rows_/2)) * (panel_rows_/4)
+                 + y % (panel_rows_/4));
+  }
+};
+
+
 /*
  * Here is where the registration happens.
  * If you add an instance of the mapper here, it will automatically be
@@ -505,6 +526,7 @@ static MuxMapperList *CreateMultiplexMapperList() {
   result->push_back(new FlippedStripeMultiplexMapper());
   result->push_back(new P10Outdoor32x16HalfScanMapper());
   result->push_back(new P10Outdoor32x16QuarterScanMapper());
+  result->push_back(new P3Outdoor64x64MultiplexMapper());
   return result;
 }
 


### PR DESCRIPTION
Fix for issues #1631, #1686

By a scientific poking method the solution was found for this RGB LED matrix (see image)
Scan 1/16 (E line is GND-connected)
Used on RPi via Adafruit Bonnet

![image](https://github.com/user-attachments/assets/d34f082c-e09b-4239-b796-e06b5677be8b)