### PR TITLE
Removed unused function in Impl class

### DIFF
--- a/lib/led-matrix.cc
+++ b/lib/led-matrix.cc
@@ -93,7 +93,6 @@ public:
   uint64_t RequestOutputs(uint64_t output_bits);
   void OutputGPIO(uint64_t output_bits);
 
-  void Clear();
 private:
   friend class RGBMatrix;
 


### PR DESCRIPTION
It seems that `RGBMatrix::Impl` has a declaration for a `Clear` function but no definition is found anywhere, and the function is never used.