### PR TITLE
Downgrade CMake Python version requirement to 3.11 to match pyproject.toml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project(rgbmatrix VERSION 0.0.1)
 include(CMakePrintHelpers) # so we can print cmake variable values, useful for debugging
 include(GNUInstallDirs)  # so that `CMAKE_INSTALL_LIBDIR` is not blank
-find_package(Python 3.13 REQUIRED COMPONENTS Interpreter Development.Module Development.Embed)
+find_package(Python 3.11 REQUIRED COMPONENTS Interpreter Development.Module Development.Embed)
 
 # Build the core library
 # Set some convenience variables


### PR DESCRIPTION
Diagnosing a build failure on Pi OS Bookworm with system Python 3.11. We support this as listed in `pyproject.toml`, but our `CMakeLists.txt` references 3.13. These values should match. Some Python users are definitely still on Bookworm so 3.11 is the more conservative approach.

Resolves build error as follows:
```
Building wheels for collected packages: rgbmatrix
  Building wheel for rgbmatrix (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for rgbmatrix (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [29 lines of output]
      *** scikit-build-core 0.12.2 using CMake 4.3.1 (wheel)
      *** Configuring CMake...
      loading initial cache file /tmp/tmpodcnugdc/build/CMakeInit.txt
      -- The C compiler identification is GNU 12.2.0
      -- The CXX compiler identification is GNU 12.2.0
      -- Detecting C compiler ABI info
      -- Detecting C compiler ABI info - done
      -- Check for working C compiler: /usr/bin/aarch64-linux-gnu-gcc - skipped
      -- Detecting C compile features
      -- Detecting C compile features - done
      -- Detecting CXX compiler ABI info
      -- Detecting CXX compiler ABI info - done
      -- Check for working CXX compiler: /usr/bin/aarch64-linux-gnu-g++ - skipped
      -- Detecting CXX compile features
      -- Detecting CXX compile features - done
      CMake Error at /tmp/pip-build-env-9ia_1y2h/normal/lib/python3.11/site-packages/cmake/data/share/cmake-4.3/Modules/FindPackageHandleStandardArgs.cmake:290 (message):
        Could NOT find Python: Found unsuitable version "3.11.2", but required is
        at least "3.13" (found /home/lego/scoreboard_env/bin/python, found
        components: Interpreter Development.Module Development.Embed)
      Call Stack (most recent call first):
        /tmp/pip-build-env-9ia_1y2h/normal/lib/python3.11/site-packages/cmake/data/share/cmake-4.3/Modules/FindPackageHandleStandardArgs.cmake:652 (_FPHSA_FAILURE_MESSAGE)
        /tmp/pip-build-env-9ia_1y2h/normal/lib/python3.11/site-packages/cmake/data/share/cmake-4.3/Modules/FindPython/Support.cmake:4334 (find_package_handle_standard_args)
        /tmp/pip-build-env-9ia_1y2h/normal/lib/python3.11/site-packages/cmake/data/share/cmake-4.3/Modules/FindPython.cmake:700 (include)
        CMakeLists.txt:9 (find_package)
```