### PR TITLE
C# bindings csproj exclusions

### DIFF
--- a/bindings/c#/RPiRgbLEDMatrix.csproj
+++ b/bindings/c#/RPiRgbLEDMatrix.csproj
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Remove="examples\**" />
-        <None Remove="examples\**" />
+        <Compile Remove="examples\**\*.cs" />
+        <None Remove="examples\**\*.cs" />
         <None Condition="$(SkipNative) != 'true'" Pack="true" 
               Include="..\..\lib\librgbmatrix.so.1"
               PackagePath="\runtimes\linux-arm64\native" >


### PR DESCRIPTION
This PR changes how the exclusion of the examples works in the RPiRgbLEDMatrix csproj file  
With the old style
```
        <Compile Remove="examples\**" />
        <None Remove="examples\**" />
```
I was having problems getting the bindings working as a submodule.
In my project, I had an exclusion:
```
    <Compile Remove="rpi-rgb-led-matrix/bindings/c#/**/*.cs" />
    <None Remove="rpi-rgb-led-matrix/bindings/c#/**/*.cs" />
```
But with the old style from RPiRgbLEDMatrix, I then could not reference my wrapper.
If I commented out my exclusion in my project, I could reference my wrapper, but then I had errors like this:
```
The type 'RGBLedMatrix' in 'D:\Data\Code\Rpi\WearWare\src\rpi-rgb-led-matrix\bindings\c#\RGBLedMatrix.cs' 
conflicts with the imported type 'RGBLedMatrix' in 'RPiRgbLEDMatrix, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.
Using the type defined in 'D:\Data\Code\Rpi\WearWare\src\rpi-rgb-led-matrix\bindings\c#\RGBLedMatrix.cs'.
```

In this PR, I changed the exclusion in the RPiRgbLEDMatrix project to:
```
        <Compile Remove="examples\**\*.cs" />
        <None Remove="examples\**\*.cs" />
```

This seems to solve the problems I was having when using the library as a submodule

I am not sure if I have done the right thing, can anyone advise on this?