### PR TITLE
Updating Python binding setup.py imports to use setuptools, enabling use of Python ≥ 3.12

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
-# The following distutils seems to stop working with newer
-# Python version >= 3.12
-# Someone with Python knowlege, please fix.
-from distutils.core import setup, Extension
+# 2025-10, updated to import from setuptools rather than distutils.core which was removed in Python 3.12.
+from setuptools import setup, Extension
 
 core_ext = Extension(
     name                = 'core',


### PR DESCRIPTION
Distutils was removed in Python 3.12, setuptools provides the needed functionality.