### PR TITLE
Re-use CreateFrameCanvas() in samples/gif-viewer.py

### DIFF
--- a/bindings/python/samples/gif-viewer.py
+++ b/bindings/python/samples/gif-viewer.py
@@ -37,7 +37,7 @@ for frame_index in range(0, num_frames):
     gif.seek(frame_index)
     # must copy the frame out of the gif, since thumbnail() modifies the image in-place
     frame = gif.copy()
-    frame.thumbnail((matrix.width, matrix.height), Image.ANTIALIAS)
+    frame.thumbnail((matrix.width, matrix.height), Image.LANCZOS)
     frames.append(frame.convert("RGB"))
 
 # Close the gif file to save memory now that we have copied out all of the frames


### PR DESCRIPTION
> Previously https://github.com/hzeller/rpi-rgb-led-matrix/pull/1556

I used the original sample to display a list of GIF files.  

After a few minutes I got this warning:  
```
CreateFrameCanvas() called 500 times. Usually you only want to call it once (or at most a few times) for double-buffering...
```

I modified the sample and re-use the canvas instead.