### PR TITLE
Fix emojis in wiring docs

### DIFF
--- a/wiring.md
+++ b/wiring.md
@@ -88,12 +88,12 @@ Then for each first panel of a chain there is a set of
 They are marked `[1]`, `[2]` and `[3]` for chain 1, 2, and 3 below.
 
 If you only connect one panel or have one chain, connect it to
-`[1]` (:smile:); if you use parallel chains, add the other `[2]` and `[3]`.
+`[1]` ( :smile: ); if you use parallel chains, add the other `[2]` and `[3]`.
 
 To make things quicker to navigate visually, each chain is marked with a
 separate icon:
 
-`[1]`=:smile:, `[2]`= :boom: and `[3]`= :droplet: ; signals that go to all
+`[1]`= :smile:, `[2]`= :boom: and `[3]`= :droplet: ; signals that go to all
 chains have all icons.
 
 |Connection                        | Pin | Pin |  Connection


### PR DESCRIPTION
Probably the most pathetic PR ever, but hey, every little helps 

Fixes emojis in the wiring docs that were not rendering. Seems sometimes they need a space before them?
<img width="955" height="271" alt="image" src="https://github.com/user-attachments/assets/7d2d814d-3ffc-442a-856e-774313b5cab9" />
