### PR TITLE
Vscode tooling

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,0 +1,43 @@
+# Instructions for remote developent on Windows using VSCode  
+These instructions are primarily aimed at those wishing to work on the C# bindings, but they are probably relevant if you wish to work on the C++ too.  
+
+## C++
+### Initial setup
+- Set the environment variables on your local PC:
+  - `RGBLEDMATRIX_REMOTE_MACHINE`: Username and hostname of your Pi, eg `root@DietPi`
+  - `RGBLEDMATRIX_REMOTE_DIR`: The remote folder on your Pi where you wish to store the repo, eg `/root/dev/rpi-rgb-led-matrix`  
+    Ensure this folder exists
+- Ensure Passwordless SSH to the Pi is set up for the account you specified in the environment variable
+- WSL must be installed
+- RSync must be installed in WSL
+
+### Working on the C++
+- Make your changes to the code
+- The following tasks are available:
+  - `Sync C++`: Syncs the local folder with the remote (Does not sync the `bindings` folder)
+  - `Build C++`: Builds the C++ library (Auto-runs `Sync C++`)
+  - `Deploy C++`: Deploys `librgbmatrix.so.1` to `/usr/lib` (Auto-runs `Build C++`)
+
+## C#
+### Initial Setup
+- Do all the setup steps for C++
+- Use the `Deploy C++` task to make sure that the linked library is in place
+- Install this extension: https://marketplace.visualstudio.com/items?itemName=rioj7.command-variable  
+  This allows us to get variables in the task in a linux (/ separator) format  
+  ie normally, `${relativeFileDirname}` in tasks would resolve to like `bindings\c#\examples\BoxesBoxesBoxes`  
+  This extensions allows us to do `${command:extension.commandvariable.file.relativeFileDirnamePosix}`...  
+  Which will resolve to `bindings/c#/examples/BoxesBoxesBoxes`  
+  This is very useful as it allows us to build rsync commands etc using the folder name of the example in linux format
+- Ensure VSDBG is set up on the Pi  
+  Currently, the launch configuration is set up for debugger path `~/vsdbg/vsdbg`
+
+### Working on the C# bindings
+- Make your changes to the code  
+- Run an example to test it  
+  Note that if you also have to make changes to the C library, you will need to Deploy the C++ too
+
+### Working on C# examples
+- To debug an example:
+  - Select the `Debug Current C#` configuration
+  - Ensure `Program.cs` (Or any file in the same folder as it) for the example is the current tab in VS Code  
+  - Hit F5

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    // See https://code.visualstudio.com/docs/editor/debugging#_launch-configurations
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Debugs the currently open C# file on the remote Raspberry Pi
+            // See the README in the .vscode folder for setup instructions
+            "name": "Debug Current C#",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${fileDirnameBasename}.dll",
+            "args": [],
+            "cwd": "${env:RGBLEDMATRIX_REMOTE_DIR}/${command:extension.commandvariable.file.relativeFileDirnamePosix}/bin",
+            "stopAtEntry": false,
+            "console": "internalConsole",
+            "pipeTransport": {
+                "pipeCwd": "${workspaceFolder}",
+                "pipeProgram": "wsl",
+                "pipeArgs": ["ssh", "${env:RGBLEDMATRIX_REMOTE_MACHINE}"],
+                "debuggerPath": "~/vsdbg/vsdbg"
+            },
+            "env": {
+                // This environment variable tells the app to use the Pi-specific configuration
+                // It affects:
+                // - Which path the PathConfig returns (eg ../playlists)
+                // - Program.cs will load Pi-specific services (e.g., RPiStreamPlayer)
+                "ASPNETCORE_ENVIRONMENT": "Pi"
+            },
+            "sourceFileMap": {
+                "/root/dev/${workspaceFolderBasename}": "${workspaceFolder}"
+            },
+            "preLaunchTask": "deploy current C#"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,85 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        // ========================================= C# Tasks =========================================
+        {
+            "label": "deploy current C#",
+            "type": "shell",
+            "command": "wsl",
+            "args": [
+                "bash",
+                "-c",
+                "rsync -avz --delete \"${command:extension.commandvariable.file.relativeFileDirnamePosix}/bin/pi-publish/\" ${env:RGBLEDMATRIX_REMOTE_MACHINE}:\"${env:RGBLEDMATRIX_REMOTE_DIR}/${command:extension.commandvariable.file.relativeFileDirnamePosix}/bin\""
+            ],
+            "problemMatcher": [],
+            "dependsOn": [
+                "publish current C#"
+            ]
+        },
+        {
+            "label": "publish current C#",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "publish",
+                "${relativeFileDirname}/${fileDirnameBasename}.csproj",
+                "-c",
+                "Debug",
+                "-r",
+                "linux-arm64",
+                "-o",
+                "${relativeFileDirname}/bin/pi-publish"
+            ],
+            "problemMatcher": [],
+            "group": "build"
+        },
+        // ========================================= C++ Tasks =========================================
+        {
+            "label": "Sync C++",
+            "type": "shell",
+            "command": "wsl",
+            "args": [
+                "bash",
+                "-c",
+                "rsync -avz . --delete --exclude bin/ --exclude obj/ ${env:RGBLEDMATRIX_REMOTE_MACHINE}:${env:RGBLEDMATRIX_REMOTE_DIR}"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "Build C++",
+            "type": "shell",
+            "command": "ssh",
+            "args": [
+                "${env:RGBLEDMATRIX_REMOTE_MACHINE}",
+                "cd ${env:RGBLEDMATRIX_REMOTE_DIR}&&",
+                "make"
+            ],
+            "problemMatcher": [],
+            "group": "build",
+            "dependsOn": [
+                "Sync C++"
+            ]
+        },
+        {
+            "label": "Deploy C++",
+            "type": "shell",
+            "command": "ssh",
+            "args": [
+                "${env:RGBLEDMATRIX_REMOTE_MACHINE}",
+                "cd ${env:RGBLEDMATRIX_REMOTE_DIR}&&",
+                "cp lib/librgbmatrix.so.1 /usr/lib"
+            ],
+            "problemMatcher": [],
+            "dependsOn": [
+                "Build C++"
+            ]
+        },
+        // ========================================= Utility Tasks =========================================
+        {
+            "label": "echo",
+            "type": "shell",
+            "command": "echo ${command:extension.commandvariable.file.relativeFileDirnamePosix}",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/bindings/c#/README.md
+++ b/bindings/c#/README.md
@@ -1,16 +1,22 @@
-C# bindings for RGB Matrix library
-======================================
+# C# bindings for RGB Matrix library
 
-Building
---------
+## Usage:
+### Building on the Pi
+- Install the .Net SDK
+  `sudo apt install dotnet8` should work in most cases.  
+   For some old distributions, read [docs](https://learn.microsoft.com/dotnet/core/install/linux)  
+- Edit `bindings/c#/MatrixOptions.cs` and put in the options for your matrix  
+- Change to an example folder  
+  eg `cd bindings/c#/examples/BoxesBoxesBoxes`  
+- Build: `dotnet build`
+- Run: `sudo dotnet run`
 
-To build the C# wrapper for the RGB Matrix C library you need to first have __.NET SDK__ installed. 
-
-### Install .NET SDK
-
-`sudo apt install dotnet8` should work in most cases.  
-For some old distributions, read [docs](https://learn.microsoft.com/dotnet/core/install/linux)
-
-Then, in the `bindings/c#` directory type: `dotnet build`
-
-To run the example applications in the c#\examples\EXAMPLE folder: `sudo dotnet run`
+### Build on a Windows PC, run on the Pi
+- Only needs .NET runtime on Pi, do not need SDK  
+  Or you could modify the `publish current C#` task and add `--self-contained` to deploy with no need for dotnet to be installed on the Pi at all.
+- See README in .vscode folder  
+  (Set some env variables, install a VSCode extension)  
+- Edit `bindings/c#/MatrixOptions.cs` and put in the options for your matrix    
+- Make one of the `Program.cs` example files the active file in VSCode  
+- Hit F5  
+  The example will build on the PC, rsync to the Pi, launch and debug


### PR DESCRIPTION
This PR adds tooling for VSCode - primarily to facilitate easily working on the C# bindings and examples  

- Add `.vscode` folder for VSCode specific settings
- Add launch tasks to build C# examples locally on PC, rsync them over to pi, launch and debug them
- Add tasks to sync the C++ API code to the pi and build from within VSCode on Windows  
- Added new VSCode specific readme in the `.vscode` folder
- Updated existing README for examples to clarify regular (Build on Pi) style usage, and mention new style usage (Build on PC)

The above are windows only (Uses WSL), however they could easily be adapted for linux too