### PR TITLE
Add Python setuptools to `nix-shell`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,7 @@ pkgs.mkShell {
       ffmpeg
       pkg-config
       python311
+      python311Packages.setuptools
       python311Packages.cython
       python311Packages.distutils-extra
     ];


### PR DESCRIPTION
I found that setuptools was missing from the nix-shell and was required when running `make` commands (e.g. `make clean`).