### PR TITLE
allow bigger slowdowns of GPIO output

### DIFF
--- a/lib/led-matrix.cc
+++ b/lib/led-matrix.cc
@@ -659,7 +659,7 @@ RGBMatrix *RGBMatrix::CreateFromOptions(const RGBMatrix::Options &options,
   // For the Pi4, we might need 2, maybe up to 4. Let's open up to 5.
   // on supproted architectures, -1 will emit memory barier (DSB ST) after GPIO write
   if (runtime_options.gpio_slowdown < (LED_MATRIX_ALLOW_BARRIER_DELAY ? -1 : 0)
-      || runtime_options.gpio_slowdown > 5) {
+      || runtime_options.gpio_slowdown > 10) {
     fprintf(stderr, "--led-slowdown-gpio=%d is outside usable range\n",
             runtime_options.gpio_slowdown);
     return NULL;


### PR DESCRIPTION
Because of ABC addressing speed issues described in hzeller#1774 ,
we need
hzeller#1773
as a workaround to slow down output until it works, although the real fix will indeed be to figure out why ABC output does not work reliably at higher speeds.
This may also be useful for people with noisy cables and/or long chains.

Note that a future merge will contain --led-row-addr-type=5 that allows running with much lower slowdown value.