### PR TITLE
Allow hot-changing of matrix options

### DIFF
--- a/bindings/c#/RGBLedMatrix.cs
+++ b/bindings/c#/RGBLedMatrix.cs
@@ -72,6 +72,16 @@ public class RGBLedMatrix : IDisposable
     /// <returns>An instance of <see cref="RGBLedCanvas"/> representing the canvas.</returns>
     public RGBLedCanvas CreateOffscreenCanvas() => new(led_matrix_create_offscreen_canvas(matrix));
 
+    [System.Runtime.InteropServices.DllImport("librgbmatrix.so.1")]
+    private static extern void framebuffer_reset_globals();
+
+    /// <summary>
+    /// Reset native framebuffer globals so that GPIO/row-address state will be
+    /// reinitialized on the next matrix creation. Useful when changing
+    /// hardware-mapping critical options at runtime.
+    /// </summary>
+    public static void ResetFramebufferGlobals() => framebuffer_reset_globals();
+
     /// <summary>
     /// Returns a canvas representing the current frame buffer.
     /// </summary>

--- a/lib/framebuffer-internal.h
+++ b/lib/framebuffer-internal.h
@@ -98,6 +98,8 @@ public:
                        int dither_bits,
                        int row_address_type);
   static void InitializePanels(GPIO *io, const char *panel_type, int columns);
+  // Reset internal static globals so InitGPIO() can re-run with new params.
+  static void ResetGlobals();
 
   // Set PWM bits used for output. Default is 11, but if you only deal with
   // simple comic-colors, 1 might be sufficient. Lower require less CPU.

--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -976,3 +976,26 @@ void Framebuffer::DumpToMatrix(GPIO *io, int pwm_low_bit) {
 }
 }  // namespace internal
 }  // namespace rgb_matrix
+namespace rgb_matrix {
+namespace internal {
+  void Framebuffer::ResetGlobals() {
+    if (sOutputEnablePulser != NULL) {
+      delete sOutputEnablePulser;
+      sOutputEnablePulser = NULL;
+    }
+    if (row_setter_ != NULL) {
+      delete row_setter_;
+      row_setter_ = NULL;
+    }
+  }
+}
+}
+
+extern "C" {
+  void framebuffer_reset_globals() {
+    rgb_matrix::internal::Framebuffer::ResetGlobals();
+    // Also reset global GPIO bookkeeping in led-matrix's static GPIO object
+    extern void ledmatrix_reset_global_gpio();
+    ledmatrix_reset_global_gpio();
+  }
+}

--- a/lib/gpio.cc
+++ b/lib/gpio.cc
@@ -203,6 +203,15 @@ gpio_bits_t GPIO::InitOutputs(gpio_bits_t outputs,
   return outputs;
 }
 
+void GPIO::ResetState() {
+  output_bits_ = 0;
+  input_bits_ = 0;
+  reserved_bits_ = 0;
+#ifdef ENABLE_WIDE_GPIO_COMPUTE_MODULE
+  uses_64_bit_ = false;
+#endif
+}
+
 gpio_bits_t GPIO::RequestInputs(gpio_bits_t inputs) {
   if (s_GPIO_registers == NULL) {
     fprintf(stderr, "Attempt to init inputs but not yet Init()-ialized.\n");

--- a/lib/gpio.h
+++ b/lib/gpio.h
@@ -49,6 +49,12 @@ public:
   // Returns the bits that were available and could be reserved.
   gpio_bits_t RequestInputs(gpio_bits_t inputs);
 
+  // Reset internal bookkeeping about which GPIOs have been claimed.
+  // This does not touch the hardware registers directly; it clears the
+  // tracked masks so subsequent InitOutputs/RequestInputs will reconfigure
+  // GPIO pins as needed.
+  void ResetState();
+
   // Set the bits that are '1' in the output. Leave the rest untouched.
   inline void SetBits(gpio_bits_t value) {
     if (!value) return;


### PR DESCRIPTION
Apologies if this is a bit vague - maybe if I describe my use-case, it will clarify where my issue lies.  
In my C# app, on very first start, no RGBLedMatrixOptions are set.  
You then go into the options page and select the options you want (Rows, Cols, RowAddressType etc), and it disposes the matrix and canvas and creates new ones.  
However, this is not taking effect for all options - specifically in my case, RowAddressType.  
If you stop the app and re-start, all fine, the new options take effect, but I would like to be able to make this actually work properly.  
I have done some work with AI on this, and it has managed to fix the problem, but it has changed a bunch of files in the library

Is there any appetite for making this change to the library? I know this PR as it currently stands does not put some code in the appropriate place (eg C bridge code in the .cc files), but it's pointless me spending more time addressing this if there's no appetite to merge this change in, or if people want to do it a different way.  

Out of interest, I notice that it is getting rid of this line, so I am guessing it's known that the current implementation leaves something to be desired?
`static GPIO io; // This static var is a little bit icky.`
  
This is about the best summary that I could get out of the AI that was not "war and peace" type lengths:  
## C++ API Checklist

- **`Framebuffer::ResetGlobals()`**: `static void Framebuffer::ResetGlobals();` — idempotently delete/null `sOutputEnablePulser` and `Framebuffer::row_setter_` and clear framebuffer-level caches so `InitGPIO` can rebuild them.

- **`GPIO::ResetState()`**: `void GPIO::ResetState();` — set `output_bits_ = input_bits_ = reserved_bits_ = 0` and reset `uses_64_bit_` (if present). Do not unmap mmapped registers.

- **Hardware-pulser cleanup**: ensure any PWM/clock registers modified by a hardware `PinPulser` are returned to a safe state (either in pulser destructor or a small `ResetHardwarePulsing()` helper).

- **Optional helper**: `void ResetNativeStateForHotReload();` — convenience that calls the above in the correct order.

**Usage / Ordering**

- Stop/destroy the running `RGBMatrix` instance (join/stop update threads).
- Call `Framebuffer::ResetGlobals()` then `s_global_io.ResetState()` (or `ResetNativeStateForHotReload()`).
- Reinitialize: `s_global_io.Init(new_slowdown)` and `Framebuffer::InitGPIO(...)` or create a new `RGBMatrix`.

**Minimal state that must be cleared**

- `output_bits_`, `input_bits_`, `reserved_bits_`, `uses_64_bit_` (GPIO bookkeeping)  
- `sOutputEnablePulser` (pulser instance)  
- `Framebuffer::row_setter_` (row-address logic and cached `last_row_`)  
- Any PWM/hardware registers if hardware pulser was used