### PR TITLE
Fixes simple square not staying on when running demo

### DIFF
--- a/examples-api-use/demo-main.cc
+++ b/examples-api-use/demo-main.cc
@@ -128,15 +128,18 @@ public:
   void Run() override {
     const int width = canvas()->width() - 1;
     const int height = canvas()->height() - 1;
-    // Borders
-    DrawLine(canvas(), 0, 0,      width, 0,      Color(255, 0, 0));
-    DrawLine(canvas(), 0, height, width, height, Color(255, 255, 0));
-    DrawLine(canvas(), 0, 0,      0,     height, Color(0, 0, 255));
-    DrawLine(canvas(), width, 0,  width, height, Color(0, 255, 0));
 
-    // Diagonals.
-    DrawLine(canvas(), 0, 0,        width, height, Color(255, 255, 255));
-    DrawLine(canvas(), 0, height, width, 0,        Color(255,   0, 255));
+    while (!interrupt_received) {
+      // Borders
+      DrawLine(canvas(), 0, 0,      width, 0,      Color(255, 0, 0));
+      DrawLine(canvas(), 0, height, width, height, Color(255, 255, 0));
+      DrawLine(canvas(), 0, 0,      0,     height, Color(0, 0, 255));
+      DrawLine(canvas(), width, 0,  width, height, Color(0, 255, 0));
+
+      // Diagonals.
+      DrawLine(canvas(), 0, 0,        width, height, Color(255, 255, 255));
+      DrawLine(canvas(), 0, height, width, 0,        Color(255,   0, 255));
+    }
   }
 };
 


### PR DESCRIPTION
The third demo, simple square, exist immediately when you run it because it doesn't wait for the interrupt. This adds it in so it shows until you stop it.