### PR TITLE
[Bindings/C#] Upgrade to .NET 8.0

### DIFF
--- a/bindings/c#/README.md
+++ b/bindings/c#/README.md
@@ -8,7 +8,7 @@ To build the C# wrapper for the RGB Matrix C library you need to first have __.N
 
 ### Install .NET SDK
 
-`sudo apt install dotnet6` should work in most cases.  
+`sudo apt install dotnet8` should work in most cases.  
 For some old distributions, read [docs](https://learn.microsoft.com/dotnet/core/install/linux)
 
 Then, in the `bindings/c#` directory type: `dotnet build`

--- a/bindings/c#/RPiRgbLEDMatrix.csproj
+++ b/bindings/c#/RPiRgbLEDMatrix.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/bindings/c#/examples/BoxesBoxesBoxes/BoxesBoxesBoxes.csproj
+++ b/bindings/c#/examples/BoxesBoxesBoxes/BoxesBoxesBoxes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/FontExample/FontExample.csproj
+++ b/bindings/c#/examples/FontExample/FontExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/MatrixRain/MatrixRain.csproj
+++ b/bindings/c#/examples/MatrixRain/MatrixRain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/MinimalExample/MinimalExample.csproj
+++ b/bindings/c#/examples/MinimalExample/MinimalExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/PlayGIF/PlayGIF.csproj
+++ b/bindings/c#/examples/PlayGIF/PlayGIF.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/bindings/c#/examples/PulsingBrightness/PulsingBrightness.csproj
+++ b/bindings/c#/examples/PulsingBrightness/PulsingBrightness.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/Rotating3DCube/Rotating3DCube.csproj
+++ b/bindings/c#/examples/Rotating3DCube/Rotating3DCube.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>


### PR DESCRIPTION
The codes under `bindings/c#/` uses .NET 6.0.
However, .NET 6.0 has already reached the end of its lifecycle, requiring migration to either .NET 8.0 or 10.0.

This PR changes the `TargetFramework` to `net8.0` to use .NET 8.0.

.NET 10.0 has already been released, but the apt package `dotnet10` is not yet available, requiring a more complex installation instruction.
Therefore, this PR changes to use .NET 8.0, which can be easily installed using the `apt install` command.