### PR TITLE
Add ability to mock RPI hardware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,6 @@ set(CMAKE_CXX_STANDARD 14)
 file(GLOB_RECURSE SHARED_SOURCES
         lib/*.c*
 )
-if(MOCK_RPI)
-    add_definitions(-DDISABLE_HARDWARE_PULSES)
-    add_definitions(-DMOCK_RPI)
-endif()
 
 add_library(${PROJECT_NAME} SHARED)
 target_sources(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ file(GLOB_RECURSE SHARED_SOURCES
         lib/*.c*
 )
 
+if(MOCK_RPI)
+    add_definitions(-DDISABLE_HARDWARE_PULSES)
+    add_definitions(-DMOCK_RPI)
+endif()
+
 add_library(${PROJECT_NAME} SHARED)
 target_sources(${PROJECT_NAME}
         PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(rpi-rgb-led-matrix VERSION 0.1.0)
+
+set(CMAKE_CXX_STANDARD 14)
+
+file(GLOB_RECURSE SHARED_SOURCES
+        lib/*.c*
+)
+if(MOCK_RPI)
+    add_definitions(-DDISABLE_HARDWARE_PULSES)
+    add_definitions(-DMOCK_RPI)
+endif()
+
+add_library(${PROJECT_NAME} SHARED)
+target_sources(${PROJECT_NAME}
+        PRIVATE
+        ${SHARED_SOURCES}
+)
+# Main Target Compile
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+target_include_directories(${PROJECT_NAME}
+        PRIVATE
+        # where the library itself will look for its internal headers
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib
+        PUBLIC
+        # where top-level project will look for the library's public headers
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        # where external projects will look for the library's public headers
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)


### PR DESCRIPTION
This will add the ability to mock RPI hardware. Mocking RPI hardware can be especially useful when the project is large and needs a lot of compile time, especially on the slow RPI 3 hardware. Building and debugging the program on a computer can speed up development significantly.