### PR TITLE
Fix a number of compiler warnings and CodeQL findings

### DIFF
--- a/examples-api-use/clock.cc
+++ b/examples-api-use/clock.cc
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>
+#include <iostream>
 
 #include <vector>
 #include <string>
@@ -193,6 +193,6 @@ int main(int argc, char *argv[]) {
   // Finished. Shut down the RGB matrix.
   delete matrix;
 
-  write(STDOUT_FILENO, "\n", 1);  // Create a fresh new line after ^C on screen
+  std::cout << std::endl;  // Create a fresh new line after ^C on screen
   return 0;
 }

--- a/examples-api-use/demo-main.cc
+++ b/examples-api-use/demo-main.cc
@@ -267,7 +267,7 @@ public:
     line = ReadLine(f, header_buf, sizeof(header_buf));
     if (!line || sscanf(line, "%d ", &value) != 1 || value != 255)
       EXIT_WITH_MSG("Only 255 for maxval allowed.");
-    const size_t pixel_count = new_width * new_height;
+    const size_t pixel_count = (size_t)new_width * (size_t)new_height;
     Pixel *new_image = new Pixel [ pixel_count ];
     assert(sizeof(Pixel) == 3);   // we make that assumption.
     if (fread(new_image, sizeof(Pixel), pixel_count, f) != pixel_count) {

--- a/examples-api-use/ledcat.cc
+++ b/examples-api-use/ledcat.cc
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
   signal(SIGTERM, InterruptHandler);
   signal(SIGINT, InterruptHandler);
 
-  ssize_t frame_size = canvas->width() * canvas->height() * 3;
+  ssize_t frame_size = (ssize_t)canvas->width() * (ssize_t)canvas->height() * 3;
   uint8_t buf[frame_size];
 
   while (1) {

--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -296,7 +296,7 @@ Framebuffer::Framebuffer(int rows, int columns, int parallel,
     inverse_color_(inverse_color),
     pwm_bits_(kBitPlanes), do_luminance_correct_(true), brightness_(100),
     double_rows_(rows / SUB_PANELS_),
-    buffer_size_(double_rows_ * columns_ * kBitPlanes * sizeof(gpio_bits_t)),
+    buffer_size_((size_t)double_rows_ * (size_t)columns_ * kBitPlanes * sizeof(gpio_bits_t)),
     shared_mapper_(mapper) {
   assert(hardware_mapping_ != NULL);   // Called InitHardwareMapping() ?
   assert(shared_mapper_ != NULL);  // Storage should be provided by RGBMatrix.
@@ -842,7 +842,7 @@ void Framebuffer::DumpToMatrix(GPIO *io, int pwm_low_bit) {
   const int start_bit = std::max(pwm_low_bit, kBitPlanes - pwm_bits_);
 
   const uint8_t half_double = double_rows_/2;
-  for (uint8_t row_loop = 0; row_loop < double_rows_; ++row_loop) {
+  for (int row_loop = 0; row_loop < double_rows_; ++row_loop) {
     uint8_t d_row;
     switch (scan_mode_) {
     case 0:  // progressive


### PR DESCRIPTION
```
clock.cc: In function ‘int main(int, char**)’:
clock.cc:196:14: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
  196 |   (void)write(STDOUT_FILENO, "\n", 1);  // Create a fresh new line after ^C on screen
      |         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~

rpi-rgb-led-matrix/lib/framebuffer.cc:299:
Multiplication result may overflow 'int' before it is converted to 'unsigned long'.
This rule finds code that converts the result of an integer multiplication to a larger type. Since the conversion applies after the multiplication, arithmetic overflow may still occur.

rpi-rgb-led-matrix/lib/framebuffer.cc:845:
Comparison between  of type uint8_t and  of wider type const int.
In a loop condition, comparison of a value of a narrow type with a value of a wide type may result in unexpected behavior if the wider value is sufficiently large (or small). This is because the narrower value may overflow. This can lead to an infinite loop.

examples-api-use/demo-main.cc:270
Multiplication result may overflow 'int' before it is converted to 'size_t'.
This rule finds code that converts the result of an integer multiplication to a larger type. Since the conversion applies after the multiplication, arithmetic overflow may still occur.

examples-api-use/ledcat.cc:43
Multiplication result may overflow 'int' before it is converted to 'ssize_t'.
This rule finds code that converts the result of an integer multiplication to a larger type. Since the conversion applies after the multiplication, arithmetic overflow may still occur.
```