### PR TITLE
Adding missing 'using' statements to the PlayGIF dotnet example

### DIFF
--- a/bindings/c#/examples/PlayGIF/Program.cs
+++ b/bindings/c#/examples/PlayGIF/Program.cs
@@ -1,6 +1,9 @@
 using RPiRgbLEDMatrix;
 using System.Runtime.InteropServices;
 using Color = RPiRgbLEDMatrix.Color;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 
 Console.Write("GIF path: ");
 var path = Console.ReadLine()!;


### PR DESCRIPTION
I could build all the C# examples except the PlayGIF one because it was missing some 'using' statements so this fixes that. Thanks.