### PR TITLE
Python Packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+RGB LED Python Package
+======================
+This fork was created to smooth installation of the Python rpi-rgb-led-matrix
+bindings (rgbmatrix). Wheel is built on Python 3.11 on a Pi3 - which should work
+for all intended use cases but has not been thoroughly tested. I'm purely an
+amateur so welcome someone with more skill and experience picking this up and
+improving it.
+
+As the originating library does not actually version, the package version is using
+the package's version (0.0.1) plus the date of the last commit as the version.
+
 Controlling RGB LED display with Raspberry Pi GPIO
 ==================================================
 

--- a/build-rpi-rgb-led-matrix.py
+++ b/build-rpi-rgb-led-matrix.py
@@ -1,0 +1,43 @@
+"""
+Hatch Build Hook to compile the rpi-rgb-led-matrix library.
+"""
+from hatchling.plugin import hookimpl
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+import os, subprocess
+import pathlib
+
+@hookimpl
+def hatch_register_build_hook():
+    """
+    Register the build hook.
+    :return:
+    """
+    return PyRGBMatrixBuildHook
+
+class PyRGBMatrixBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "pyrgbmatrix"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def clean(self, *args, **kwargs):
+        self.app.display_info("Running make clean...")
+        clean_process = subprocess.Popen('make clean', shell=True)
+        stdout, stderr = clean_process.communicate()
+        if stderr:
+            self.app.display_warning("Make clean encountered error.")
+
+    def initialize(self, _: str, build_data: dict):
+        """
+        Initialize the build, fetch the repo, determine version and compile.
+        :param _:
+        :param build_data:
+        :return:
+        """
+
+        self.app.display("Building rpi-rgb-led-matrix library...")
+        make_process = subprocess.Popen('make build-python HARDWARE_DESC="adafruit-hat-pwm"', shell=True)
+        stdout, stderr = make_process.communicate()
+        if stderr:
+            raise BaseException("Error occurred during build.")

--- a/hatch.toml
+++ b/hatch.toml
@@ -1,0 +1,22 @@
+# Build environment.
+[envs.hatch-build]
+dependencies = ["cython"]
+
+# External hook script which invokes the makefile to build C library.
+[build.targets.wheel.hooks.custom]
+dependencies = ["cython"]
+path = "build-rpi-rgb-led-matrix.py"
+
+# cython build for the python bindings.
+[build.targets.wheel]
+packages = ["bindings/python/"]
+
+[build.targets.wheel.hooks.cython]
+dependencies = ["hatch-cython"]
+
+[build.targets.wheel.hooks.cython.options]
+src = "src/bindings/python"
+includes = ["../../include"]
+libraries = "rgbmatrix"
+library_dirs = ["../../lib"]
+compile_args = ["-O3", "-Wall"]

--- a/hatch.toml
+++ b/hatch.toml
@@ -2,20 +2,26 @@
 [envs.hatch-build]
 dependencies = ["cython"]
 
+# Wheel build configuration
+[build.targets.wheel]
+packages = ["bindings/python/rgbmatrix"]
+exclude = [
+    "*.cpp",
+    "*.pyd",
+    "*.pyx"
+    ]
+artifacts = ["*.so"]
+
 # External hook script which invokes the makefile to build C library.
 [build.targets.wheel.hooks.custom]
 dependencies = ["cython"]
 path = "build-rpi-rgb-led-matrix.py"
 
-# cython build for the python bindings.
-[build.targets.wheel]
-packages = ["bindings/python/"]
-
 [build.targets.wheel.hooks.cython]
 dependencies = ["hatch-cython"]
 
 [build.targets.wheel.hooks.cython.options]
-src = "src/bindings/python"
+src = "src/bindings/python/rgbmatrix"
 includes = ["../../include"]
 libraries = "rgbmatrix"
 library_dirs = ["../../lib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "rgbmatrix"
+version = "0.0.1+20240924"
+description = "Packaged version of Christoph Friedrich's rpi-rgb-led-matrix library."
+authors = [{name="Christoph Friedrich", email="christoph.friedrich@vonaffenfels.de"}]
+maintainers = [{name="Chris Gill", email="chris@chrisgill.net"}]
+license = "GPL-2.0-or-later"
+readme = "README.md"
+requires-python = ">=3.11"


### PR DESCRIPTION
Per Marc's suggestion, making a PR here for review.
I put together packaging information for Python so that rpi-rgb-led-matrix can be installed as a package directly with pip. This is currently in a "works for me" state.
The build-rpi-rgb-led-matrix.py script uses the Hatch prebuild hooks to call the makefile and build the C libraries. The settings in hatch.toml make the Python package out of the files in "bindings/python/rgbmatrix". This does not include extensive checking for failures of the make process or passing of build options for different python packagers or cross-compiling.
Also note that PyPi no longer accepts local tags for version numbers. I had intended to put in code that would calculate a version based on the previous commit to the repo (ie: '0.0.1+20240924' for commit 0ff6a69). That may still be a viable strategy if you don't care about publishing to PyPi.