### PR TITLE
Added from --led-row-addr-type=5 contributed by board707

### DIFF
--- a/lib/options-initialize.cc
+++ b/lib/options-initialize.cc
@@ -419,8 +419,8 @@ bool RGBMatrix::Options::Validate(std::string *err_in) const {
     success = false;
   }
 
-  if (row_address_type < 0 || row_address_type > 4) {
-    err->append("Row address type values can be 0 (default), 1 (AB addressing), 2 (direct row select), 3 (ABC address), 4 (ABC Shift + DE direct).\n");
+  if (row_address_type < 0 || row_address_type > 5) {
+    err->append("Row address type values can be 0 (default), 1 (AB addressing), 2 (direct row select), 3 (ABC address), 4 (ABC Shift + DE direct), 5 (Test row select).\n");
     success = false;
   }
 


### PR DESCRIPTION
This is just like --led-row-addr-type=3 but faster (as in works without a much higher gpio_slowdown which is now allowed by https://github.com/hzeller/rpi-rgb-led-matrix/pull/1785 )

If you find yourself having very high slowdowns with ABC panels, please try this addr-type 5 instead of 3.

Discussion:
https://github.com/hzeller/rpi-rgb-led-matrix/issues/1774

TESTED=marcmerlin (on rpi3a and rpi0 2w)