### PR TITLE
fix: remove -march=native, to allow cross-compilation

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -172,7 +172,7 @@ DEFINES+=$(USER_DEFINES)
 
 DEFINES+=-DDEFAULT_HARDWARE='"$(HARDWARE_DESC)"'
 INCDIR=../include
-CFLAGS=-W -Wall -Wextra -Wno-unused-parameter -O3 -g -fPIC $(DEFINES) -march=native
+CFLAGS=-W -Wall -Wextra -Wno-unused-parameter -O3 -g -fPIC $(DEFINES)
 CXXFLAGS=$(CFLAGS) -fno-exceptions -std=c++11
 
 all : $(TARGET).a $(TARGET).so.1


### PR DESCRIPTION
On my machine, "cromwell":

```
$ uname -a
Linux cromwell 6.1.0-25-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.106-3 (2024-08-26) x86_64 GNU/Linux
```

I tried to cross-compile, overriding `CXX` to use a cross-compiling
toolchain.

This failed because `-march=native` is not a valid value when
cross-compiling from x86_64 to ARMv8.

In the `lib` directory:

```
$ CXX=aarch64-linux-gnu-g++ CC=aarch64-linux-gnu-gcc make
aarch64-linux-gnu-g++ -I../include -W -Wall -Wextra -Wno-unused-parameter -O3 -g -fPIC  -DDEFAULT_HARDWARE='"regular"' -march=native -fno-exceptions -std=c++11 -c -o gpio.o gpio.cc
cc1plus: error: unknown value ‘native’ for ‘-march’
cc1plus: note: valid arguments are: armv8-a armv8.1-a armv8.2-a armv8.3-a armv8.4-a armv8.5-a armv8.6-a armv8.7-a armv8.8-a armv8-r armv9-a
make: *** [Makefile:192: gpio.o] Error 1
```

With this change, compilation succeeds:

```
$ CXX=aarch64-linux-gnu-g++ CC=aarch64-linux-gnu-gcc make
```

produces `librgbmatrix.a` and `librgbmatrix.so.1` files just fine.
