### PR TITLE
Added a central bash runner script to improve flickering (with RT process priority and cpu thread-pinning)

### DIFF
--- a/rgbmatrix
+++ b/rgbmatrix
@@ -1,0 +1,4 @@
+# Run your display executables through this centralized bash script to reduce flicker from:
+#   1. Improved linux process priority
+#   2. Optimizing execution by pinning CPU to one thread (prevent thread-switching and kernel-interupts)
+chrt -f 90 taskset -c 3 "$@"


### PR DESCRIPTION
Added a `rgbmatrix` bash script which can be used centrally to run display executables. When doing this the process will do two things:
1. Set very high linux process priority with `chrt` (change realtime)

```The primary goal of chrt is to manage how the Linux kernel's scheduler handles time-critical applications. By using chrt, users can ensure that important processes are scheduled with higher priority, which can significantly enhance system performance and responsiveness in environments where real-time processing is essential. ```

2. Pin the execution thread to CPU 3 which is isolated with `isolcpus=3` in the rgbmatrix library. This minimizes thread-switching, cache thrashing and general performance relating to flickering.