### PR TITLE
Fix cross-compile

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -172,7 +172,17 @@ DEFINES+=$(USER_DEFINES)
 
 DEFINES+=-DDEFAULT_HARDWARE='"$(HARDWARE_DESC)"'
 INCDIR=../include
-CFLAGS=-W -Wall -Wextra -Wno-unused-parameter -O3 -march=native -mtune=native -flto=2 -g -fPIC $(DEFINES)
+
+# When cross-compiling for aarch64 (e.g. using aarch64-linux-gnu-g++),
+# the compiler does not accept '-march=native' or '-mtune=native'. Detect
+# that situation and avoid those flags. For native builds keep the flags.
+ifneq (,$(findstring aarch64-linux-gnu,$(CXX)))
+CPU_ARCH_FLAGS=
+else
+CPU_ARCH_FLAGS=-march=native -mtune=native
+endif
+
+CFLAGS=-W -Wall -Wextra -Wno-unused-parameter -O3 $(CPU_ARCH_FLAGS) -flto=2 -g -fPIC $(DEFINES)
 CXXFLAGS=$(CFLAGS) -fno-exceptions -std=c++11
 
 all : $(TARGET).a $(TARGET).so.1


### PR DESCRIPTION
#1855 broke cross-compiling on windows.  
AI wrote this PR to fix it. @rwstca can you review please?  
This is the error that I get when I try to cross-compile
```
Executing task: wsl bash -lc 'make -C rpi-rgb-led-matrix/lib CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ AR=aarch64-linux-gnu-ar' 

make: Entering directory '/mnt/d/Data/Code/GitHub/Mine/WearWare/rpi-rgb-led-matrix/lib'
aarch64-linux-gnu-g++ -I../include -W -Wall -Wextra -Wno-unused-parameter -O3 -march=native -mtune=native -flto=2 -g -fPIC  -DDEFAULT_HARDWARE='"regular"' -fno-exceptions -std=c++11 -c -o gpio.o gpio.cc
cc1plus: error: unknown value ‘native’ for ‘-march’
cc1plus: note: valid arguments are: armv8-a armv8.1-a armv8.2-a armv8.3-a armv8.4-a armv8.5-a armv8.6-a
cc1plus: error: unknown value ‘native’ for ‘-mtune’
cc1plus: note: valid arguments are: cortex-a34 cortex-a35 cortex-a53 cortex-a57 cortex-a72 cortex-a73 thunderx thunderxt88p1 thunderxt88 octeontx octeontx81 octeontx83 thunderxt81 thunderxt83 emag xgene1 falkor qdf24xx exynos-m1 phecda thunderx2t99p1 vulcan thunderx2t99 cortex-a55 cortex-a75 cortex-a76 cortex-a76ae cortex-a77 cortex-a65 cortex-a65ae ares neoverse-n1 neoverse-e1 octeontx2 octeontx2t98 octeontx2t96 octeontx2t93 octeontx2f95 octeontx2f95n octeontx2f95mm a64fx tsv110 thunderx3t110 zeus neoverse-v1 saphira neoverse-n2 cortex-a57.cortex-a53 cortex-a72.cortex-a53 cortex-a73.cortex-a35 cortex-a73.cortex-a53 cortex-a75.cortex-a55 cortex-a76.cortex-a55 generic
make: *** [Makefile:192: gpio.o] Error 1
```