### PR TITLE
Raspberry Pi 5 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(Python 3.11 REQUIRED COMPONENTS Interpreter Development.Module Deve
 # Set some convenience variables
 set(RGBMATRIX_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
 set(RGBMATRIX_SOURCE_DIR ${CMAKE_SOURCE_DIR}/lib)
+set(RGBMATRIX_RP1_PIO_VENDOR_DIR
+    ${CMAKE_SOURCE_DIR}/lib/rp1/rp1_pio_vendor)
 
 # Define the RGBMATRIX headers.
 set(RGBMATRIX_HEADERS
@@ -39,6 +41,9 @@ set(RGBMATRIX_SOURCES
     ${RGBMATRIX_SOURCE_DIR}/multiplex-mappers.cc
     ${RGBMATRIX_SOURCE_DIR}/options-initialize.cc
     ${RGBMATRIX_SOURCE_DIR}/pixel-mapper.cc
+    ${RGBMATRIX_SOURCE_DIR}/rp1/rp1_pio_backend.cc
+    ${RGBMATRIX_SOURCE_DIR}/rp1/rp1_pio_support.c
+    ${RGBMATRIX_SOURCE_DIR}/rp1/rp1_rio_backend.cc
     ${RGBMATRIX_SOURCE_DIR}/thread.cc
 )
 cmake_print_variables(RGBMATRIX_SOURCES)
@@ -52,6 +57,10 @@ target_sources(rgbmatrix PRIVATE ${RGBMATRIX_SOURCES})
 
 # Add the includes to the library
 target_include_directories(rgbmatrix PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(rgbmatrix PRIVATE
+    ${RGBMATRIX_RP1_PIO_VENDOR_DIR}/piolib/include
+    ${RGBMATRIX_RP1_PIO_VENDOR_DIR}/include
+)
 
 # Install location changes depending if called by scikit-build-core
 install(TARGETS rgbmatrix DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -91,6 +100,8 @@ IF(DEFINED SKBUILD)
     target_include_directories(core PRIVATE
         ${PYBINDING_SOURCE_DIR}/shims
         ${CMAKE_SOURCE_DIR}/include
+        ${RGBMATRIX_RP1_PIO_VENDOR_DIR}/piolib/include
+        ${RGBMATRIX_RP1_PIO_VENDOR_DIR}/include
     )
     # target_link_libraries(core PRIVATE rgbmatrix)
     # target_link_options(core PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wl,--whole-archive>)
@@ -106,6 +117,8 @@ IF(DEFINED SKBUILD)
         ${CMAKE_SOURCE_DIR}/include
         ${PYBINDING_SOURCE_DIR}/shims
         ${CMAKE_SOURCE_DIR}/include
+        ${RGBMATRIX_RP1_PIO_VENDOR_DIR}/piolib/include
+        ${RGBMATRIX_RP1_PIO_VENDOR_DIR}/include
     )
     # target_link_libraries(graphics PRIVATE rgbmatrix)
     # target_link_options(graphics PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wl,--whole-archive>)

--- a/README.md
+++ b/README.md
@@ -71,17 +71,34 @@ lib, as it only supports non PWM panels (until someone contributes PWM support).
 PWM/E-PWM/S-PWM Panels
 ----------------------
 Newer PWM panels are not currently supported by this lib, but support would really be appreciated.
-- https://github.com/hzeller/rpi-rgb-led-matrix/issues/466 is the master bug tracking PWM efforts
+- https://github.com/hzeller/rpi-rgb-led-matrix/issues/466 - Master bug tracking PWM efforts
+- https://github.com/hzeller/rpi-rgb-led-matrix/issues/1866 - Continued discussion
 
-Raspberry Pi up to 4 supported
+Some experimentation and success has been made with the following fork. Some panel support with FM6373, FM6363, SM16380SH
+- https://github.com/kingdo9/rpi-rgb-led-matrix_pwm_experiment
+
+
+Raspberry Pi 1-5 supported
 ------------------------------
 This library supports the old Raspberry Pi's Version 1 with 26 pin header and
-also the B+ models, the Pi Zero, Raspberry Pi 2 and 3 with 40 pins, as well
+also the B+ models, the Pi Zero, Raspberry Pi 2,3,4 and 5 with 40 pins, as well
 as the Compute Modules which have 44 GPIOs.
 
-The Raspberry Pi 5 still needs some research into the vastly changed peripherals
-and is not yet supported. See https://github.com/hzeller/rpi-rgb-led-matrix/issues/1603#issuecomment-2624713250
-and https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter
+#### Raspberry Pi 5 support has now been added.
+There are two modes to run this on the Pi 5 
+
+**--led-rp1-rio=0** - Uses the Pi 5 coprocessor RP1 to perform the work (default) - Very minimal CPU usage
+
+**--led-rp1-rio=1** - Uses Registered IO block of RP1 to communicate with the GPIO - Higher CPU usage but much faster performance.\
+**NOTE: --led-slowdown-gpio** can have the opposite effect in this mode, so going from 2 to 3 may increase performance slightly with --led-rp1-rio=1.
+
+Pi 5 Discussion -  https://github.com/hzeller/rpi-rgb-led-matrix/issues/1603
+
+
+Thanks to contributions from the following libraries to help implement this.
+https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter \
+https://github.com/bitslip6/rpi-gpu-hub75-matrix \
+https://www.i-programmer.info/programming/148-hardware/16887-raspberry-pi-iot-in-c-pi-5-memory-mapped-gpio.html
 
 The 26 pin models can drive one chain of RGB panels, the 40 pin models
 **up to three** chains in parallel (each chain 12 or more panels long).
@@ -94,20 +111,6 @@ this [troubleshooting section](#troubleshooting) what to do.
 A lightweight, non-GUI, distribution such as [DietPi] is recommended.
 [Raspbian Lite][raspbian-lite] is a bit easier to get started with and
 is a good second choice.
-
-Raspberry Pi5
--------------
-At this time of this writing, this library does not support Pi5. Latest update is
-in https://github.com/hzeller/rpi-rgb-led-matrix/issues/1603 but please don't ask 
-"is it ready yet" or "I need this" as it will only be added if someone who
-needs/wants it (including you) writes and contributes the code.  
-However, Adafruit wrote their own driver for Pi5. It is entirely different from
-this one and we can't help you or provide support for it, however if you buy
-hardware from Adafruit, including their active-3 low profile board 
-( https://www.adafruit.com/product/6358 ), they do support users of the hardware
-they sold. Please go to 
-* https://learn.adafruit.com/adafruit-triple-led-matrix-bonnet-for-raspberry-pi-with-hub75/raspberry-pi-5-setup
-* code here: https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter/tree/main/src
 
 Types of Displays
 -----------------

--- a/bindings/c#/RGBLedMatrix.cs
+++ b/bindings/c#/RGBLedMatrix.cs
@@ -47,11 +47,12 @@ public class RGBLedMatrix : IDisposable
             // other than passing it via command-line, and if you call the bindings from a library,
             // you cannot do that unless you also pass that argument to your app, which just seems silly.
             // Without no-drop-privs, dotnet cannot load any libraries, so it seems essential
-            var argv = new string[args.Length + 2];
+            var argv = new string[args.Length + 3];
             argv[0] = args[0];
             argv[1] = $"--led-slowdown-gpio={options.GpioSlowdown}";
-            argv[2] = "--led-no-drop-privs";
-            Array.Copy(args, 1, argv, 3, args.Length - 1);
+            argv[2] = $"--led-rp1-rio={options.Rp1Rio}";
+            argv[3] = "--led-no-drop-privs";
+            Array.Copy(args, 1, argv, 4, args.Length - 1);
 
             matrix = led_matrix_create_from_options_const_argv(ref opt, argv.Length, argv);
             if (matrix == (IntPtr)0)

--- a/bindings/c#/RGBLedMatrixOptions.cs
+++ b/bindings/c#/RGBLedMatrixOptions.cs
@@ -118,6 +118,12 @@ public struct RGBLedMatrixOptions
     public int GpioSlowdown = 1;
 
     /// <summary>
+    /// On Raspberry Pi 5-family boards, choose the experimental RP1 RIO backend instead of
+    /// the default RP1 PIO backend. 0 = PIO, 1 = RIO.
+    /// </summary>
+    public int Rp1Rio = 0;
+
+    /// <summary>
     /// Creates default matrix settings.
     /// </summary>
     public RGBLedMatrixOptions() { }

--- a/bindings/python/rgbmatrix/core.pyx
+++ b/bindings/python/rgbmatrix/core.pyx
@@ -199,6 +199,10 @@ cdef class RGBMatrixOptions:
         def __get__(self): return self.__runtime_options.gpio_slowdown
         def __set__(self, uint8_t value): self.__runtime_options.gpio_slowdown = value
 
+    property rp1_rio:
+        def __get__(self): return self.__runtime_options.rp1_rio
+        def __set__(self, uint8_t value): self.__runtime_options.rp1_rio = value
+
     property daemon:
         def __get__(self): return self.__runtime_options.daemon
         def __set__(self, uint8_t value): self.__runtime_options.daemon = value

--- a/bindings/python/rgbmatrix/cppinc.pxd
+++ b/bindings/python/rgbmatrix/cppinc.pxd
@@ -33,8 +33,10 @@ cdef extern from "led-matrix.h" namespace "rgb_matrix":
     struct RuntimeOptions:
       RuntimeOptions() except +
       int gpio_slowdown
+      int rp1_rio
       int daemon
       int drop_privileges
+      bool do_gpio_init
       const char *drop_priv_user
       const char *drop_priv_group
 

--- a/bindings/python/samples/samplebase.py
+++ b/bindings/python/samples/samplebase.py
@@ -24,6 +24,7 @@ class SampleBase(object):
         self.parser.add_argument("--led-pwm-lsb-nanoseconds", action="store", help="Base time-unit for the on-time in the lowest significant bit in nanoseconds. Default: 130", default=130, type=int)
         self.parser.add_argument("--led-show-refresh", action="store_true", help="Shows the current refresh rate of the LED panel")
         self.parser.add_argument("--led-slowdown-gpio", action="store", help="Slow down writing to GPIO. Range: 0..4. Default: 1", default=1, type=int)
+        self.parser.add_argument("--led-rp1-rio", action="store", help="On Raspberry Pi 5-family boards, use the experimental RP1 RIO backend instead of RP1 PIO. 0=PIO, 1=RIO.", default=0, choices=[0, 1], type=int)
         self.parser.add_argument("--led-no-hardware-pulse", action="store", help="Don't use hardware pin-pulse generation")
         self.parser.add_argument("--led-rgb-sequence", action="store", help="Switch if your matrix has led colors swapped. Default: RGB", default="RGB", type=str)
         self.parser.add_argument("--led-pixel-mapper", action="store", help="Apply pixel mappers. e.g \"Rotate:90\"", default="", type=str)
@@ -67,6 +68,8 @@ class SampleBase(object):
 
         if self.args.led_slowdown_gpio != None:
             options.gpio_slowdown = self.args.led_slowdown_gpio
+        if self.args.led_rp1_rio != None:
+            options.rp1_rio = self.args.led_rp1_rio
         if self.args.led_no_hardware_pulse:
           options.disable_hardware_pulsing = True
         if not self.args.drop_privileges:

--- a/include/led-matrix-c.h
+++ b/include/led-matrix-c.h
@@ -166,6 +166,7 @@ struct RGBLedMatrixOptions {
  */
 struct RGBLedRuntimeOptions {
   int gpio_slowdown;    // 0 = no slowdown.          Flag: --led-slowdown-gpio
+  int rp1_rio;          // 0 = default PIO. 1 = RP1 RIO. Flag: --led-rp1-rio
 
   // ----------
   // If the following options are set to disabled with -1, they are not

--- a/include/led-matrix.h
+++ b/include/led-matrix.h
@@ -404,6 +404,7 @@ struct RuntimeOptions {
   RuntimeOptions();
 
   int gpio_slowdown;    // 0 = no slowdown.    Flag: --led-slowdown-gpio
+  int rp1_rio;          // 0 = default PIO. 1 = RP1 RIO. Flag: --led-rp1-rio
 
   // ----------
   // If the following options are set to disabled with -1, they are not

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -11,6 +11,9 @@
 
 # cmake_print_variables(CMAKE_CURRENT_SOURCE_DIR)
 
+set(RGBMATRIX_RP1_PIO_VENDOR_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR}/rp1/rp1_pio_vendor)
+
 # Define the RGBMATRIX headers.
 set(RGBMATRIX_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/canvas.h
@@ -37,6 +40,9 @@ set(RGBMATRIX_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/multiplex-mappers.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/options-initialize.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/pixel-mapper.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/rp1/rp1_pio_backend.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/rp1/rp1_pio_support.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/rp1/rp1_rio_backend.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/thread.cc
 )
 cmake_print_variables(RGBMATRIX_SOURCES)
@@ -52,6 +58,10 @@ target_sources(rgbmatrix PRIVATE ${RGBMATRIX_SOURCES})
 # Add include directories
 target_include_directories(rgbmatrix PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> )
+target_include_directories(rgbmatrix PRIVATE
+    ${RGBMATRIX_RP1_PIO_VENDOR_DIR}/piolib/include
+    ${RGBMATRIX_RP1_PIO_VENDOR_DIR}/include
+)
 
 # Install the library.
 #install(

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -8,7 +8,8 @@ include ../config.mk
 OBJECTS=gpio.o led-matrix.o options-initialize.o framebuffer.o \
 	thread.o bdf-font.o graphics.o led-matrix-c.o hardware-mapping.o \
 	pixel-mapper.o multiplex-mappers.o \
-	content-streamer.o content-streamer-c.o
+	content-streamer.o content-streamer-c.o \
+	rp1/rp1_pio_backend.o rp1/rp1_pio_support.o rp1/rp1_rio_backend.o
 
 TARGET=librgbmatrix
 
@@ -174,8 +175,10 @@ DEFINES+=$(USER_DEFINES)
 
 DEFINES+=-DDEFAULT_HARDWARE='"$(HARDWARE_DESC)"'
 INCDIR=../include
+RP1_PIO_VENDOR_DIR=./rp1/rp1_pio_vendor
+RP1_PIO_INCLUDES=-I$(RP1_PIO_VENDOR_DIR)/piolib/include -I$(RP1_PIO_VENDOR_DIR)/include
 
-CFLAGS=-W -Wall -Wextra -Wno-unused-parameter -O3 $(CPU_ARCH_FLAGS) $(LTO_FLAGS) -g -fPIC $(DEFINES)
+CFLAGS=-W -Wall -Wextra -Wno-unused-parameter -O3 $(CPU_ARCH_FLAGS) $(LTO_FLAGS) -g -fPIC $(DEFINES) $(RP1_PIO_INCLUDES)
 CXXFLAGS=$(CFLAGS) -fno-exceptions -std=c++11
 
 all : $(TARGET).a $(TARGET).so.1

--- a/lib/framebuffer-internal.h
+++ b/lib/framebuffer-internal.h
@@ -135,6 +135,17 @@ public:
   void Fill(uint8_t red, uint8_t green, uint8_t blue);
   void SubFill(int x, int y, int width, int height, uint8_t red, uint8_t green, uint8_t blue);
 
+  const struct HardwareMapping &hardware_mapping() const {
+    return *hardware_mapping_;
+  }
+  int columns() const { return columns_; }
+  int scan_mode() const { return scan_mode_; }
+  int double_rows() const { return double_rows_; }
+  const gpio_bits_t *RowDataAt(int double_row, int bit) const {
+    return &bitplane_buffer_[double_row * (columns_ * kBitPlanes)
+                             + bit * columns_];
+  }
+
 private:
   static const struct HardwareMapping *hardware_mapping_;
   static RowAddressSetter *row_setter_;

--- a/lib/framebuffer.cc
+++ b/lib/framebuffer.cc
@@ -31,6 +31,8 @@
 #include <algorithm>
 
 #include "gpio.h"
+#include "rp1/rp1_pio_backend.h"
+#include "rp1/rp1_rio_backend.h"
 #include "../include/graphics.h"
 
 namespace rgb_matrix {
@@ -437,6 +439,20 @@ Framebuffer::~Framebuffer() {
     return;  // already initialized.
 
   const struct HardwareMapping &h = *hardware_mapping_;
+  const int double_rows = rows / SUB_PANELS_;
+
+  if (Rp1RioShouldActivate(h.name, row_address_type, parallel)) {
+    Rp1RioInitOrDie(h, double_rows, parallel, pwm_lsb_nanoseconds, dither_bits,
+                    row_address_type);
+    return;
+  }
+
+  if (Rp1PioShouldActivate(h.name, row_address_type, parallel)) {
+    Rp1PioInitOrDie(h, double_rows, parallel, pwm_lsb_nanoseconds, dither_bits,
+                    row_address_type);
+    return;
+  }
+
   // Tell GPIO about all bits we intend to use.
   gpio_bits_t all_used_bits = 0;
 
@@ -459,7 +475,6 @@ Framebuffer::~Framebuffer() {
     all_used_bits |= h.p5_r1 | h.p5_g1 | h.p5_b1 | h.p5_r2 | h.p5_g2 | h.p5_b2;
   }
 
-  const int double_rows = rows / SUB_PANELS_;
   switch (row_address_type) {
   case 0:
     row_setter_ = new DirectRowAddressSetter(double_rows, h);
@@ -595,6 +610,14 @@ static void InitFM6127(GPIO *io, const struct HardwareMapping &h, int columns) {
                                               const char *panel_type,
                                               int columns) {
   if (!panel_type || panel_type[0] == '\0') return;
+  if (Rp1RioIsActive()) {
+    Rp1RioInitializePanels(*hardware_mapping_, panel_type, columns);
+    return;
+  }
+  if (Rp1PioIsActive()) {
+    Rp1PioInitializePanels(*hardware_mapping_, panel_type, columns);
+    return;
+  }
   if (strncasecmp(panel_type, "fm6126", 6) == 0) {
     InitFM6126(io, *hardware_mapping_, columns);
   }
@@ -907,6 +930,15 @@ void Framebuffer::CopyFrom(const Framebuffer *other) {
 }
 
 void Framebuffer::DumpToMatrix(GPIO *io, int pwm_low_bit) {
+  if (Rp1RioIsActive()) {
+    Rp1RioDumpFramebuffer(this, pwm_low_bit);
+    return;
+  }
+  if (Rp1PioIsActive()) {
+    Rp1PioDumpFramebuffer(this, pwm_low_bit);
+    return;
+  }
+
   const struct HardwareMapping &h = *hardware_mapping_;
   gpio_bits_t color_clk_mask = 0;  // Mask of bits while clocking in.
   color_clk_mask |= h.p0_r1 | h.p0_g1 | h.p0_b1 | h.p0_r2 | h.p0_g2 | h.p0_b2;
@@ -982,6 +1014,8 @@ namespace internal {
       delete sOutputEnablePulser;
       sOutputEnablePulser = NULL;
     }
+    Rp1RioDeinit();
+    Rp1PioDeinit();
     if (row_setter_ != NULL) {
       delete row_setter_;
       row_setter_ = NULL;

--- a/lib/gpio.cc
+++ b/lib/gpio.cc
@@ -240,7 +240,8 @@ enum RaspberryPiModel {
   PI_MODEL_1,
   PI_MODEL_2,
   PI_MODEL_3,
-  PI_MODEL_4
+  PI_MODEL_4,
+  PI_MODEL_5
 };
 
 static int ReadBinaryFileToBuffer(uint8_t *buffer, size_t size,
@@ -333,6 +334,12 @@ static RaspberryPiModel DetermineRaspberryModel() {
   case 0x15: /* CM4S */
     return PI_MODEL_4;
 
+  case 0x17: /* Pi 5 */
+  case 0x18: /* CM5 */
+  case 0x19: /* Pi 500 / 500+ */
+  case 0x1a: /* CM5 Lite */
+    return PI_MODEL_5;
+
   default:  /* a bunch of versions representing Pi 3 */
     return PI_MODEL_3;
   }
@@ -354,6 +361,11 @@ static uint32_t *mmap_bcm_register(off_t register_offset) {
   case PI_MODEL_2: base = BCM2709_PERI_BASE; break;
   case PI_MODEL_3: base = BCM2709_PERI_BASE; break;
   case PI_MODEL_4: base = BCM2711_PERI_BASE; break;
+  case PI_MODEL_5:
+    fprintf(stderr,
+            "Pi 5-family boards use the RP1 backends instead of the legacy "
+            "BCM GPIO mapping.\n");
+    return NULL;
   }
 
   int mem_fd;
@@ -437,6 +449,10 @@ bool GPIO::Init(int slowdown) {
 
 bool GPIO::IsPi4() {
   return GetPiModel() == PI_MODEL_4;
+}
+
+bool GPIO::IsPi5Family() {
+  return GetPiModel() == PI_MODEL_5;
 }
 
 /*
@@ -524,6 +540,7 @@ bool Timers::Init() {
   case PI_MODEL_2: busy_wait_impl = busy_wait_nanos_rpi_2; break;
   case PI_MODEL_3: busy_wait_impl = busy_wait_nanos_rpi_3; break;
   case PI_MODEL_4: busy_wait_impl = busy_wait_nanos_rpi_4; break;
+  case PI_MODEL_5: busy_wait_impl = busy_wait_nanos_rpi_4; break;
   }
 
   DisableRealtimeThrottling();
@@ -549,6 +566,7 @@ static uint32_t JitterAllowanceMicroseconds() {
   case PI_MODEL_2: case PI_MODEL_3:
     return EMPIRICAL_NANOSLEEP_OVERHEAD_US + 35;  // 99.999%-ile
   case PI_MODEL_4:
+  case PI_MODEL_5:
     return EMPIRICAL_NANOSLEEP_OVERHEAD_US + 10;  // this one is fast.
   }
   return EMPIRICAL_NANOSLEEP_OVERHEAD_US;

--- a/lib/gpio.h
+++ b/lib/gpio.h
@@ -80,8 +80,10 @@ public:
 
   inline gpio_bits_t Read() const { return ReadRegisters() & input_bits_; }
 
-  // Return if this is appears to be a Pi4
+  // Return if this appears to be a Pi 4-class board.
   static bool IsPi4();
+  // Return if this appears to be a Pi 5-family board with RP1 I/O.
+  static bool IsPi5Family();
 
 private:
   inline void delay() const {

--- a/lib/led-matrix-c.cc
+++ b/lib/led-matrix-c.cc
@@ -96,6 +96,7 @@ static struct RGBLedMatrix *led_matrix_create_from_options_optional_edit(
     // Same story as RGBMatrix::Options
 #define RT_OPT_COPY_IF_SET(o) if (rt_opts->o) default_rt.o = rt_opts->o
     RT_OPT_COPY_IF_SET(gpio_slowdown);
+    RT_OPT_COPY_IF_SET(rp1_rio);
     RT_OPT_COPY_IF_SET(daemon);
     RT_OPT_COPY_IF_SET(drop_privileges);
     RT_OPT_COPY_IF_SET(do_gpio_init);
@@ -142,6 +143,7 @@ static struct RGBLedMatrix *led_matrix_create_from_options_optional_edit(
   if (rt_opts) {
 #define ACTUAL_VALUE_BACK_TO_RT_OPT(o) rt_opts->o = runtime_opt.o
     ACTUAL_VALUE_BACK_TO_RT_OPT(gpio_slowdown);
+    ACTUAL_VALUE_BACK_TO_RT_OPT(rp1_rio);
     ACTUAL_VALUE_BACK_TO_RT_OPT(daemon);
     ACTUAL_VALUE_BACK_TO_RT_OPT(drop_privileges);
     ACTUAL_VALUE_BACK_TO_RT_OPT(do_gpio_init);

--- a/lib/led-matrix.cc
+++ b/lib/led-matrix.cc
@@ -30,6 +30,8 @@
 #include <unistd.h>
 
 #include "gpio.h"
+#include "rp1/rp1_pio_backend.h"
+#include "rp1/rp1_rio_backend.h"
 #include "thread.h"
 #include "framebuffer-internal.h"
 #include "multiplex-mappers-internal.h"
@@ -199,12 +201,14 @@ public:
       }
 
       // Read input bits.
-      const gpio_bits_t inputs = io_->Read();
-      if (inputs != last_gpio_bits) {
-        last_gpio_bits = inputs;
-        MutexLock l(&input_sync_);
-        gpio_inputs_ = inputs;
-        pthread_cond_signal(&input_change_);
+      if (!Rp1PioIsActive() && !Rp1RioIsActive()) {
+        const gpio_bits_t inputs = io_->Read();
+        if (inputs != last_gpio_bits) {
+          last_gpio_bits = inputs;
+          MutexLock l(&input_sync_);
+          gpio_inputs_ = inputs;
+          pthread_cond_signal(&input_change_);
+        }
       }
 
       ++frame_count;
@@ -424,6 +428,8 @@ RGBMatrix::Impl::~Impl() {
   // Make sure LEDs are off.
   active_->Clear();
   if (io_) active_->framebuffer()->DumpToMatrix(io_, 0);
+  internal::Rp1RioDeinit();
+  internal::Rp1PioDeinit();
 
   for (size_t i = 0; i < created_frames_.size(); ++i) {
     delete created_frames_[i];
@@ -436,16 +442,19 @@ RGBMatrix::~RGBMatrix() {
 }
 
 uint64_t RGBMatrix::Impl::RequestInputs(uint64_t bits) {
+  if (Rp1PioIsActive() || Rp1RioIsActive()) return 0;
   return io_->RequestInputs(static_cast<gpio_bits_t>(bits));
 }
 
 uint64_t RGBMatrix::Impl::RequestOutputs(uint64_t output_bits) {
+  if (Rp1PioIsActive() || Rp1RioIsActive()) return 0;
   uint64_t success_bits = io_->InitOutputs(static_cast<gpio_bits_t>(output_bits));
   user_output_bits_ |= success_bits;
   return success_bits;
 }
 
 void RGBMatrix::Impl::OutputGPIO(uint64_t output_bits) {
+  if (Rp1PioIsActive() || Rp1RioIsActive()) return;
   io_->WriteMaskedBits(static_cast<gpio_bits_t>(output_bits), static_cast<gpio_bits_t>(user_output_bits_));
 }
 
@@ -554,6 +563,7 @@ FrameCanvas *RGBMatrix::Impl::SwapOnVSync(FrameCanvas *other,
 
 uint64_t RGBMatrix::Impl::AwaitInputChange(int timeout_ms) {
   if (!updater_) return 0;
+  if (Rp1PioIsActive() || Rp1RioIsActive()) return 0;
   return updater_->AwaitInputChange(timeout_ms);
 }
 
@@ -707,12 +717,55 @@ RGBMatrix *RGBMatrix::CreateFromOptions(const RGBMatrix::Options &options,
             runtime_options.gpio_slowdown);
     return NULL;
   }
+  if (runtime_options.rp1_rio != 0 && runtime_options.rp1_rio != 1) {
+    fprintf(stderr, "--led-rp1-rio=%d is outside usable range 0..1\n",
+            runtime_options.rp1_rio);
+    return NULL;
+  }
 
   // Use file-scope GPIO instance.
   GPIO &io = s_global_io;
+  Rp1RioSetEnabled(runtime_options.rp1_rio > 0);
+  const bool use_rp1_rio = runtime_options.do_gpio_init
+      && Rp1RioShouldActivate(options.hardware_mapping,
+                              options.row_address_type,
+                              options.parallel);
+  const bool use_rp1_pio = !use_rp1_rio && runtime_options.do_gpio_init
+      && Rp1PioShouldActivate(options.hardware_mapping,
+                              options.row_address_type,
+                              options.parallel);
+  if (use_rp1_rio) {
+    Rp1RioSetGpioSlowdown(runtime_options.gpio_slowdown);
+  }
+  if (use_rp1_pio) {
+    Rp1PioSetGpioSlowdown(runtime_options.gpio_slowdown);
+  }
+
+  const bool pi5_backend_available =
+      Rp1PioPlatformDetected() || Rp1RioPlatformDetected();
+  if (runtime_options.do_gpio_init && pi5_backend_available
+      && !use_rp1_pio && !use_rp1_rio) {
+    if (Rp1RioBackendRequested()) {
+      fprintf(stderr,
+              "Pi 5-family RP1 RIO backend was requested via "
+              "--led-rp1-rio=1, but this configuration is not "
+              "supported yet.\n"
+              "Supported for now: mappings "
+              "regular/adafruit-hat/adafruit-hat-pwm/classic and "
+              "--led-row-addr-type=0 or 2.\n");
+    } else {
+      fprintf(stderr,
+              "Pi 5-family RP1 backend is available, but this configuration is not "
+              "supported yet.\n"
+              "Supported for now: mappings "
+              "regular/adafruit-hat/adafruit-hat-pwm/classic and "
+              "--led-row-addr-type=0 or 2.\n");
+    }
+    return NULL;
+  }
 
   // C wrapper implementation is at file scope; use local reference `io`.
-  if (runtime_options.do_gpio_init
+  if (runtime_options.do_gpio_init && !use_rp1_pio && !use_rp1_rio
       && !io.Init(runtime_options.gpio_slowdown)) {
     fprintf(stderr, "Must run as root to be able to access /dev/mem\n"
             "Prepend 'sudo' to the command\n");

--- a/lib/options-initialize.cc
+++ b/lib/options-initialize.cc
@@ -37,6 +37,7 @@ RuntimeOptions::RuntimeOptions() :
 #else
   gpio_slowdown(GPIO::IsPi4() ? 2 : 1),
 #endif
+  rp1_rio(0),
   daemon(0),            // Don't become a daemon by default.
   drop_privileges(1),   // Encourage good practice: drop privileges by default.
   do_gpio_init(true),
@@ -225,6 +226,16 @@ static bool FlagInit(int &argc, char **&argv,
       //-- Runtime options.
       if (ConsumeIntFlag("slowdown-gpio", it, end, &ropts->gpio_slowdown, &err))
         continue;
+      const int err_before_rp1_rio = err;
+      if (ConsumeIntFlag("rp1-rio", it, end, &ropts->rp1_rio, &err)) {
+        if (err == err_before_rp1_rio
+            && ropts->rp1_rio != 0 && ropts->rp1_rio != 1) {
+          fprintf(stderr, "%s%s=%d is outside usable range 0..1\n",
+                  OPTION_PREFIX, "rp1-rio", ropts->rp1_rio);
+          ++err;
+        }
+        continue;
+      }
       if (ropts->daemon >= 0 && ConsumeBoolFlag("daemon", it, &bool_scratch)) {
         ropts->daemon = bool_scratch ? 1 : 0;
         continue;
@@ -368,6 +379,11 @@ void PrintMatrixFlags(FILE *out, const RGBMatrix::Options &d,
           (LED_MATRIX_ALLOW_BARRIER_DELAY ? -1 : 0), r.gpio_slowdown,
           LED_MATRIX_ALLOW_BARRIER_DELAY ? "Use -1 for memory barrier approach"
                                          : "");
+  fprintf(out,
+          "\t--led-rp1-rio=<0|1>       : On Raspberry Pi 5-family boards, choose the "
+          "experimental RP1 RIO backend instead of RP1 PIO.\n"
+          "\t                            0=PIO, 1=RIO (Default: %d).\n",
+          r.rp1_rio);
   if (r.daemon >= 0) {
     const bool on = (r.daemon > 0);
     fprintf(out,

--- a/lib/rp1/rp1_pio_backend.cc
+++ b/lib/rp1/rp1_pio_backend.cc
@@ -1,0 +1,613 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+#include "rp1_pio_backend.h"
+
+#include <algorithm>
+#include <errno.h>
+#include <fcntl.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+#include "../framebuffer-internal.h"
+#include "../gpio.h"
+#include "../hardware-mapping.h"
+
+extern "C" {
+#include "hardware/pio.h"
+#include "piolib.h"
+}
+
+#include "piomatter/protomatter.pio.h"
+
+namespace rgb_matrix {
+namespace internal {
+namespace {
+
+// Pi 5 PIO path:
+// - framebuffer.cc still decides row order and prepares one GPIO bitmap per
+//   pixel clock in the software framebuffer.
+// - this backend repackages those GPIO bitmaps into a compact command stream
+//   for a single RP1 PIO state machine.
+// - the PIO program owns the clock edge timing via side-set; the CPU only
+//   describes which GPIO levels to present and how long each bitplane stays on.
+
+static const uint32_t kPioOutputPinCount = 28;
+static const uint32_t kMaxTransferBytes = 65532;
+// Command words use bit 31 as a tag:
+//   1 = "the next N words are GPIO samples to clock out"
+//   0 = "hold this GPIO sample for N encoded delay cycles"
+static const uint32_t kCommandData = 1u << 31;
+static const int kDelayOverheadClocks = 5;
+static const int kClocksPerDataWord = 2;
+static const int kPostAddressDelayClocks = 5;
+static const double kBaseTargetPioClockHz = 27000000.0;
+
+struct Rp1PioState {
+  Rp1PioState()
+      : active(false),
+        panel_init_warned(false),
+        pio(NULL),
+        sm(-1),
+        row_address_type(0),
+        double_rows(0),
+        gpio_slowdown(1),
+        output_enable_bit(0),
+        latch_bit(0),
+        used_mask(0) {
+  }
+
+  bool active;
+  bool panel_init_warned;
+  PIO pio;
+  int sm;
+  // Cached configuration copied from the selected matrix mapping so the hot
+  // dump loop does not need to rediscover backend-specific details each frame.
+  int row_address_type;
+  int double_rows;
+  int gpio_slowdown;
+  uint32_t output_enable_bit;
+  uint32_t latch_bit;
+  uint32_t used_mask;
+  std::vector<int> bitplane_active_words;
+  std::vector<uint32_t> transfer_buffer;
+};
+
+Rp1PioState s_pio_state;
+
+static double TargetPioClockHz() {
+  // Chained panels have tighter setup/hold margin; reuse the public slowdown
+  // flag as a Pi 5 PIO pixel-clock divisor.
+  const int divisor = std::max(1, s_pio_state.gpio_slowdown);
+  return kBaseTargetPioClockHz / divisor;
+}
+
+static bool ReadSmallTextFile(const char *path, std::string *result) {
+  const int fd = open(path, O_RDONLY);
+  if (fd < 0) return false;
+
+  char buffer[256];
+  const ssize_t len = read(fd, buffer, sizeof(buffer) - 1);
+  close(fd);
+  if (len <= 0) return false;
+
+  buffer[len] = '\0';
+  result->assign(buffer, buffer + len);
+  return true;
+}
+
+static bool FileExists(const char *path) {
+  struct stat st;
+  return stat(path, &st) == 0;
+}
+
+static bool MappingNameSupported(const char *hardware_mapping) {
+  if (hardware_mapping == NULL || *hardware_mapping == '\0') {
+    hardware_mapping = "regular";
+  }
+  // Keep this intentionally narrower than the generic library mapping list.
+  // The PIO backend assumes one clock side-set pin and RP1 GPIOs 0..27 only.
+  return strcmp(hardware_mapping, "regular") == 0
+      || strcmp(hardware_mapping, "regular-pi1") == 0
+      || strcmp(hardware_mapping, "classic") == 0
+      || strcmp(hardware_mapping, "adafruit-hat") == 0
+      || strcmp(hardware_mapping, "adafruit-hat-pwm") == 0;
+}
+
+static uint32_t CollectColorMask(const HardwareMapping &h, int parallel) {
+  uint32_t mask = 0;
+  mask |= h.p0_r1 | h.p0_g1 | h.p0_b1 | h.p0_r2 | h.p0_g2 | h.p0_b2;
+  if (parallel >= 2) {
+    mask |= h.p1_r1 | h.p1_g1 | h.p1_b1 | h.p1_r2 | h.p1_g2 | h.p1_b2;
+  }
+  if (parallel >= 3) {
+    mask |= h.p2_r1 | h.p2_g1 | h.p2_b1 | h.p2_r2 | h.p2_g2 | h.p2_b2;
+  }
+  if (parallel >= 4) {
+    mask |= h.p3_r1 | h.p3_g1 | h.p3_b1 | h.p3_r2 | h.p3_g2 | h.p3_b2;
+  }
+  if (parallel >= 5) {
+    mask |= h.p4_r1 | h.p4_g1 | h.p4_b1 | h.p4_r2 | h.p4_g2 | h.p4_b2;
+  }
+  if (parallel >= 6) {
+    mask |= h.p5_r1 | h.p5_g1 | h.p5_b1 | h.p5_r2 | h.p5_g2 | h.p5_b2;
+  }
+  return mask;
+}
+
+static uint32_t CollectAddressMask(const HardwareMapping &h, int double_rows,
+                                   int row_address_type) {
+  switch (row_address_type) {
+  case 0: {
+    uint32_t mask = h.a;
+    if (double_rows > 2) mask |= h.b;
+    if (double_rows > 4) mask |= h.c;
+    if (double_rows > 8) mask |= h.d;
+    if (double_rows > 16) mask |= h.e;
+    return mask;
+  }
+  case 2:
+    return h.a | h.b | h.c | h.d;
+  default:
+    return 0;
+  }
+}
+
+static uint32_t BuildUsedMask(const HardwareMapping &h, int double_rows,
+                              int parallel, int row_address_type) {
+  uint32_t mask = h.output_enable | h.clock | h.strobe;
+  mask |= CollectAddressMask(h, double_rows, row_address_type);
+  mask |= CollectColorMask(h, parallel);
+  return mask;
+}
+
+static bool FitsInPioWord(uint64_t bits) {
+  const uint64_t kAllowedMask = (1ull << kPioOutputPinCount) - 1;
+  return (bits & ~kAllowedMask) == 0;
+}
+
+static bool IsSingleBit(uint64_t bits) {
+  return bits != 0 && (bits & (bits - 1)) == 0;
+}
+
+static uint32_t CalcRowAddressBits(const HardwareMapping &h,
+                                   int row_address_type, int row) {
+  switch (row_address_type) {
+  case 0: {
+    uint32_t bits = 0;
+    if (row & 0x01) bits |= h.a;
+    if (row & 0x02) bits |= h.b;
+    if (row & 0x04) bits |= h.c;
+    if (row & 0x08) bits |= h.d;
+    if (row & 0x10) bits |= h.e;
+    return bits;
+  }
+  case 2:
+    switch (row & 0x03) {
+    case 0: return h.b | h.c | h.d;
+    case 1: return h.a | h.c | h.d;
+    case 2: return h.a | h.b | h.d;
+    default: return h.a | h.b | h.c;
+    }
+  default:
+    return 0;
+  }
+}
+
+static int DisplayRowFromLoop(int row_loop, int double_rows, int scan_mode) {
+  if (scan_mode != 1) return row_loop;
+
+  const int half_double = double_rows / 2;
+  return (row_loop < half_double)
+             ? (row_loop << 1)
+             : (((row_loop - half_double) << 1) + 1);
+}
+
+static void AppendDelay(std::vector<uint32_t> *buffer, uint32_t pins,
+                        int clock_cycles) {
+  int encoded_cycles = clock_cycles - kDelayOverheadClocks;
+  if (encoded_cycles < 1) encoded_cycles = 1;
+  buffer->push_back(static_cast<uint32_t>(encoded_cycles - 1));
+  buffer->push_back(pins);
+}
+
+static void AppendDataHeader(std::vector<uint32_t> *buffer, int words) {
+  buffer->push_back(kCommandData | static_cast<uint32_t>(words - 1));
+}
+
+static int TransferLarge(PIO pio, int sm, const uint32_t *data,
+                         size_t data_bytes) {
+  // The userspace piolib transfer helper caps one request below 64 KiB, so
+  // large frame updates are streamed in chunks.
+  while (data_bytes > 0) {
+    const size_t chunk = std::min(data_bytes,
+                                  static_cast<size_t>(kMaxTransferBytes));
+    int rc = pio_sm_xfer_data(pio, sm, PIO_DIR_TO_SM, chunk,
+                              const_cast<uint32_t *>(data));
+    if (rc != 0) return rc;
+    data += chunk / sizeof(*data);
+    data_bytes -= chunk;
+  }
+  return 0;
+}
+
+static void InitPinDirection(PIO pio, int sm, uint32_t used_mask) {
+  for (uint32_t pin = 0; pin < kPioOutputPinCount; ++pin) {
+    if ((used_mask & (1u << pin)) == 0) continue;
+    pio_gpio_init(pio, pin);
+    pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, true);
+  }
+}
+
+static void ReleasePinDirection(PIO pio, int sm, uint32_t used_mask) {
+  for (uint32_t pin = 0; pin < kPioOutputPinCount; ++pin) {
+    if ((used_mask & (1u << pin)) == 0) continue;
+    pio_gpio_init(pio, pin);
+    pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, false);
+  }
+}
+
+static void PrepareBitplaneTimings(int pwm_lsb_nanoseconds, int dither_bits,
+                                   std::vector<int> *timings_out) {
+  timings_out->clear();
+  int timing_ns = pwm_lsb_nanoseconds;
+  for (int b = 0; b < Framebuffer::kBitPlanes; ++b) {
+    timings_out->push_back(timing_ns);
+    if (b >= dither_bits) timing_ns *= 2;
+  }
+}
+
+static void PrepareBitplaneActiveWords(int pwm_lsb_nanoseconds, int dither_bits,
+                                       std::vector<int> *active_words_out) {
+  std::vector<int> timings_ns;
+  PrepareBitplaneTimings(pwm_lsb_nanoseconds, dither_bits, &timings_ns);
+
+  const double data_word_ns = (1e9 * kClocksPerDataWord) / TargetPioClockHz();
+  active_words_out->clear();
+  active_words_out->reserve(timings_ns.size());
+  for (size_t i = 0; i < timings_ns.size(); ++i) {
+    const int word_count = std::max(
+        1, static_cast<int>(ceil(static_cast<double>(timings_ns[i]) /
+                                 data_word_ns)));
+    active_words_out->push_back(word_count);
+  }
+}
+
+static void ConfigureStateMachineOrDie(const HardwareMapping &mapping) {
+  Rp1PioState &state = s_pio_state;
+  // One state machine drives the whole display. All GPIO samples are expanded
+  // on the CPU side; the PIO program's job is to issue clock edges and honor
+  // encoded delay commands at a stable cadence.
+  state.pio = pio0;
+  if (PIO_IS_ERR(state.pio)) {
+    fprintf(stderr, "Opening /dev/pio0 failed with error %d\n",
+            PIO_ERR_VAL(state.pio));
+    abort();
+  }
+
+  state.sm = pio_claim_unused_sm(state.pio, true);
+  if (state.sm < 0) {
+    fprintf(stderr, "Could not claim an unused RP1 PIO state machine.\n");
+    abort();
+  }
+
+  const int xfer_rc = pio_sm_config_xfer(state.pio, state.sm, PIO_DIR_TO_SM,
+                                         kMaxTransferBytes, 3);
+  if (xfer_rc != 0) {
+    fprintf(stderr, "RP1 PIO DMA configuration failed: %d\n", xfer_rc);
+    abort();
+  }
+
+  static const struct pio_program kProgram = {
+      protomatter,
+      32,
+      -1,
+      0,
+  };
+  const uint offset = pio_add_program(state.pio, &kProgram);
+  if (offset == PIO_ORIGIN_INVALID) {
+    fprintf(stderr, "Loading the HUB75 RP1 PIO program failed.\n");
+    abort();
+  }
+
+  pio_sm_clear_fifos(state.pio, state.sm);
+  pio_sm_set_clkdiv(state.pio, state.sm, 1.0f);
+
+  pio_sm_config config = pio_get_default_sm_config();
+  sm_config_set_wrap(&config, offset + protomatter_wrap_target,
+                     offset + protomatter_wrap);
+  // The config API expects the full encoded side-set field width. For
+  // ".side_set 1 opt", that means 1 data bit plus the optional-enable bit.
+  const uint encoded_sideset_bits =
+      protomatter_sideset_pin_count + (protomatter_sideset_enable ? 1u : 0u);
+  sm_config_set_sideset(&config, encoded_sideset_bits,
+                        protomatter_sideset_enable, false);
+  sm_config_set_out_shift(&config, false, true, 32);
+  sm_config_set_fifo_join(&config, PIO_FIFO_JOIN_TX);
+  sm_config_set_clkdiv(&config, clock_get_hz(clk_sys) / TargetPioClockHz());
+  sm_config_set_out_pins(&config, 0, kPioOutputPinCount);
+
+  const unsigned clock_pin = __builtin_ctz(mapping.clock);
+  sm_config_set_sideset_pins(&config, clock_pin);
+
+  pio_sm_init(state.pio, state.sm, offset, &config);
+  InitPinDirection(state.pio, state.sm, state.used_mask);
+  pio_sm_set_enabled(state.pio, state.sm, true);
+  pio_sm_set_pins_with_mask(state.pio, state.sm, state.output_enable_bit,
+                            state.used_mask);
+}
+
+static void SendRawWordsOrDie(const std::vector<uint32_t> &pins) {
+  if (pins.empty()) return;
+
+  Rp1PioState &state = s_pio_state;
+  // Panel init sequences reuse the same command format as the refresh loop,
+  // but always run with OE blanked so the panel does not flash partial data.
+  std::vector<uint32_t> buffer;
+  buffer.reserve(pins.size() + 3);
+  AppendDataHeader(&buffer, pins.size());
+  for (size_t i = 0; i < pins.size(); ++i) {
+    buffer.push_back(pins[i] | state.output_enable_bit);
+  }
+  AppendDelay(&buffer, state.output_enable_bit, 0);
+
+  const int rc = TransferLarge(state.pio, state.sm, &buffer[0],
+                               buffer.size() * sizeof(buffer[0]));
+  if (rc != 0) {
+    fprintf(stderr, "RP1 PIO transfer failed during panel init: %d\n", rc);
+    abort();
+  }
+}
+
+static void SendFM6126Init(const HardwareMapping &h, int columns) {
+  const uint32_t bits_on =
+      CollectColorMask(h, 6) | static_cast<uint32_t>(h.a);
+  const uint32_t bits_off = h.a;
+  static const char *init_b12 = "0111111111111111";
+  static const char *init_b13 = "0000000001000000";
+
+  std::vector<uint32_t> pins;
+  pins.reserve(columns * 2);
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b12[i % 16] == '0') ? bits_off : bits_on;
+    if (i > columns - 12) value |= h.strobe;
+    pins.push_back(value);
+  }
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b13[i % 16] == '0') ? bits_off : bits_on;
+    if (i > columns - 13) value |= h.strobe;
+    pins.push_back(value);
+  }
+  SendRawWordsOrDie(pins);
+}
+
+static void SendFM6127Init(const HardwareMapping &h, int columns) {
+  const uint32_t bits_r_on = h.p0_r1 | h.p0_r2;
+  const uint32_t bits_g_on = h.p0_g1 | h.p0_g2;
+  const uint32_t bits_b_on = h.p0_b1 | h.p0_b2;
+  const uint32_t bits_on = bits_r_on | bits_g_on | bits_b_on;
+  static const char *init_b12 = "1111111111001110";
+  static const char *init_b13 = "1110000001100010";
+  static const char *init_b11 = "0101111100000000";
+
+  std::vector<uint32_t> pins;
+  pins.reserve(columns * 3);
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b12[i % 16] == '0') ? 0 : bits_on;
+    if (i > columns - 12) value |= h.strobe;
+    pins.push_back(value);
+  }
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b13[i % 16] == '0') ? 0 : bits_on;
+    if (i > columns - 13) value |= h.strobe;
+    pins.push_back(value);
+  }
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b11[i % 16] == '0') ? 0 : bits_on;
+    if (i > columns - 11) value |= h.strobe;
+    pins.push_back(value);
+  }
+  SendRawWordsOrDie(pins);
+}
+
+}  // namespace
+
+bool Rp1PioPlatformDetected() {
+  if (!GPIO::IsPi5Family()) {
+    std::string model;
+    if (!ReadSmallTextFile("/proc/device-tree/model", &model)) {
+      return false;
+    }
+    if (model.find("Raspberry Pi 5") == std::string::npos
+        && model.find("Compute Module 5") == std::string::npos) {
+      return false;
+    }
+  }
+  return FileExists("/dev/pio0");
+}
+
+bool Rp1PioConfigSupported(const char *hardware_mapping, int row_address_type,
+                           int parallel) {
+  if (!Rp1PioPlatformDetected()) return false;
+  if (!MappingNameSupported(hardware_mapping)) return false;
+  if (!(row_address_type == 0 || row_address_type == 2)) return false;
+  return parallel >= 1 && parallel <= 3;
+}
+
+bool Rp1PioShouldActivate(const char *hardware_mapping, int row_address_type,
+                          int parallel) {
+  return Rp1PioConfigSupported(hardware_mapping, row_address_type, parallel);
+}
+
+void Rp1PioSetGpioSlowdown(int slowdown) {
+  s_pio_state.gpio_slowdown = slowdown <= 1 ? 1 : slowdown;
+}
+
+bool Rp1PioIsActive() { return s_pio_state.active; }
+
+void Rp1PioInitOrDie(const HardwareMapping &mapping, int double_rows, int parallel,
+                     int pwm_lsb_nanoseconds, int dither_bits,
+                     int row_address_type) {
+  Rp1PioState &state = s_pio_state;
+  if (state.active) return;
+
+  state.row_address_type = row_address_type;
+  state.double_rows = double_rows;
+  state.output_enable_bit = mapping.output_enable;
+  state.latch_bit = mapping.strobe;
+  state.used_mask = BuildUsedMask(mapping, state.double_rows, parallel,
+                                  row_address_type);
+
+  if (!FitsInPioWord(state.used_mask)) {
+    fprintf(stderr,
+            "The selected GPIO mapping uses pins outside RP1 PIO's 0..27 "
+            "range.\n");
+    abort();
+  }
+  if (!FitsInPioWord(mapping.clock) || !FitsInPioWord(mapping.strobe)
+      || !FitsInPioWord(mapping.output_enable)
+      || !FitsInPioWord(CollectAddressMask(mapping, state.double_rows,
+                                           row_address_type))
+      || !FitsInPioWord(CollectColorMask(mapping, parallel))) {
+    fprintf(stderr, "The Pi 5-family RP1 backend only supports GPIO bits 0..27.\n");
+    abort();
+  }
+  if (!IsSingleBit(mapping.clock)) {
+    fprintf(stderr,
+            "The Pi 5-family RP1 PIO backend requires the clock signal to map to "
+            "exactly one GPIO pin.\n");
+    abort();
+  }
+
+  PrepareBitplaneActiveWords(pwm_lsb_nanoseconds, dither_bits,
+                             &state.bitplane_active_words);
+  ConfigureStateMachineOrDie(mapping);
+  state.active = true;
+}
+
+void Rp1PioInitializePanels(const HardwareMapping &mapping,
+                            const char *panel_type, int columns) {
+  if (!s_pio_state.active || panel_type == NULL || *panel_type == '\0') return;
+
+  if (strncasecmp(panel_type, "fm6126", 6) == 0) {
+    SendFM6126Init(mapping, columns);
+  } else if (strncasecmp(panel_type, "fm6127", 6) == 0) {
+    SendFM6127Init(mapping, columns);
+  } else if (!s_pio_state.panel_init_warned) {
+    fprintf(stderr,
+            "Pi 5-family RP1 backend: panel init '%s' is not implemented; "
+            "continuing without panel init.\n",
+            panel_type);
+    s_pio_state.panel_init_warned = true;
+  }
+}
+
+void Rp1PioDumpFramebuffer(Framebuffer *framebuffer, int pwm_low_bit) {
+  if (!s_pio_state.active || framebuffer == NULL) return;
+
+  Rp1PioState &state = s_pio_state;
+  // The framebuffer already contains per-column color GPIO bits. This pass only
+  // adds row-address selection, latch/OE sequencing, and the active-time delay
+  // that gives each PWM bitplane its brightness weight.
+  const HardwareMapping &h = framebuffer->hardware_mapping();
+  const int start_bit =
+      std::max(pwm_low_bit, Framebuffer::kBitPlanes - framebuffer->pwmbits());
+  const int double_rows = framebuffer->double_rows();
+  const int columns = framebuffer->columns();
+  const int scan_mode = framebuffer->scan_mode();
+
+  const int plane_count = Framebuffer::kBitPlanes - start_bit;
+  state.transfer_buffer.clear();
+  state.transfer_buffer.reserve(
+      double_rows * plane_count * (columns + 8) + 8);
+
+  uint32_t previous_addr = CalcRowAddressBits(
+      h, state.row_address_type,
+      DisplayRowFromLoop(double_rows - 1, double_rows, scan_mode));
+  int previous_active_words = 0;
+
+  for (int row_loop = 0; row_loop < double_rows; ++row_loop) {
+    const int display_row =
+        DisplayRowFromLoop(row_loop, double_rows, scan_mode);
+    const uint32_t current_addr =
+        CalcRowAddressBits(h, state.row_address_type, display_row);
+
+    for (int bit = start_bit; bit < Framebuffer::kBitPlanes; ++bit) {
+      const gpio_bits_t *row_data = framebuffer->RowDataAt(display_row, bit);
+      AppendDataHeader(&state.transfer_buffer, columns);
+
+      int remaining_overlap_words = previous_active_words;
+      for (int col = 0; col < columns; ++col) {
+        uint32_t pins = static_cast<uint32_t>(row_data[col]) | previous_addr;
+        if (remaining_overlap_words <= 0) {
+          pins |= state.output_enable_bit;
+        }
+        state.transfer_buffer.push_back(pins);
+        if (remaining_overlap_words > 0) --remaining_overlap_words;
+      }
+
+      if (remaining_overlap_words > 0) {
+        AppendDelay(&state.transfer_buffer, previous_addr,
+                    remaining_overlap_words * kClocksPerDataWord);
+      }
+
+      if (current_addr != previous_addr) {
+        AppendDelay(&state.transfer_buffer,
+                    current_addr | state.output_enable_bit,
+                    kPostAddressDelayClocks);
+      }
+      AppendDelay(&state.transfer_buffer,
+                  current_addr | state.output_enable_bit | state.latch_bit, 0);
+
+      previous_addr = current_addr;
+      previous_active_words = state.bitplane_active_words[bit];
+    }
+  }
+
+  if (previous_active_words > 0) {
+    AppendDelay(&state.transfer_buffer, previous_addr,
+                previous_active_words * kClocksPerDataWord);
+  }
+  AppendDelay(&state.transfer_buffer, previous_addr | state.output_enable_bit,
+              0);
+
+  const int rc = TransferLarge(state.pio, state.sm, &state.transfer_buffer[0],
+                               state.transfer_buffer.size()
+                                   * sizeof(state.transfer_buffer[0]));
+  if (rc != 0) {
+    fprintf(stderr, "RP1 PIO framebuffer transfer failed: %d\n", rc);
+    abort();
+  }
+}
+
+void Rp1PioDeinit() {
+  Rp1PioState &state = s_pio_state;
+  if (!state.active) return;
+
+  pio_sm_set_enabled(state.pio, state.sm, false);
+  pio_sm_clear_fifos(state.pio, state.sm);
+  ReleasePinDirection(state.pio, state.sm, state.used_mask);
+  pio_sm_unclaim(state.pio, state.sm);
+  pio_close(state.pio);
+
+  state.active = false;
+  state.panel_init_warned = false;
+  state.pio = NULL;
+  state.sm = -1;
+  state.row_address_type = 0;
+  state.double_rows = 0;
+  state.gpio_slowdown = 1;
+  state.output_enable_bit = 0;
+  state.latch_bit = 0;
+  state.used_mask = 0;
+  state.bitplane_active_words.clear();
+  state.transfer_buffer.clear();
+}
+
+}  // namespace internal
+}  // namespace rgb_matrix

--- a/lib/rp1/rp1_pio_backend.h
+++ b/lib/rp1/rp1_pio_backend.h
@@ -1,0 +1,38 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+#ifndef RP1_PIO_BACKEND_H
+#define RP1_PIO_BACKEND_H
+
+struct HardwareMapping;
+
+namespace rgb_matrix {
+namespace internal {
+class Framebuffer;
+
+// Internal Pi 5-family RP1 PIO renderer.
+//
+// Expected call flow:
+// - detect/select with PlatformDetected()/ConfigSupported()/ShouldActivate()
+// - push runtime timing with SetGpioSlowdown()
+// - initialize once with InitOrDie()
+// - optionally run panel-specific startup via InitializePanels()
+// - stream each refresh via DumpFramebuffer()
+// - release claimed state-machine resources with Deinit()
+bool Rp1PioPlatformDetected();
+bool Rp1PioConfigSupported(const char *hardware_mapping, int row_address_type,
+                           int parallel);
+bool Rp1PioShouldActivate(const char *hardware_mapping, int row_address_type,
+                          int parallel);
+void Rp1PioSetGpioSlowdown(int slowdown);
+bool Rp1PioIsActive();
+void Rp1PioInitOrDie(const HardwareMapping &mapping, int double_rows, int parallel,
+                     int pwm_lsb_nanoseconds, int dither_bits,
+                     int row_address_type);
+void Rp1PioInitializePanels(const HardwareMapping &mapping,
+                            const char *panel_type, int columns);
+void Rp1PioDumpFramebuffer(Framebuffer *framebuffer, int pwm_low_bit);
+void Rp1PioDeinit();
+
+}  // namespace internal
+}  // namespace rgb_matrix
+
+#endif  // RP1_PIO_BACKEND_H

--- a/lib/rp1/rp1_pio_support.c
+++ b/lib/rp1/rp1_pio_support.c
@@ -1,0 +1,9 @@
+/*
+ * Pull the small vendor piolib implementation into one local translation unit.
+ *
+ * The project build files only need to know about rp1_pio_support.c; this
+ * wrapper keeps the vendored RP1 C sources grouped together for both Make and
+ * CMake and avoids sprinkling vendor-specific source lists through the tree.
+ */
+#include "rp1_pio_vendor/piolib/pio_rp1.c"
+#include "rp1_pio_vendor/piolib/piolib.c"

--- a/lib/rp1/rp1_pio_vendor/include/piomatter/protomatter.pio.h
+++ b/lib/rp1/rp1_pio_vendor/include/piomatter/protomatter.pio.h
@@ -1,0 +1,53 @@
+#pragma once
+
+const int protomatter_wrap = 4;
+const int protomatter_wrap_target = 0;
+const int protomatter_sideset_pin_count = 1;
+const bool protomatter_sideset_enable = 1;
+const uint16_t protomatter[] = {
+    // ; data format (out-shift-right):
+    // ; MSB ... LSB
+    // ; 0 ddd......ddd: 31-bit delay
+    // ; 1 ccc......ccc: 31 bit data count
+    // .side_set 1 opt
+    // .wrap_target
+    // top:
+    0x6021, //     out x, 1
+    0x605f, //     out y, 31
+    0x0025, //     jmp !x do_delay
+            // data_loop:
+    0x6000, //     out pins, 32
+    0x1883, //     jmp y--, data_loop  side 1 ; assert clk bit
+            // .wrap
+            // do_delay:
+    0x6000, //     out pins, 32
+            // delay_loop:
+    0x0086, //     jmp y--, delay_loop
+    0x0000, //     jmp top
+    //     ;; fill program out to 32 instructions so nothing else can load
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+    0xa042, //     nop
+};

--- a/lib/rp1/rp1_pio_vendor/piolib/include/hardware/clocks.h
+++ b/lib/rp1/rp1_pio_vendor/piolib/include/hardware/clocks.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2024 Raspberry Pi Ltd.
+ * All rights reserved.
+ */
+
+#ifndef _HARDWARE_CLOCKS_H
+#define _HARDWARE_CLOCKS_H
+
+enum clock_index {
+    clk_gpout0 = 0,     ///< GPIO Muxing 0
+    clk_gpout1,         ///< GPIO Muxing 1
+    clk_gpout2,         ///< GPIO Muxing 2
+    clk_gpout3,         ///< GPIO Muxing 3
+    clk_ref,            ///< Watchdog and timers reference clock
+    clk_sys,            ///< Processors, bus fabric, memory, memory mapped registers
+    clk_peri,           ///< Peripheral clock for UART and SPI
+    clk_usb,            ///< USB clock
+    clk_adc,            ///< ADC clock
+    clk_rtc,            ///< Real time clock
+    CLK_COUNT
+};
+
+#endif

--- a/lib/rp1/rp1_pio_vendor/piolib/include/hardware/gpio.h
+++ b/lib/rp1/rp1_pio_vendor/piolib/include/hardware/gpio.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2024 Raspberry Pi Ltd.
+ * All rights reserved.
+ */
+#ifndef _HARDWARE_GPIO_H
+#define _HARDWARE_GPIO_H
+
+#include "pio_platform.h"
+
+#ifndef PARAM_ASSERTIONS_ENABLED_GPIO
+#define PARAM_ASSERTIONS_ENABLED_GPIO 0
+#endif
+
+#define NUM_BANK0_GPIOS 32
+
+enum gpio_function {
+    GPIO_FUNC_XIP = 0,
+    GPIO_FUNC_SPI = 1,
+    GPIO_FUNC_UART = 2,
+    GPIO_FUNC_I2C = 3,
+    GPIO_FUNC_PWM = 4,
+    GPIO_FUNC_SIO = 5,
+    GPIO_FUNC_PIO0 = 6,
+    GPIO_FUNC_PIO1 = 7,
+    GPIO_FUNC_GPCK = 8,
+    GPIO_FUNC_USB = 9,
+    GPIO_FUNC_NULL = 0x1f,
+};
+
+#define GPIO_OUT 1
+#define GPIO_IN 0
+
+enum gpio_irq_level {
+    GPIO_IRQ_LEVEL_LOW = 0x1u,
+    GPIO_IRQ_LEVEL_HIGH = 0x2u,
+    GPIO_IRQ_EDGE_FALL = 0x4u,
+    GPIO_IRQ_EDGE_RISE = 0x8u,
+};
+
+enum gpio_override {
+    GPIO_OVERRIDE_NORMAL = 0,      ///< peripheral signal selected via \ref gpio_set_function
+    GPIO_OVERRIDE_INVERT = 1,      ///< invert peripheral signal selected via \ref gpio_set_function
+    GPIO_OVERRIDE_LOW = 2,         ///< drive low/disable output
+    GPIO_OVERRIDE_HIGH = 3,        ///< drive high/enable output
+};
+enum gpio_slew_rate {
+    GPIO_SLEW_RATE_SLOW = 0,  ///< Slew rate limiting enabled
+    GPIO_SLEW_RATE_FAST = 1   ///< Slew rate limiting disabled
+};
+
+enum gpio_drive_strength {
+    GPIO_DRIVE_STRENGTH_2MA = 0, ///< 2 mA nominal drive strength
+    GPIO_DRIVE_STRENGTH_4MA = 1, ///< 4 mA nominal drive strength
+    GPIO_DRIVE_STRENGTH_8MA = 2, ///< 8 mA nominal drive strength
+    GPIO_DRIVE_STRENGTH_12MA = 3 ///< 12 mA nominal drive strength
+};
+
+static inline void check_gpio_param(__unused uint gpio) {
+    invalid_params_if(GPIO, gpio >= NUM_BANK0_GPIOS);
+}
+
+#endif

--- a/lib/rp1/rp1_pio_vendor/piolib/include/hardware/pio.h
+++ b/lib/rp1/rp1_pio_vendor/piolib/include/hardware/pio.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2024 Raspberry Pi Ltd.
+ * All rights reserved.
+ */
+#ifndef _HARDWARE_PIO_H
+#define _HARDWARE_PIO_H
+
+#include "piolib.h"
+
+#endif

--- a/lib/rp1/rp1_pio_vendor/piolib/include/hardware/pio_instructions.h
+++ b/lib/rp1/rp1_pio_vendor/piolib/include/hardware/pio_instructions.h
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _HARDWARE_PIO_INSTRUCTIONS_H
+#define _HARDWARE_PIO_INSTRUCTIONS_H
+
+//#include "pico.h"
+
+/** \brief PIO instruction encoding 
+ *  \defgroup pio_instructions pio_instructions
+ *  \ingroup hardware_pio
+ * 
+ * Functions for generating PIO instruction encodings programmatically. In debug builds
+ *`PARAM_ASSERTIONS_ENABLED_PIO_INSTRUCTIONS` can be set to 1 to enable validation of encoding function
+ * parameters.
+ *
+ * For fuller descriptions of the instructions in question see the "RP2040 Datasheet"
+ */
+
+// PICO_CONFIG: PARAM_ASSERTIONS_ENABLED_PIO_INSTRUCTIONS, Enable/disable assertions in the PIO instructions, type=bool, default=0, group=pio_instructions
+#ifndef PARAM_ASSERTIONS_ENABLED_PIO_INSTRUCTIONS
+#define PARAM_ASSERTIONS_ENABLED_PIO_INSTRUCTIONS 0
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum pio_instr_bits {
+    pio_instr_bits_jmp = 0x0000,
+    pio_instr_bits_wait = 0x2000,
+    pio_instr_bits_in = 0x4000,
+    pio_instr_bits_out = 0x6000,
+    pio_instr_bits_push = 0x8000,
+    pio_instr_bits_pull = 0x8080,
+    pio_instr_bits_mov = 0xa000,
+    pio_instr_bits_irq = 0xc000,
+    pio_instr_bits_set = 0xe000,
+};
+
+#ifndef NDEBUG
+#define _PIO_INVALID_IN_SRC    0x08u
+#define _PIO_INVALID_OUT_DEST 0x10u
+#define _PIO_INVALID_SET_DEST 0x20u
+#define _PIO_INVALID_MOV_SRC  0x40u
+#define _PIO_INVALID_MOV_DEST 0x80u
+#else
+#define _PIO_INVALID_IN_SRC    0u
+#define _PIO_INVALID_OUT_DEST 0u
+#define _PIO_INVALID_SET_DEST 0u
+#define _PIO_INVALID_MOV_SRC  0u
+#define _PIO_INVALID_MOV_DEST 0u
+#endif
+
+/*! \brief Enumeration of values to pass for source/destination args for instruction encoding functions
+ *  \ingroup pio_instructions
+ *
+ * \note Not all values are suitable for all functions. Validity is only checked in debug mode when
+ * `PARAM_ASSERTIONS_ENABLED_PIO_INSTRUCTIONS` is 1
+ */
+enum pio_src_dest {
+    pio_pins = 0u,
+    pio_x = 1u,
+    pio_y = 2u,
+    pio_null = 3u | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_DEST,
+    pio_pindirs = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_MOV_SRC | _PIO_INVALID_MOV_DEST,
+    pio_exec_mov = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC,
+    pio_status = 5u | _PIO_INVALID_IN_SRC | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_DEST,
+    pio_pc = 5u | _PIO_INVALID_IN_SRC | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC,
+    pio_isr = 6u | _PIO_INVALID_SET_DEST,
+    pio_osr = 7u | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST,
+    pio_exec_out = 7u | _PIO_INVALID_IN_SRC | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC | _PIO_INVALID_MOV_DEST,
+};
+
+static inline uint _pio_major_instr_bits(uint instr) {
+    return instr & 0xe000u;
+}
+
+static inline uint _pio_encode_instr_and_args(enum pio_instr_bits instr_bits, uint arg1, uint arg2) {
+    valid_params_if(PIO_INSTRUCTIONS, arg1 <= 0x7);
+#if PARAM_ASSERTIONS_ENABLED(PIO_INSTRUCTIONS)
+    uint32_t major = _pio_major_instr_bits(instr_bits);
+    if (major == pio_instr_bits_in || major == pio_instr_bits_out) {
+        assert(arg2 && arg2 <= 32);
+    } else {
+        assert(arg2 <= 31);
+    }
+#endif
+    return instr_bits | (arg1 << 5u) | (arg2 & 0x1fu);
+}
+
+static inline uint _pio_encode_instr_and_src_dest(enum pio_instr_bits instr_bits, enum pio_src_dest dest, uint value) {
+    return _pio_encode_instr_and_args(instr_bits, dest & 7u, value);
+}
+
+/*! \brief Encode just the delay slot bits of an instruction
+ *  \ingroup pio_instructions
+ *
+ * \note This function does not return a valid instruction encoding; instead it returns an encoding of the delay
+ * slot suitable for `OR`ing with the result of an encoding function for an actual instruction. Care should be taken when
+ * combining the results of this function with the results of \ref pio_encode_sideset and \ref pio_encode_sideset_opt
+ * as they share the same bits within the instruction encoding.
+ *
+ * \param cycles the number of cycles 0-31 (or less if side set is being used)
+ * \return the delay slot bits to be ORed with an instruction encoding
+ */
+static inline uint pio_encode_delay(uint cycles) {
+    // note that the maximum cycles will be smaller if sideset_bit_count > 0
+    valid_params_if(PIO_INSTRUCTIONS, cycles <= 0x1f);
+    return cycles << 8u;
+}
+
+/*! \brief Encode just the side set bits of an instruction (in non optional side set mode)
+ *  \ingroup pio_instructions
+ *
+ * \note This function does not return a valid instruction encoding; instead it returns an encoding of the side set bits
+ * suitable for `OR`ing with the result of an encoding function for an actual instruction. Care should be taken when
+ * combining the results of this function with the results of \ref pio_encode_delay as they share the same bits
+ * within the instruction encoding.
+ *
+ * \param sideset_bit_count number of side set bits as would be specified via `.sideset` in pioasm
+ * \param value the value to sideset on the pins
+ * \return the side set bits to be ORed with an instruction encoding
+ */
+static inline uint pio_encode_sideset(uint sideset_bit_count, uint value) {
+    valid_params_if(PIO_INSTRUCTIONS, sideset_bit_count >= 1 && sideset_bit_count <= 5);
+    valid_params_if(PIO_INSTRUCTIONS, value <= ((1u << sideset_bit_count) - 1));
+    return value << (13u - sideset_bit_count);
+}
+
+/*! \brief Encode just the side set bits of an instruction (in optional -`opt` side set mode)
+ *  \ingroup pio_instructions
+ *
+ * \note This function does not return a valid instruction encoding; instead it returns an encoding of the side set bits
+ * suitable for `OR`ing with the result of an encoding function for an actual instruction. Care should be taken when
+ * combining the results of this function with the results of \ref pio_encode_delay as they share the same bits
+ * within the instruction encoding.
+ *
+ * \param sideset_bit_count number of side set bits as would be specified via `.sideset <n> opt` in pioasm
+ * \param value the value to sideset on the pins
+ * \return the side set bits to be ORed with an instruction encoding
+ */
+static inline uint pio_encode_sideset_opt(uint sideset_bit_count, uint value) {
+    valid_params_if(PIO_INSTRUCTIONS, sideset_bit_count >= 1 && sideset_bit_count <= 4);
+    valid_params_if(PIO_INSTRUCTIONS, value <= ((1u << sideset_bit_count) - 1));
+    return 0x1000u | value << (12u - sideset_bit_count);
+}
+
+/*! \brief Encode an unconditional JMP instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `JMP <addr>`
+ *
+ * \param addr The target address 0-31 (an absolute address within the PIO instruction memory)
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_jmp(uint addr) {
+    return _pio_encode_instr_and_args(pio_instr_bits_jmp, 0, addr);
+}
+
+/*! \brief Encode a conditional JMP if scratch X zero instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `JMP !X <addr>`
+ *
+ * \param addr The target address 0-31 (an absolute address within the PIO instruction memory)
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_jmp_not_x(uint addr) {
+    return _pio_encode_instr_and_args(pio_instr_bits_jmp, 1, addr);
+}
+
+/*! \brief Encode a conditional JMP if scratch X non-zero (and post-decrement X) instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `JMP X-- <addr>`
+ *
+ * \param addr The target address 0-31 (an absolute address within the PIO instruction memory)
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_jmp_x_dec(uint addr) {
+    return _pio_encode_instr_and_args(pio_instr_bits_jmp, 2, addr);
+}
+
+/*! \brief Encode a conditional JMP if scratch Y zero instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `JMP !Y <addr>`
+ *
+ * \param addr The target address 0-31 (an absolute address within the PIO instruction memory)
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_jmp_not_y(uint addr) {
+    return _pio_encode_instr_and_args(pio_instr_bits_jmp, 3, addr);
+}
+
+/*! \brief Encode a conditional JMP if scratch Y non-zero (and post-decrement Y) instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `JMP Y-- <addr>`
+ *
+ * \param addr The target address 0-31 (an absolute address within the PIO instruction memory)
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_jmp_y_dec(uint addr) {
+    return _pio_encode_instr_and_args(pio_instr_bits_jmp, 4, addr);
+}
+
+/*! \brief Encode a conditional JMP if scratch X not equal scratch Y instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `JMP X!=Y <addr>`
+ *
+ * \param addr The target address 0-31 (an absolute address within the PIO instruction memory)
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_jmp_x_ne_y(uint addr) {
+    return _pio_encode_instr_and_args(pio_instr_bits_jmp, 5, addr);
+}
+
+/*! \brief Encode a conditional JMP if input pin high instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `JMP PIN <addr>`
+ *
+ * \param addr The target address 0-31 (an absolute address within the PIO instruction memory)
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_jmp_pin(uint addr) {
+    return _pio_encode_instr_and_args(pio_instr_bits_jmp, 6, addr);
+}
+
+/*! \brief Encode a conditional JMP if output shift register not empty instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `JMP !OSRE <addr>`
+ *
+ * \param addr The target address 0-31 (an absolute address within the PIO instruction memory)
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_jmp_not_osre(uint addr) {
+    return _pio_encode_instr_and_args(pio_instr_bits_jmp, 7, addr);
+}
+
+static inline uint _pio_encode_irq(bool relative, uint irq) {
+    valid_params_if(PIO_INSTRUCTIONS, irq <= 7);
+    return (relative ? 0x10u : 0x0u) | irq;
+}
+
+/*! \brief Encode a WAIT for GPIO pin instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `WAIT <polarity> GPIO <gpio>`
+ *
+ * \param polarity true for `WAIT 1`, false for `WAIT 0`
+ * \param gpio The real GPIO number 0-31
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_wait_gpio(bool polarity, uint gpio) {
+    return _pio_encode_instr_and_args(pio_instr_bits_wait, 0u | (polarity ? 4u : 0u), gpio);
+}
+
+/*! \brief Encode a WAIT for pin instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `WAIT <polarity> PIN <pin>`
+ *
+ * \param polarity true for `WAIT 1`, false for `WAIT 0`
+ * \param pin The pin number 0-31 relative to the executing SM's input pin mapping
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_wait_pin(bool polarity, uint pin) {
+    return _pio_encode_instr_and_args(pio_instr_bits_wait, 1u | (polarity ? 4u : 0u), pin);
+}
+
+/*! \brief Encode a WAIT for IRQ instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `WAIT <polarity> IRQ <irq> <relative>`
+ *
+ * \param polarity true for `WAIT 1`, false for `WAIT 0`
+ * \param relative true for a `WAIT IRQ <irq> REL`, false for regular `WAIT IRQ <irq>`
+ * \param irq the irq number 0-7
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_wait_irq(bool polarity, bool relative, uint irq) {
+    valid_params_if(PIO_INSTRUCTIONS, irq <= 7);
+    return _pio_encode_instr_and_args(pio_instr_bits_wait, 2u | (polarity ? 4u : 0u), _pio_encode_irq(relative, irq));
+}
+
+/*! \brief Encode an IN instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `IN <src>, <count>`
+ *
+ * \param src The source to take data from
+ * \param count The number of bits 1-32
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_in(enum pio_src_dest src, uint count) {
+    valid_params_if(PIO_INSTRUCTIONS, !(src & _PIO_INVALID_IN_SRC));
+    return _pio_encode_instr_and_src_dest(pio_instr_bits_in, src, count);
+}
+
+/*! \brief Encode an OUT instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `OUT <src>, <count>`
+ *
+ * \param dest The destination to write data to
+ * \param count The number of bits 1-32
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_out(enum pio_src_dest dest, uint count) {
+    valid_params_if(PIO_INSTRUCTIONS, !(dest & _PIO_INVALID_OUT_DEST));
+    return _pio_encode_instr_and_src_dest(pio_instr_bits_out, dest, count);
+}
+
+/*! \brief Encode a PUSH instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `PUSH <if_full>, <block>`
+ *
+ * \param if_full true for `PUSH IF_FULL ...`, false for `PUSH ...`
+ * \param block true for `PUSH ... BLOCK`, false for `PUSH ...`
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_push(bool if_full, bool block) {
+    return _pio_encode_instr_and_args(pio_instr_bits_push, (if_full ? 2u : 0u) | (block ? 1u : 0u), 0);
+}
+
+/*! \brief Encode a PULL instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `PULL <if_empty>, <block>`
+ *
+ * \param if_empty true for `PULL IF_EMPTY ...`, false for `PULL ...`
+ * \param block true for `PULL ... BLOCK`, false for `PULL ...`
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_pull(bool if_empty, bool block) {
+    return _pio_encode_instr_and_args(pio_instr_bits_pull, (if_empty ? 2u : 0u) | (block ? 1u : 0u), 0);
+}
+
+/*! \brief Encode a MOV instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `MOV <dest>, <src>`
+ *
+ * \param dest The destination to write data to
+ * \param src The source to take data from
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_mov(enum pio_src_dest dest, enum pio_src_dest src) {
+    valid_params_if(PIO_INSTRUCTIONS, !(dest & _PIO_INVALID_MOV_DEST));
+    valid_params_if(PIO_INSTRUCTIONS, !(src & _PIO_INVALID_MOV_SRC));
+    return _pio_encode_instr_and_src_dest(pio_instr_bits_mov, dest, src & 7u);
+}
+
+/*! \brief Encode a MOV instruction with bit invert
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `MOV <dest>, ~<src>`
+ *
+ * \param dest The destination to write inverted data to
+ * \param src The source to take data from
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_mov_not(enum pio_src_dest dest, enum pio_src_dest src) {
+    valid_params_if(PIO_INSTRUCTIONS, !(dest & _PIO_INVALID_MOV_DEST));
+    valid_params_if(PIO_INSTRUCTIONS, !(src & _PIO_INVALID_MOV_SRC));
+    return _pio_encode_instr_and_src_dest(pio_instr_bits_mov, dest, (1u << 3u) | (src & 7u));
+}
+
+/*! \brief Encode a MOV instruction with bit reverse
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `MOV <dest>, ::<src>`
+ *
+ * \param dest The destination to write bit reversed data to
+ * \param src The source to take data from
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_mov_reverse(enum pio_src_dest dest, enum pio_src_dest src) {
+    valid_params_if(PIO_INSTRUCTIONS, !(dest & _PIO_INVALID_MOV_DEST));
+    valid_params_if(PIO_INSTRUCTIONS, !(src & _PIO_INVALID_MOV_SRC));
+    return _pio_encode_instr_and_src_dest(pio_instr_bits_mov, dest, (2u << 3u) | (src & 7u));
+}
+
+/*! \brief Encode a IRQ SET instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `IRQ SET <irq> <relative>`
+ *
+ * \param relative true for a `IRQ SET <irq> REL`, false for regular `IRQ SET <irq>`
+ * \param irq the irq number 0-7
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_irq_set(bool relative, uint irq) {
+    return _pio_encode_instr_and_args(pio_instr_bits_irq, 0, _pio_encode_irq(relative, irq));
+}
+
+/*! \brief Encode a IRQ WAIT instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `IRQ WAIT <irq> <relative>`
+ *
+ * \param relative true for a `IRQ WAIT <irq> REL`, false for regular `IRQ WAIT <irq>`
+ * \param irq the irq number 0-7
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_irq_wait(bool relative, uint irq) {
+    return _pio_encode_instr_and_args(pio_instr_bits_irq, 1, _pio_encode_irq(relative, irq));
+}
+
+/*! \brief Encode a IRQ CLEAR instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `IRQ CLEAR <irq> <relative>`
+ *
+ * \param relative true for a `IRQ CLEAR <irq> REL`, false for regular `IRQ CLEAR <irq>`
+ * \param irq the irq number 0-7
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_irq_clear(bool relative, uint irq) {
+    return _pio_encode_instr_and_args(pio_instr_bits_irq, 2, _pio_encode_irq(relative, irq));
+}
+
+/*! \brief Encode a SET instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `SET <dest>, <value>`
+ *
+ * \param dest The destination to apply the value to
+ * \param value The value 0-31
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_set(enum pio_src_dest dest, uint value) {
+    valid_params_if(PIO_INSTRUCTIONS, !(dest & _PIO_INVALID_SET_DEST));
+    return _pio_encode_instr_and_src_dest(pio_instr_bits_set, dest, value);
+}
+
+/*! \brief Encode a NOP instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `NOP` which is itself encoded as `MOV y, y`
+ *
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_nop(void) {
+    return pio_encode_mov(pio_y, pio_y);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/rp1/rp1_pio_vendor/piolib/include/hardware/regs/proc_pio.h
+++ b/lib/rp1/rp1_pio_vendor/piolib/include/hardware/regs/proc_pio.h
@@ -1,0 +1,3222 @@
+/**
+ * Copyright (c) 2023 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+// =============================================================================
+// Register block : PROC_PIO
+// Version        : 1
+// Bus type       : ahbl
+// Description    : Programmable IO block
+// =============================================================================
+#ifndef HARDWARE_REGS_PROC_PIO_DEFINED
+#define HARDWARE_REGS_PROC_PIO_DEFINED
+// =============================================================================
+// Register    : PROC_PIO_CTRL
+// Description : PIO control register
+#define PROC_PIO_CTRL_OFFSET _u(0x00000000)
+#define PROC_PIO_CTRL_BITS   _u(0x00000fff)
+#define PROC_PIO_CTRL_RESET  _u(0x00000000)
+#define PROC_PIO_CTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_CTRL_CLKDIV_RESTART
+// Description : Force clock dividers to restart their count and clear
+//               fractional
+//               accumulators. Restart multiple dividers to synchronise them.
+#define PROC_PIO_CTRL_CLKDIV_RESTART_RESET  _u(0x0)
+#define PROC_PIO_CTRL_CLKDIV_RESTART_BITS   _u(0x00000f00)
+#define PROC_PIO_CTRL_CLKDIV_RESTART_MSB    _u(11)
+#define PROC_PIO_CTRL_CLKDIV_RESTART_LSB    _u(8)
+#define PROC_PIO_CTRL_CLKDIV_RESTART_ACCESS "SC"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_CTRL_SM_RESTART
+// Description : Clear internal SM state which is otherwise difficult to access
+//               (e.g. shift counters). Self-clearing.
+#define PROC_PIO_CTRL_SM_RESTART_RESET  _u(0x0)
+#define PROC_PIO_CTRL_SM_RESTART_BITS   _u(0x000000f0)
+#define PROC_PIO_CTRL_SM_RESTART_MSB    _u(7)
+#define PROC_PIO_CTRL_SM_RESTART_LSB    _u(4)
+#define PROC_PIO_CTRL_SM_RESTART_ACCESS "SC"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_CTRL_SM_ENABLE
+// Description : Enable state machine
+#define PROC_PIO_CTRL_SM_ENABLE_RESET  _u(0x0)
+#define PROC_PIO_CTRL_SM_ENABLE_BITS   _u(0x0000000f)
+#define PROC_PIO_CTRL_SM_ENABLE_MSB    _u(3)
+#define PROC_PIO_CTRL_SM_ENABLE_LSB    _u(0)
+#define PROC_PIO_CTRL_SM_ENABLE_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_FSTAT
+// Description : FIFO status register
+#define PROC_PIO_FSTAT_OFFSET _u(0x00000004)
+#define PROC_PIO_FSTAT_BITS   _u(0x0f0f0f0f)
+#define PROC_PIO_FSTAT_RESET  _u(0x0f000f00)
+#define PROC_PIO_FSTAT_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FSTAT_TXEMPTY
+// Description : State machine TX FIFO is empty
+#define PROC_PIO_FSTAT_TXEMPTY_RESET  _u(0xf)
+#define PROC_PIO_FSTAT_TXEMPTY_BITS   _u(0x0f000000)
+#define PROC_PIO_FSTAT_TXEMPTY_MSB    _u(27)
+#define PROC_PIO_FSTAT_TXEMPTY_LSB    _u(24)
+#define PROC_PIO_FSTAT_TXEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FSTAT_TXFULL
+// Description : State machine TX FIFO is full
+#define PROC_PIO_FSTAT_TXFULL_RESET  _u(0x0)
+#define PROC_PIO_FSTAT_TXFULL_BITS   _u(0x000f0000)
+#define PROC_PIO_FSTAT_TXFULL_MSB    _u(19)
+#define PROC_PIO_FSTAT_TXFULL_LSB    _u(16)
+#define PROC_PIO_FSTAT_TXFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FSTAT_RXEMPTY
+// Description : State machine RX FIFO is empty
+#define PROC_PIO_FSTAT_RXEMPTY_RESET  _u(0xf)
+#define PROC_PIO_FSTAT_RXEMPTY_BITS   _u(0x00000f00)
+#define PROC_PIO_FSTAT_RXEMPTY_MSB    _u(11)
+#define PROC_PIO_FSTAT_RXEMPTY_LSB    _u(8)
+#define PROC_PIO_FSTAT_RXEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FSTAT_RXFULL
+// Description : State machine RX FIFO is full
+#define PROC_PIO_FSTAT_RXFULL_RESET  _u(0x0)
+#define PROC_PIO_FSTAT_RXFULL_BITS   _u(0x0000000f)
+#define PROC_PIO_FSTAT_RXFULL_MSB    _u(3)
+#define PROC_PIO_FSTAT_RXFULL_LSB    _u(0)
+#define PROC_PIO_FSTAT_RXFULL_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_FDEBUG
+// Description : FIFO debug register
+#define PROC_PIO_FDEBUG_OFFSET _u(0x00000008)
+#define PROC_PIO_FDEBUG_BITS   _u(0x0f0f0f0f)
+#define PROC_PIO_FDEBUG_RESET  _u(0x00000000)
+#define PROC_PIO_FDEBUG_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FDEBUG_TXSTALL
+// Description : State machine has stalled on empty TX FIFO. Write 1 to clear.
+#define PROC_PIO_FDEBUG_TXSTALL_RESET  _u(0x0)
+#define PROC_PIO_FDEBUG_TXSTALL_BITS   _u(0x0f000000)
+#define PROC_PIO_FDEBUG_TXSTALL_MSB    _u(27)
+#define PROC_PIO_FDEBUG_TXSTALL_LSB    _u(24)
+#define PROC_PIO_FDEBUG_TXSTALL_ACCESS "WC"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FDEBUG_TXOVER
+// Description : TX FIFO overflow has occurred. Write 1 to clear.
+#define PROC_PIO_FDEBUG_TXOVER_RESET  _u(0x0)
+#define PROC_PIO_FDEBUG_TXOVER_BITS   _u(0x000f0000)
+#define PROC_PIO_FDEBUG_TXOVER_MSB    _u(19)
+#define PROC_PIO_FDEBUG_TXOVER_LSB    _u(16)
+#define PROC_PIO_FDEBUG_TXOVER_ACCESS "WC"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FDEBUG_RXUNDER
+// Description : RX FIFO underflow has occurred. Write 1 to clear.
+#define PROC_PIO_FDEBUG_RXUNDER_RESET  _u(0x0)
+#define PROC_PIO_FDEBUG_RXUNDER_BITS   _u(0x00000f00)
+#define PROC_PIO_FDEBUG_RXUNDER_MSB    _u(11)
+#define PROC_PIO_FDEBUG_RXUNDER_LSB    _u(8)
+#define PROC_PIO_FDEBUG_RXUNDER_ACCESS "WC"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FDEBUG_RXSTALL
+// Description : State machine has stalled on full RX FIFO. Write 1 to clear.
+#define PROC_PIO_FDEBUG_RXSTALL_RESET  _u(0x0)
+#define PROC_PIO_FDEBUG_RXSTALL_BITS   _u(0x0000000f)
+#define PROC_PIO_FDEBUG_RXSTALL_MSB    _u(3)
+#define PROC_PIO_FDEBUG_RXSTALL_LSB    _u(0)
+#define PROC_PIO_FDEBUG_RXSTALL_ACCESS "WC"
+// =============================================================================
+// Register    : PROC_PIO_FLEVEL
+// Description : FIFO levels
+//               These count up to 15 only. When counting higher the extra bit
+//               is set in flevel2 register and this value saturates
+#define PROC_PIO_FLEVEL_OFFSET _u(0x0000000c)
+#define PROC_PIO_FLEVEL_BITS   _u(0xffffffff)
+#define PROC_PIO_FLEVEL_RESET  _u(0x00000000)
+#define PROC_PIO_FLEVEL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL_RX3
+// Description : None
+#define PROC_PIO_FLEVEL_RX3_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL_RX3_BITS   _u(0xf0000000)
+#define PROC_PIO_FLEVEL_RX3_MSB    _u(31)
+#define PROC_PIO_FLEVEL_RX3_LSB    _u(28)
+#define PROC_PIO_FLEVEL_RX3_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL_TX3
+// Description : None
+#define PROC_PIO_FLEVEL_TX3_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL_TX3_BITS   _u(0x0f000000)
+#define PROC_PIO_FLEVEL_TX3_MSB    _u(27)
+#define PROC_PIO_FLEVEL_TX3_LSB    _u(24)
+#define PROC_PIO_FLEVEL_TX3_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL_RX2
+// Description : None
+#define PROC_PIO_FLEVEL_RX2_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL_RX2_BITS   _u(0x00f00000)
+#define PROC_PIO_FLEVEL_RX2_MSB    _u(23)
+#define PROC_PIO_FLEVEL_RX2_LSB    _u(20)
+#define PROC_PIO_FLEVEL_RX2_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL_TX2
+// Description : None
+#define PROC_PIO_FLEVEL_TX2_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL_TX2_BITS   _u(0x000f0000)
+#define PROC_PIO_FLEVEL_TX2_MSB    _u(19)
+#define PROC_PIO_FLEVEL_TX2_LSB    _u(16)
+#define PROC_PIO_FLEVEL_TX2_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL_RX1
+// Description : None
+#define PROC_PIO_FLEVEL_RX1_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL_RX1_BITS   _u(0x0000f000)
+#define PROC_PIO_FLEVEL_RX1_MSB    _u(15)
+#define PROC_PIO_FLEVEL_RX1_LSB    _u(12)
+#define PROC_PIO_FLEVEL_RX1_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL_TX1
+// Description : None
+#define PROC_PIO_FLEVEL_TX1_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL_TX1_BITS   _u(0x00000f00)
+#define PROC_PIO_FLEVEL_TX1_MSB    _u(11)
+#define PROC_PIO_FLEVEL_TX1_LSB    _u(8)
+#define PROC_PIO_FLEVEL_TX1_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL_RX0
+// Description : None
+#define PROC_PIO_FLEVEL_RX0_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL_RX0_BITS   _u(0x000000f0)
+#define PROC_PIO_FLEVEL_RX0_MSB    _u(7)
+#define PROC_PIO_FLEVEL_RX0_LSB    _u(4)
+#define PROC_PIO_FLEVEL_RX0_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL_TX0
+// Description : None
+#define PROC_PIO_FLEVEL_TX0_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL_TX0_BITS   _u(0x0000000f)
+#define PROC_PIO_FLEVEL_TX0_MSB    _u(3)
+#define PROC_PIO_FLEVEL_TX0_LSB    _u(0)
+#define PROC_PIO_FLEVEL_TX0_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_FLEVEL2
+// Description : FIFO level extra bits
+//               These are only used in double fifo mode, and the fifo has more
+//               than 15 elements
+#define PROC_PIO_FLEVEL2_OFFSET _u(0x00000010)
+#define PROC_PIO_FLEVEL2_BITS   _u(0x11111111)
+#define PROC_PIO_FLEVEL2_RESET  _u(0x00000000)
+#define PROC_PIO_FLEVEL2_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL2_RX3
+// Description : None
+#define PROC_PIO_FLEVEL2_RX3_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL2_RX3_BITS   _u(0x10000000)
+#define PROC_PIO_FLEVEL2_RX3_MSB    _u(28)
+#define PROC_PIO_FLEVEL2_RX3_LSB    _u(28)
+#define PROC_PIO_FLEVEL2_RX3_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL2_TX3
+// Description : None
+#define PROC_PIO_FLEVEL2_TX3_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL2_TX3_BITS   _u(0x01000000)
+#define PROC_PIO_FLEVEL2_TX3_MSB    _u(24)
+#define PROC_PIO_FLEVEL2_TX3_LSB    _u(24)
+#define PROC_PIO_FLEVEL2_TX3_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL2_RX2
+// Description : None
+#define PROC_PIO_FLEVEL2_RX2_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL2_RX2_BITS   _u(0x00100000)
+#define PROC_PIO_FLEVEL2_RX2_MSB    _u(20)
+#define PROC_PIO_FLEVEL2_RX2_LSB    _u(20)
+#define PROC_PIO_FLEVEL2_RX2_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL2_TX2
+// Description : None
+#define PROC_PIO_FLEVEL2_TX2_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL2_TX2_BITS   _u(0x00010000)
+#define PROC_PIO_FLEVEL2_TX2_MSB    _u(16)
+#define PROC_PIO_FLEVEL2_TX2_LSB    _u(16)
+#define PROC_PIO_FLEVEL2_TX2_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL2_RX1
+// Description : None
+#define PROC_PIO_FLEVEL2_RX1_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL2_RX1_BITS   _u(0x00001000)
+#define PROC_PIO_FLEVEL2_RX1_MSB    _u(12)
+#define PROC_PIO_FLEVEL2_RX1_LSB    _u(12)
+#define PROC_PIO_FLEVEL2_RX1_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL2_TX1
+// Description : None
+#define PROC_PIO_FLEVEL2_TX1_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL2_TX1_BITS   _u(0x00000100)
+#define PROC_PIO_FLEVEL2_TX1_MSB    _u(8)
+#define PROC_PIO_FLEVEL2_TX1_LSB    _u(8)
+#define PROC_PIO_FLEVEL2_TX1_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL2_RX0
+// Description : None
+#define PROC_PIO_FLEVEL2_RX0_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL2_RX0_BITS   _u(0x00000010)
+#define PROC_PIO_FLEVEL2_RX0_MSB    _u(4)
+#define PROC_PIO_FLEVEL2_RX0_LSB    _u(4)
+#define PROC_PIO_FLEVEL2_RX0_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_FLEVEL2_TX0
+// Description : None
+#define PROC_PIO_FLEVEL2_TX0_RESET  _u(0x0)
+#define PROC_PIO_FLEVEL2_TX0_BITS   _u(0x00000001)
+#define PROC_PIO_FLEVEL2_TX0_MSB    _u(0)
+#define PROC_PIO_FLEVEL2_TX0_LSB    _u(0)
+#define PROC_PIO_FLEVEL2_TX0_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_TXF0
+// Description : Direct write access to the TX FIFO for this state machine. Each
+//               write pushes one word to the FIFO.
+#define PROC_PIO_TXF0_OFFSET _u(0x00000014)
+#define PROC_PIO_TXF0_BITS   _u(0xffffffff)
+#define PROC_PIO_TXF0_RESET  _u(0x00000000)
+#define PROC_PIO_TXF0_WIDTH  _u(32)
+#define PROC_PIO_TXF0_MSB    _u(31)
+#define PROC_PIO_TXF0_LSB    _u(0)
+#define PROC_PIO_TXF0_ACCESS "WF"
+// =============================================================================
+// Register    : PROC_PIO_TXF1
+// Description : Direct write access to the TX FIFO for this state machine. Each
+//               write pushes one word to the FIFO.
+#define PROC_PIO_TXF1_OFFSET _u(0x00000018)
+#define PROC_PIO_TXF1_BITS   _u(0xffffffff)
+#define PROC_PIO_TXF1_RESET  _u(0x00000000)
+#define PROC_PIO_TXF1_WIDTH  _u(32)
+#define PROC_PIO_TXF1_MSB    _u(31)
+#define PROC_PIO_TXF1_LSB    _u(0)
+#define PROC_PIO_TXF1_ACCESS "WF"
+// =============================================================================
+// Register    : PROC_PIO_TXF2
+// Description : Direct write access to the TX FIFO for this state machine. Each
+//               write pushes one word to the FIFO.
+#define PROC_PIO_TXF2_OFFSET _u(0x0000001c)
+#define PROC_PIO_TXF2_BITS   _u(0xffffffff)
+#define PROC_PIO_TXF2_RESET  _u(0x00000000)
+#define PROC_PIO_TXF2_WIDTH  _u(32)
+#define PROC_PIO_TXF2_MSB    _u(31)
+#define PROC_PIO_TXF2_LSB    _u(0)
+#define PROC_PIO_TXF2_ACCESS "WF"
+// =============================================================================
+// Register    : PROC_PIO_TXF3
+// Description : Direct write access to the TX FIFO for this state machine. Each
+//               write pushes one word to the FIFO.
+#define PROC_PIO_TXF3_OFFSET _u(0x00000020)
+#define PROC_PIO_TXF3_BITS   _u(0xffffffff)
+#define PROC_PIO_TXF3_RESET  _u(0x00000000)
+#define PROC_PIO_TXF3_WIDTH  _u(32)
+#define PROC_PIO_TXF3_MSB    _u(31)
+#define PROC_PIO_TXF3_LSB    _u(0)
+#define PROC_PIO_TXF3_ACCESS "WF"
+// =============================================================================
+// Register    : PROC_PIO_RXF0
+// Description : Direct read access to the RX FIFO for this state machine. Each
+//               read pops one word from the FIFO.
+#define PROC_PIO_RXF0_OFFSET _u(0x00000024)
+#define PROC_PIO_RXF0_BITS   _u(0xffffffff)
+#define PROC_PIO_RXF0_RESET  "-"
+#define PROC_PIO_RXF0_WIDTH  _u(32)
+#define PROC_PIO_RXF0_MSB    _u(31)
+#define PROC_PIO_RXF0_LSB    _u(0)
+#define PROC_PIO_RXF0_ACCESS "RF"
+// =============================================================================
+// Register    : PROC_PIO_RXF1
+// Description : Direct read access to the RX FIFO for this state machine. Each
+//               read pops one word from the FIFO.
+#define PROC_PIO_RXF1_OFFSET _u(0x00000028)
+#define PROC_PIO_RXF1_BITS   _u(0xffffffff)
+#define PROC_PIO_RXF1_RESET  "-"
+#define PROC_PIO_RXF1_WIDTH  _u(32)
+#define PROC_PIO_RXF1_MSB    _u(31)
+#define PROC_PIO_RXF1_LSB    _u(0)
+#define PROC_PIO_RXF1_ACCESS "RF"
+// =============================================================================
+// Register    : PROC_PIO_RXF2
+// Description : Direct read access to the RX FIFO for this state machine. Each
+//               read pops one word from the FIFO.
+#define PROC_PIO_RXF2_OFFSET _u(0x0000002c)
+#define PROC_PIO_RXF2_BITS   _u(0xffffffff)
+#define PROC_PIO_RXF2_RESET  "-"
+#define PROC_PIO_RXF2_WIDTH  _u(32)
+#define PROC_PIO_RXF2_MSB    _u(31)
+#define PROC_PIO_RXF2_LSB    _u(0)
+#define PROC_PIO_RXF2_ACCESS "RF"
+// =============================================================================
+// Register    : PROC_PIO_RXF3
+// Description : Direct read access to the RX FIFO for this state machine. Each
+//               read pops one word from the FIFO.
+#define PROC_PIO_RXF3_OFFSET _u(0x00000030)
+#define PROC_PIO_RXF3_BITS   _u(0xffffffff)
+#define PROC_PIO_RXF3_RESET  "-"
+#define PROC_PIO_RXF3_WIDTH  _u(32)
+#define PROC_PIO_RXF3_MSB    _u(31)
+#define PROC_PIO_RXF3_LSB    _u(0)
+#define PROC_PIO_RXF3_ACCESS "RF"
+// =============================================================================
+// Register    : PROC_PIO_IRQ
+// Description : Interrupt request register. Write 1 to clear
+#define PROC_PIO_IRQ_OFFSET _u(0x00000034)
+#define PROC_PIO_IRQ_BITS   _u(0x000000ff)
+#define PROC_PIO_IRQ_RESET  _u(0x00000000)
+#define PROC_PIO_IRQ_WIDTH  _u(32)
+#define PROC_PIO_IRQ_MSB    _u(7)
+#define PROC_PIO_IRQ_LSB    _u(0)
+#define PROC_PIO_IRQ_ACCESS "WC"
+// =============================================================================
+// Register    : PROC_PIO_IRQ_FORCE
+// Description : Writing a 1 to each of these bits will forcibly assert the
+//               corresponding IRQ.
+//               Note this is different to the INTF register: writing here
+//               affects PIO internal
+//               state. INTF just asserts the processor-facing IRQ signal for
+//               testing ISRs,
+//               and is not visible to the state machines.
+#define PROC_PIO_IRQ_FORCE_OFFSET _u(0x00000038)
+#define PROC_PIO_IRQ_FORCE_BITS   _u(0x000000ff)
+#define PROC_PIO_IRQ_FORCE_RESET  _u(0x00000000)
+#define PROC_PIO_IRQ_FORCE_WIDTH  _u(32)
+#define PROC_PIO_IRQ_FORCE_MSB    _u(7)
+#define PROC_PIO_IRQ_FORCE_LSB    _u(0)
+#define PROC_PIO_IRQ_FORCE_ACCESS "WF"
+// =============================================================================
+// Register    : PROC_PIO_INPUT_SYNC_BYPASS
+// Description : There is a 2-flipflop synchronizer on each GPIO input, which
+//               protects
+//               PIO logic from metastabilities. This increases input delay, and
+//               for fast
+//               synchronous IO (e.g. SPI) these synchronizers may need to be
+//               bypassed.
+//               Each bit in this register corresponds to one GPIO.
+//               0 -> input is synchronized (default)
+//               1 -> synchronizer is bypassed
+//               If in doubt, leave this register as all zeroes.
+#define PROC_PIO_INPUT_SYNC_BYPASS_OFFSET _u(0x0000003c)
+#define PROC_PIO_INPUT_SYNC_BYPASS_BITS   _u(0xffffffff)
+#define PROC_PIO_INPUT_SYNC_BYPASS_RESET  _u(0x00000000)
+#define PROC_PIO_INPUT_SYNC_BYPASS_WIDTH  _u(32)
+#define PROC_PIO_INPUT_SYNC_BYPASS_MSB    _u(31)
+#define PROC_PIO_INPUT_SYNC_BYPASS_LSB    _u(0)
+#define PROC_PIO_INPUT_SYNC_BYPASS_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_DBG_PADOUT
+// Description : Read to sample the pad output values PIO is currently driving
+//               to the GPIOs.
+#define PROC_PIO_DBG_PADOUT_OFFSET _u(0x00000040)
+#define PROC_PIO_DBG_PADOUT_BITS   _u(0xffffffff)
+#define PROC_PIO_DBG_PADOUT_RESET  _u(0x00000000)
+#define PROC_PIO_DBG_PADOUT_WIDTH  _u(32)
+#define PROC_PIO_DBG_PADOUT_MSB    _u(31)
+#define PROC_PIO_DBG_PADOUT_LSB    _u(0)
+#define PROC_PIO_DBG_PADOUT_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_DBG_PADOE
+// Description : Read to sample the pad output enables (direction) PIO is
+//               currently driving to the GPIOs.
+#define PROC_PIO_DBG_PADOE_OFFSET _u(0x00000044)
+#define PROC_PIO_DBG_PADOE_BITS   _u(0xffffffff)
+#define PROC_PIO_DBG_PADOE_RESET  _u(0x00000000)
+#define PROC_PIO_DBG_PADOE_WIDTH  _u(32)
+#define PROC_PIO_DBG_PADOE_MSB    _u(31)
+#define PROC_PIO_DBG_PADOE_LSB    _u(0)
+#define PROC_PIO_DBG_PADOE_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_DBG_CFGINFO
+// Description : The PIO hardware has some free parameters that may vary between
+//               chip products.
+//               These should be provided in the chip datasheet, but are also
+//               exposed here.
+#define PROC_PIO_DBG_CFGINFO_OFFSET _u(0x00000048)
+#define PROC_PIO_DBG_CFGINFO_BITS   _u(0x003f0f3f)
+#define PROC_PIO_DBG_CFGINFO_RESET  _u(0x00000000)
+#define PROC_PIO_DBG_CFGINFO_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_DBG_CFGINFO_IMEM_SIZE
+// Description : The size of the instruction memory, measured in units of one
+//               instruction
+#define PROC_PIO_DBG_CFGINFO_IMEM_SIZE_RESET  "-"
+#define PROC_PIO_DBG_CFGINFO_IMEM_SIZE_BITS   _u(0x003f0000)
+#define PROC_PIO_DBG_CFGINFO_IMEM_SIZE_MSB    _u(21)
+#define PROC_PIO_DBG_CFGINFO_IMEM_SIZE_LSB    _u(16)
+#define PROC_PIO_DBG_CFGINFO_IMEM_SIZE_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_DBG_CFGINFO_SM_COUNT
+// Description : The number of state machines this PIO instance is equipped
+//               with.
+#define PROC_PIO_DBG_CFGINFO_SM_COUNT_RESET  "-"
+#define PROC_PIO_DBG_CFGINFO_SM_COUNT_BITS   _u(0x00000f00)
+#define PROC_PIO_DBG_CFGINFO_SM_COUNT_MSB    _u(11)
+#define PROC_PIO_DBG_CFGINFO_SM_COUNT_LSB    _u(8)
+#define PROC_PIO_DBG_CFGINFO_SM_COUNT_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_DBG_CFGINFO_FIFO_DEPTH
+// Description : The depth of the state machine TX/RX FIFOs, measured in words.
+//               Joining fifos via SHIFTCTRL_FJOIN gives one FIFO with double
+//               this depth.
+#define PROC_PIO_DBG_CFGINFO_FIFO_DEPTH_RESET  "-"
+#define PROC_PIO_DBG_CFGINFO_FIFO_DEPTH_BITS   _u(0x0000003f)
+#define PROC_PIO_DBG_CFGINFO_FIFO_DEPTH_MSB    _u(5)
+#define PROC_PIO_DBG_CFGINFO_FIFO_DEPTH_LSB    _u(0)
+#define PROC_PIO_DBG_CFGINFO_FIFO_DEPTH_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM0
+// Description : Write-only access to instruction memory location 0
+#define PROC_PIO_INSTR_MEM0_OFFSET _u(0x0000004c)
+#define PROC_PIO_INSTR_MEM0_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM0_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM0_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM0_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM0_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM0_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM1
+// Description : Write-only access to instruction memory location 1
+#define PROC_PIO_INSTR_MEM1_OFFSET _u(0x00000050)
+#define PROC_PIO_INSTR_MEM1_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM1_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM1_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM1_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM1_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM1_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM2
+// Description : Write-only access to instruction memory location 2
+#define PROC_PIO_INSTR_MEM2_OFFSET _u(0x00000054)
+#define PROC_PIO_INSTR_MEM2_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM2_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM2_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM2_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM2_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM2_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM3
+// Description : Write-only access to instruction memory location 3
+#define PROC_PIO_INSTR_MEM3_OFFSET _u(0x00000058)
+#define PROC_PIO_INSTR_MEM3_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM3_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM3_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM3_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM3_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM3_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM4
+// Description : Write-only access to instruction memory location 4
+#define PROC_PIO_INSTR_MEM4_OFFSET _u(0x0000005c)
+#define PROC_PIO_INSTR_MEM4_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM4_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM4_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM4_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM4_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM4_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM5
+// Description : Write-only access to instruction memory location 5
+#define PROC_PIO_INSTR_MEM5_OFFSET _u(0x00000060)
+#define PROC_PIO_INSTR_MEM5_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM5_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM5_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM5_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM5_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM5_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM6
+// Description : Write-only access to instruction memory location 6
+#define PROC_PIO_INSTR_MEM6_OFFSET _u(0x00000064)
+#define PROC_PIO_INSTR_MEM6_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM6_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM6_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM6_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM6_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM6_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM7
+// Description : Write-only access to instruction memory location 7
+#define PROC_PIO_INSTR_MEM7_OFFSET _u(0x00000068)
+#define PROC_PIO_INSTR_MEM7_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM7_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM7_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM7_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM7_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM7_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM8
+// Description : Write-only access to instruction memory location 8
+#define PROC_PIO_INSTR_MEM8_OFFSET _u(0x0000006c)
+#define PROC_PIO_INSTR_MEM8_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM8_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM8_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM8_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM8_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM8_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM9
+// Description : Write-only access to instruction memory location 9
+#define PROC_PIO_INSTR_MEM9_OFFSET _u(0x00000070)
+#define PROC_PIO_INSTR_MEM9_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM9_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM9_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM9_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM9_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM9_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM10
+// Description : Write-only access to instruction memory location 10
+#define PROC_PIO_INSTR_MEM10_OFFSET _u(0x00000074)
+#define PROC_PIO_INSTR_MEM10_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM10_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM10_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM10_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM10_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM10_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM11
+// Description : Write-only access to instruction memory location 11
+#define PROC_PIO_INSTR_MEM11_OFFSET _u(0x00000078)
+#define PROC_PIO_INSTR_MEM11_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM11_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM11_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM11_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM11_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM11_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM12
+// Description : Write-only access to instruction memory location 12
+#define PROC_PIO_INSTR_MEM12_OFFSET _u(0x0000007c)
+#define PROC_PIO_INSTR_MEM12_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM12_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM12_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM12_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM12_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM12_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM13
+// Description : Write-only access to instruction memory location 13
+#define PROC_PIO_INSTR_MEM13_OFFSET _u(0x00000080)
+#define PROC_PIO_INSTR_MEM13_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM13_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM13_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM13_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM13_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM13_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM14
+// Description : Write-only access to instruction memory location 14
+#define PROC_PIO_INSTR_MEM14_OFFSET _u(0x00000084)
+#define PROC_PIO_INSTR_MEM14_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM14_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM14_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM14_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM14_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM14_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM15
+// Description : Write-only access to instruction memory location 15
+#define PROC_PIO_INSTR_MEM15_OFFSET _u(0x00000088)
+#define PROC_PIO_INSTR_MEM15_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM15_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM15_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM15_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM15_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM15_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM16
+// Description : Write-only access to instruction memory location 16
+#define PROC_PIO_INSTR_MEM16_OFFSET _u(0x0000008c)
+#define PROC_PIO_INSTR_MEM16_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM16_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM16_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM16_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM16_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM16_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM17
+// Description : Write-only access to instruction memory location 17
+#define PROC_PIO_INSTR_MEM17_OFFSET _u(0x00000090)
+#define PROC_PIO_INSTR_MEM17_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM17_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM17_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM17_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM17_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM17_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM18
+// Description : Write-only access to instruction memory location 18
+#define PROC_PIO_INSTR_MEM18_OFFSET _u(0x00000094)
+#define PROC_PIO_INSTR_MEM18_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM18_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM18_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM18_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM18_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM18_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM19
+// Description : Write-only access to instruction memory location 19
+#define PROC_PIO_INSTR_MEM19_OFFSET _u(0x00000098)
+#define PROC_PIO_INSTR_MEM19_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM19_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM19_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM19_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM19_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM19_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM20
+// Description : Write-only access to instruction memory location 20
+#define PROC_PIO_INSTR_MEM20_OFFSET _u(0x0000009c)
+#define PROC_PIO_INSTR_MEM20_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM20_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM20_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM20_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM20_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM20_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM21
+// Description : Write-only access to instruction memory location 21
+#define PROC_PIO_INSTR_MEM21_OFFSET _u(0x000000a0)
+#define PROC_PIO_INSTR_MEM21_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM21_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM21_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM21_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM21_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM21_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM22
+// Description : Write-only access to instruction memory location 22
+#define PROC_PIO_INSTR_MEM22_OFFSET _u(0x000000a4)
+#define PROC_PIO_INSTR_MEM22_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM22_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM22_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM22_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM22_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM22_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM23
+// Description : Write-only access to instruction memory location 23
+#define PROC_PIO_INSTR_MEM23_OFFSET _u(0x000000a8)
+#define PROC_PIO_INSTR_MEM23_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM23_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM23_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM23_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM23_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM23_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM24
+// Description : Write-only access to instruction memory location 24
+#define PROC_PIO_INSTR_MEM24_OFFSET _u(0x000000ac)
+#define PROC_PIO_INSTR_MEM24_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM24_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM24_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM24_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM24_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM24_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM25
+// Description : Write-only access to instruction memory location 25
+#define PROC_PIO_INSTR_MEM25_OFFSET _u(0x000000b0)
+#define PROC_PIO_INSTR_MEM25_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM25_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM25_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM25_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM25_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM25_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM26
+// Description : Write-only access to instruction memory location 26
+#define PROC_PIO_INSTR_MEM26_OFFSET _u(0x000000b4)
+#define PROC_PIO_INSTR_MEM26_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM26_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM26_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM26_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM26_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM26_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM27
+// Description : Write-only access to instruction memory location 27
+#define PROC_PIO_INSTR_MEM27_OFFSET _u(0x000000b8)
+#define PROC_PIO_INSTR_MEM27_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM27_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM27_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM27_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM27_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM27_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM28
+// Description : Write-only access to instruction memory location 28
+#define PROC_PIO_INSTR_MEM28_OFFSET _u(0x000000bc)
+#define PROC_PIO_INSTR_MEM28_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM28_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM28_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM28_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM28_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM28_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM29
+// Description : Write-only access to instruction memory location 29
+#define PROC_PIO_INSTR_MEM29_OFFSET _u(0x000000c0)
+#define PROC_PIO_INSTR_MEM29_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM29_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM29_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM29_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM29_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM29_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM30
+// Description : Write-only access to instruction memory location 30
+#define PROC_PIO_INSTR_MEM30_OFFSET _u(0x000000c4)
+#define PROC_PIO_INSTR_MEM30_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM30_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM30_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM30_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM30_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM30_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_INSTR_MEM31
+// Description : Write-only access to instruction memory location 31
+#define PROC_PIO_INSTR_MEM31_OFFSET _u(0x000000c8)
+#define PROC_PIO_INSTR_MEM31_BITS   _u(0x0000ffff)
+#define PROC_PIO_INSTR_MEM31_RESET  _u(0x00000000)
+#define PROC_PIO_INSTR_MEM31_WIDTH  _u(32)
+#define PROC_PIO_INSTR_MEM31_MSB    _u(15)
+#define PROC_PIO_INSTR_MEM31_LSB    _u(0)
+#define PROC_PIO_INSTR_MEM31_ACCESS "WO"
+// =============================================================================
+// Register    : PROC_PIO_SM0_CLKDIV
+// Description : Clock divider register for state machine 0
+//               Frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
+#define PROC_PIO_SM0_CLKDIV_OFFSET _u(0x000000cc)
+#define PROC_PIO_SM0_CLKDIV_BITS   _u(0xffffff00)
+#define PROC_PIO_SM0_CLKDIV_RESET  _u(0x00010000)
+#define PROC_PIO_SM0_CLKDIV_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_CLKDIV_INT
+// Description : Effective frequency is sysclk/int.
+//               Value of 0 is interpreted as max possible value
+#define PROC_PIO_SM0_CLKDIV_INT_RESET  _u(0x0001)
+#define PROC_PIO_SM0_CLKDIV_INT_BITS   _u(0xffff0000)
+#define PROC_PIO_SM0_CLKDIV_INT_MSB    _u(31)
+#define PROC_PIO_SM0_CLKDIV_INT_LSB    _u(16)
+#define PROC_PIO_SM0_CLKDIV_INT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_CLKDIV_FRAC
+// Description : Fractional part of clock divider
+#define PROC_PIO_SM0_CLKDIV_FRAC_RESET  _u(0x00)
+#define PROC_PIO_SM0_CLKDIV_FRAC_BITS   _u(0x0000ff00)
+#define PROC_PIO_SM0_CLKDIV_FRAC_MSB    _u(15)
+#define PROC_PIO_SM0_CLKDIV_FRAC_LSB    _u(8)
+#define PROC_PIO_SM0_CLKDIV_FRAC_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM0_EXECCTRL
+// Description : Execution/behavioural settings for state machine 0
+#define PROC_PIO_SM0_EXECCTRL_OFFSET _u(0x000000d0)
+#define PROC_PIO_SM0_EXECCTRL_BITS   _u(0xffffffbf)
+#define PROC_PIO_SM0_EXECCTRL_RESET  _u(0x0001f000)
+#define PROC_PIO_SM0_EXECCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_EXEC_STALLED
+// Description : An instruction written to SMx_INSTR is stalled, and latched by
+//               the
+//               state machine. Will clear once the instruction completes.
+#define PROC_PIO_SM0_EXECCTRL_EXEC_STALLED_RESET  _u(0x0)
+#define PROC_PIO_SM0_EXECCTRL_EXEC_STALLED_BITS   _u(0x80000000)
+#define PROC_PIO_SM0_EXECCTRL_EXEC_STALLED_MSB    _u(31)
+#define PROC_PIO_SM0_EXECCTRL_EXEC_STALLED_LSB    _u(31)
+#define PROC_PIO_SM0_EXECCTRL_EXEC_STALLED_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_SIDE_EN
+// Description : If 1, the delay MSB is used as side-set enable, rather than a
+//               side-set data bit. This allows instructions to perform side-set
+//               optionally,
+//               rather than on every instruction.
+#define PROC_PIO_SM0_EXECCTRL_SIDE_EN_RESET  _u(0x0)
+#define PROC_PIO_SM0_EXECCTRL_SIDE_EN_BITS   _u(0x40000000)
+#define PROC_PIO_SM0_EXECCTRL_SIDE_EN_MSB    _u(30)
+#define PROC_PIO_SM0_EXECCTRL_SIDE_EN_LSB    _u(30)
+#define PROC_PIO_SM0_EXECCTRL_SIDE_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_SIDE_PINDIR
+// Description : Side-set data is asserted to pin OEs instead of pin values
+#define PROC_PIO_SM0_EXECCTRL_SIDE_PINDIR_RESET  _u(0x0)
+#define PROC_PIO_SM0_EXECCTRL_SIDE_PINDIR_BITS   _u(0x20000000)
+#define PROC_PIO_SM0_EXECCTRL_SIDE_PINDIR_MSB    _u(29)
+#define PROC_PIO_SM0_EXECCTRL_SIDE_PINDIR_LSB    _u(29)
+#define PROC_PIO_SM0_EXECCTRL_SIDE_PINDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_JMP_PIN
+// Description : The GPIO number to use as condition for JMP PIN. Unaffected by
+//               input mapping.
+#define PROC_PIO_SM0_EXECCTRL_JMP_PIN_RESET  _u(0x00)
+#define PROC_PIO_SM0_EXECCTRL_JMP_PIN_BITS   _u(0x1f000000)
+#define PROC_PIO_SM0_EXECCTRL_JMP_PIN_MSB    _u(28)
+#define PROC_PIO_SM0_EXECCTRL_JMP_PIN_LSB    _u(24)
+#define PROC_PIO_SM0_EXECCTRL_JMP_PIN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_OUT_EN_SEL
+// Description : Which data bit to use for inline OUT enable
+#define PROC_PIO_SM0_EXECCTRL_OUT_EN_SEL_RESET  _u(0x00)
+#define PROC_PIO_SM0_EXECCTRL_OUT_EN_SEL_BITS   _u(0x00f80000)
+#define PROC_PIO_SM0_EXECCTRL_OUT_EN_SEL_MSB    _u(23)
+#define PROC_PIO_SM0_EXECCTRL_OUT_EN_SEL_LSB    _u(19)
+#define PROC_PIO_SM0_EXECCTRL_OUT_EN_SEL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_INLINE_OUT_EN
+// Description : If 1, use a bit of OUT data as an auxiliary write enable
+//               When used in conjunction with OUT_STICKY, writes with an enable
+//               of 0 will
+//               deassert the latest pin write. This can create useful
+//               masking/override behaviour
+//               due to the priority ordering of state machine pin writes (SM0 <
+//               SM1 < ...)
+#define PROC_PIO_SM0_EXECCTRL_INLINE_OUT_EN_RESET  _u(0x0)
+#define PROC_PIO_SM0_EXECCTRL_INLINE_OUT_EN_BITS   _u(0x00040000)
+#define PROC_PIO_SM0_EXECCTRL_INLINE_OUT_EN_MSB    _u(18)
+#define PROC_PIO_SM0_EXECCTRL_INLINE_OUT_EN_LSB    _u(18)
+#define PROC_PIO_SM0_EXECCTRL_INLINE_OUT_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_OUT_STICKY
+// Description : Continuously assert the most recent OUT/SET to the pins
+#define PROC_PIO_SM0_EXECCTRL_OUT_STICKY_RESET  _u(0x0)
+#define PROC_PIO_SM0_EXECCTRL_OUT_STICKY_BITS   _u(0x00020000)
+#define PROC_PIO_SM0_EXECCTRL_OUT_STICKY_MSB    _u(17)
+#define PROC_PIO_SM0_EXECCTRL_OUT_STICKY_LSB    _u(17)
+#define PROC_PIO_SM0_EXECCTRL_OUT_STICKY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_WRAP_TOP
+// Description : After reaching this address, execution is wrapped to
+//               wrap_bottom.
+//               If the instruction is a jump, and the jump condition is true,
+//               the jump takes priority.
+#define PROC_PIO_SM0_EXECCTRL_WRAP_TOP_RESET  _u(0x1f)
+#define PROC_PIO_SM0_EXECCTRL_WRAP_TOP_BITS   _u(0x0001f000)
+#define PROC_PIO_SM0_EXECCTRL_WRAP_TOP_MSB    _u(16)
+#define PROC_PIO_SM0_EXECCTRL_WRAP_TOP_LSB    _u(12)
+#define PROC_PIO_SM0_EXECCTRL_WRAP_TOP_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_WRAP_BOTTOM
+// Description : After reaching wrap_top, execution is wrapped to this address.
+#define PROC_PIO_SM0_EXECCTRL_WRAP_BOTTOM_RESET  _u(0x00)
+#define PROC_PIO_SM0_EXECCTRL_WRAP_BOTTOM_BITS   _u(0x00000f80)
+#define PROC_PIO_SM0_EXECCTRL_WRAP_BOTTOM_MSB    _u(11)
+#define PROC_PIO_SM0_EXECCTRL_WRAP_BOTTOM_LSB    _u(7)
+#define PROC_PIO_SM0_EXECCTRL_WRAP_BOTTOM_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_STATUS_SEL
+// Description : Comparison used for the MOV x, STATUS instruction.
+//               0x0 -> All-ones if TX FIFO level < N, otherwise all-zeroes
+//               0x1 -> All-ones if RX FIFO level < N, otherwise all-zeroes
+#define PROC_PIO_SM0_EXECCTRL_STATUS_SEL_RESET         _u(0x0)
+#define PROC_PIO_SM0_EXECCTRL_STATUS_SEL_BITS          _u(0x00000020)
+#define PROC_PIO_SM0_EXECCTRL_STATUS_SEL_MSB           _u(5)
+#define PROC_PIO_SM0_EXECCTRL_STATUS_SEL_LSB           _u(5)
+#define PROC_PIO_SM0_EXECCTRL_STATUS_SEL_ACCESS        "RW"
+#define PROC_PIO_SM0_EXECCTRL_STATUS_SEL_VALUE_TXLEVEL _u(0x0)
+#define PROC_PIO_SM0_EXECCTRL_STATUS_SEL_VALUE_RXLEVEL _u(0x1)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_EXECCTRL_STATUS_N
+// Description : Comparison level for the MOV x, STATUS instruction
+#define PROC_PIO_SM0_EXECCTRL_STATUS_N_RESET  _u(0x00)
+#define PROC_PIO_SM0_EXECCTRL_STATUS_N_BITS   _u(0x0000001f)
+#define PROC_PIO_SM0_EXECCTRL_STATUS_N_MSB    _u(4)
+#define PROC_PIO_SM0_EXECCTRL_STATUS_N_LSB    _u(0)
+#define PROC_PIO_SM0_EXECCTRL_STATUS_N_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM0_SHIFTCTRL
+// Description : Control behaviour of the input/output shift registers for state
+//               machine 0
+#define PROC_PIO_SM0_SHIFTCTRL_OFFSET _u(0x000000d4)
+#define PROC_PIO_SM0_SHIFTCTRL_BITS   _u(0xffff0000)
+#define PROC_PIO_SM0_SHIFTCTRL_RESET  _u(0x000c0000)
+#define PROC_PIO_SM0_SHIFTCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_SHIFTCTRL_FJOIN_RX
+// Description : When 1, RX FIFO steals the TX FIFO's storage, and becomes twice
+//               as deep.
+//               TX FIFO is disabled as a result (always reads as both full and
+//               empty).
+//               FIFOs are flushed when this bit is changed.
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_RX_RESET  _u(0x0)
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_RX_BITS   _u(0x80000000)
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_RX_MSB    _u(31)
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_RX_LSB    _u(31)
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_RX_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_SHIFTCTRL_FJOIN_TX
+// Description : When 1, TX FIFO steals the RX FIFO's storage, and becomes twice
+//               as deep.
+//               RX FIFO is disabled as a result (always reads as both full and
+//               empty).
+//               FIFOs are flushed when this bit is changed.
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_TX_RESET  _u(0x0)
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_TX_BITS   _u(0x40000000)
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_TX_MSB    _u(30)
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_TX_LSB    _u(30)
+#define PROC_PIO_SM0_SHIFTCTRL_FJOIN_TX_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_SHIFTCTRL_PULL_THRESH
+// Description : Number of bits shifted out of TXSR before autopull or
+//               conditional pull.
+//               Write 0 for value of 32.
+#define PROC_PIO_SM0_SHIFTCTRL_PULL_THRESH_RESET  _u(0x00)
+#define PROC_PIO_SM0_SHIFTCTRL_PULL_THRESH_BITS   _u(0x3e000000)
+#define PROC_PIO_SM0_SHIFTCTRL_PULL_THRESH_MSB    _u(29)
+#define PROC_PIO_SM0_SHIFTCTRL_PULL_THRESH_LSB    _u(25)
+#define PROC_PIO_SM0_SHIFTCTRL_PULL_THRESH_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_SHIFTCTRL_PUSH_THRESH
+// Description : Number of bits shifted into RXSR before autopush or conditional
+//               push.
+//               Write 0 for value of 32.
+#define PROC_PIO_SM0_SHIFTCTRL_PUSH_THRESH_RESET  _u(0x00)
+#define PROC_PIO_SM0_SHIFTCTRL_PUSH_THRESH_BITS   _u(0x01f00000)
+#define PROC_PIO_SM0_SHIFTCTRL_PUSH_THRESH_MSB    _u(24)
+#define PROC_PIO_SM0_SHIFTCTRL_PUSH_THRESH_LSB    _u(20)
+#define PROC_PIO_SM0_SHIFTCTRL_PUSH_THRESH_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_SHIFTCTRL_OUT_SHIFTDIR
+// Description : 1 = shift out of output shift register to right. 0 = to left.
+#define PROC_PIO_SM0_SHIFTCTRL_OUT_SHIFTDIR_RESET  _u(0x1)
+#define PROC_PIO_SM0_SHIFTCTRL_OUT_SHIFTDIR_BITS   _u(0x00080000)
+#define PROC_PIO_SM0_SHIFTCTRL_OUT_SHIFTDIR_MSB    _u(19)
+#define PROC_PIO_SM0_SHIFTCTRL_OUT_SHIFTDIR_LSB    _u(19)
+#define PROC_PIO_SM0_SHIFTCTRL_OUT_SHIFTDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_SHIFTCTRL_IN_SHIFTDIR
+// Description : 1 = shift input shift register to right (data enters from
+//               left). 0 = to left.
+#define PROC_PIO_SM0_SHIFTCTRL_IN_SHIFTDIR_RESET  _u(0x1)
+#define PROC_PIO_SM0_SHIFTCTRL_IN_SHIFTDIR_BITS   _u(0x00040000)
+#define PROC_PIO_SM0_SHIFTCTRL_IN_SHIFTDIR_MSB    _u(18)
+#define PROC_PIO_SM0_SHIFTCTRL_IN_SHIFTDIR_LSB    _u(18)
+#define PROC_PIO_SM0_SHIFTCTRL_IN_SHIFTDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_SHIFTCTRL_AUTOPULL
+// Description : Pull automatically when the output shift register is emptied
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPULL_RESET  _u(0x0)
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPULL_BITS   _u(0x00020000)
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPULL_MSB    _u(17)
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPULL_LSB    _u(17)
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_SHIFTCTRL_AUTOPUSH
+// Description : Push automatically when the input shift register is filled
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPUSH_RESET  _u(0x0)
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPUSH_BITS   _u(0x00010000)
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPUSH_MSB    _u(16)
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPUSH_LSB    _u(16)
+#define PROC_PIO_SM0_SHIFTCTRL_AUTOPUSH_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM0_ADDR
+// Description : Current instruction address of state machine 0
+#define PROC_PIO_SM0_ADDR_OFFSET _u(0x000000d8)
+#define PROC_PIO_SM0_ADDR_BITS   _u(0x0000001f)
+#define PROC_PIO_SM0_ADDR_RESET  _u(0x00000000)
+#define PROC_PIO_SM0_ADDR_WIDTH  _u(32)
+#define PROC_PIO_SM0_ADDR_MSB    _u(4)
+#define PROC_PIO_SM0_ADDR_LSB    _u(0)
+#define PROC_PIO_SM0_ADDR_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_SM0_INSTR
+// Description : Instruction currently being executed by state machine 0
+//               Write to execute an instruction immediately (including jumps)
+//               and then resume execution.
+#define PROC_PIO_SM0_INSTR_OFFSET _u(0x000000dc)
+#define PROC_PIO_SM0_INSTR_BITS   _u(0x0000ffff)
+#define PROC_PIO_SM0_INSTR_RESET  "-"
+#define PROC_PIO_SM0_INSTR_WIDTH  _u(32)
+#define PROC_PIO_SM0_INSTR_MSB    _u(15)
+#define PROC_PIO_SM0_INSTR_LSB    _u(0)
+#define PROC_PIO_SM0_INSTR_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM0_PINCTRL
+// Description : State machine pin control
+#define PROC_PIO_SM0_PINCTRL_OFFSET _u(0x000000e0)
+#define PROC_PIO_SM0_PINCTRL_BITS   _u(0xffffffff)
+#define PROC_PIO_SM0_PINCTRL_RESET  _u(0x14000000)
+#define PROC_PIO_SM0_PINCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_PINCTRL_SIDESET_COUNT
+// Description : The number of delay bits co-opted for side-set. Inclusive of
+//               the enable bit, if present.
+#define PROC_PIO_SM0_PINCTRL_SIDESET_COUNT_RESET  _u(0x0)
+#define PROC_PIO_SM0_PINCTRL_SIDESET_COUNT_BITS   _u(0xe0000000)
+#define PROC_PIO_SM0_PINCTRL_SIDESET_COUNT_MSB    _u(31)
+#define PROC_PIO_SM0_PINCTRL_SIDESET_COUNT_LSB    _u(29)
+#define PROC_PIO_SM0_PINCTRL_SIDESET_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_PINCTRL_SET_COUNT
+// Description : The number of pins asserted by a SET. Max of 5
+#define PROC_PIO_SM0_PINCTRL_SET_COUNT_RESET  _u(0x5)
+#define PROC_PIO_SM0_PINCTRL_SET_COUNT_BITS   _u(0x1c000000)
+#define PROC_PIO_SM0_PINCTRL_SET_COUNT_MSB    _u(28)
+#define PROC_PIO_SM0_PINCTRL_SET_COUNT_LSB    _u(26)
+#define PROC_PIO_SM0_PINCTRL_SET_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_PINCTRL_OUT_COUNT
+// Description : The number of pins asserted by an OUT. Value of 0 -> 32 pins
+#define PROC_PIO_SM0_PINCTRL_OUT_COUNT_RESET  _u(0x00)
+#define PROC_PIO_SM0_PINCTRL_OUT_COUNT_BITS   _u(0x03f00000)
+#define PROC_PIO_SM0_PINCTRL_OUT_COUNT_MSB    _u(25)
+#define PROC_PIO_SM0_PINCTRL_OUT_COUNT_LSB    _u(20)
+#define PROC_PIO_SM0_PINCTRL_OUT_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_PINCTRL_IN_BASE
+// Description : The virtual pin corresponding to IN bit 0
+#define PROC_PIO_SM0_PINCTRL_IN_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM0_PINCTRL_IN_BASE_BITS   _u(0x000f8000)
+#define PROC_PIO_SM0_PINCTRL_IN_BASE_MSB    _u(19)
+#define PROC_PIO_SM0_PINCTRL_IN_BASE_LSB    _u(15)
+#define PROC_PIO_SM0_PINCTRL_IN_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_PINCTRL_SIDESET_BASE
+// Description : The virtual pin corresponding to delay field bit 0
+#define PROC_PIO_SM0_PINCTRL_SIDESET_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM0_PINCTRL_SIDESET_BASE_BITS   _u(0x00007c00)
+#define PROC_PIO_SM0_PINCTRL_SIDESET_BASE_MSB    _u(14)
+#define PROC_PIO_SM0_PINCTRL_SIDESET_BASE_LSB    _u(10)
+#define PROC_PIO_SM0_PINCTRL_SIDESET_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_PINCTRL_SET_BASE
+// Description : The virtual pin corresponding to SET bit 0
+#define PROC_PIO_SM0_PINCTRL_SET_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM0_PINCTRL_SET_BASE_BITS   _u(0x000003e0)
+#define PROC_PIO_SM0_PINCTRL_SET_BASE_MSB    _u(9)
+#define PROC_PIO_SM0_PINCTRL_SET_BASE_LSB    _u(5)
+#define PROC_PIO_SM0_PINCTRL_SET_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_PINCTRL_OUT_BASE
+// Description : The virtual pin corresponding to OUT bit 0
+#define PROC_PIO_SM0_PINCTRL_OUT_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM0_PINCTRL_OUT_BASE_BITS   _u(0x0000001f)
+#define PROC_PIO_SM0_PINCTRL_OUT_BASE_MSB    _u(4)
+#define PROC_PIO_SM0_PINCTRL_OUT_BASE_LSB    _u(0)
+#define PROC_PIO_SM0_PINCTRL_OUT_BASE_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM0_DMACTRL_TX
+// Description : State machine DMA control
+#define PROC_PIO_SM0_DMACTRL_TX_OFFSET _u(0x000000e4)
+#define PROC_PIO_SM0_DMACTRL_TX_BITS   _u(0xc0000f9f)
+#define PROC_PIO_SM0_DMACTRL_TX_RESET  _u(0x00000104)
+#define PROC_PIO_SM0_DMACTRL_TX_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_DMACTRL_TX_DREQ_EN
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM0_DMACTRL_TX_DREQ_EN_RESET  _u(0x0)
+#define PROC_PIO_SM0_DMACTRL_TX_DREQ_EN_BITS   _u(0x80000000)
+#define PROC_PIO_SM0_DMACTRL_TX_DREQ_EN_MSB    _u(31)
+#define PROC_PIO_SM0_DMACTRL_TX_DREQ_EN_LSB    _u(31)
+#define PROC_PIO_SM0_DMACTRL_TX_DREQ_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_DMACTRL_TX_ACTIVE
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM0_DMACTRL_TX_ACTIVE_RESET  "-"
+#define PROC_PIO_SM0_DMACTRL_TX_ACTIVE_BITS   _u(0x40000000)
+#define PROC_PIO_SM0_DMACTRL_TX_ACTIVE_MSB    _u(30)
+#define PROC_PIO_SM0_DMACTRL_TX_ACTIVE_LSB    _u(30)
+#define PROC_PIO_SM0_DMACTRL_TX_ACTIVE_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_DMACTRL_TX_DWELL_TIME
+// Description : Delay in number of bus cycles before successive DREQs are
+//               generated.
+//               Used to account for system bus latency in write data arriving
+//               at the FIFO.
+#define PROC_PIO_SM0_DMACTRL_TX_DWELL_TIME_RESET  _u(0x02)
+#define PROC_PIO_SM0_DMACTRL_TX_DWELL_TIME_BITS   _u(0x00000f80)
+#define PROC_PIO_SM0_DMACTRL_TX_DWELL_TIME_MSB    _u(11)
+#define PROC_PIO_SM0_DMACTRL_TX_DWELL_TIME_LSB    _u(7)
+#define PROC_PIO_SM0_DMACTRL_TX_DWELL_TIME_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_DMACTRL_TX_FIFO_THRESHOLD
+// Description : Threshold control. If there are no more than THRESHOLD items in
+//               the TX FIFO, DMA dreq and/or the interrupt line is asserted.
+#define PROC_PIO_SM0_DMACTRL_TX_FIFO_THRESHOLD_RESET  _u(0x04)
+#define PROC_PIO_SM0_DMACTRL_TX_FIFO_THRESHOLD_BITS   _u(0x0000001f)
+#define PROC_PIO_SM0_DMACTRL_TX_FIFO_THRESHOLD_MSB    _u(4)
+#define PROC_PIO_SM0_DMACTRL_TX_FIFO_THRESHOLD_LSB    _u(0)
+#define PROC_PIO_SM0_DMACTRL_TX_FIFO_THRESHOLD_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM0_DMACTRL_RX
+// Description : State machine DMA control
+#define PROC_PIO_SM0_DMACTRL_RX_OFFSET _u(0x000000e8)
+#define PROC_PIO_SM0_DMACTRL_RX_BITS   _u(0xc0000f9f)
+#define PROC_PIO_SM0_DMACTRL_RX_RESET  _u(0x00000104)
+#define PROC_PIO_SM0_DMACTRL_RX_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_DMACTRL_RX_DREQ_EN
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM0_DMACTRL_RX_DREQ_EN_RESET  _u(0x0)
+#define PROC_PIO_SM0_DMACTRL_RX_DREQ_EN_BITS   _u(0x80000000)
+#define PROC_PIO_SM0_DMACTRL_RX_DREQ_EN_MSB    _u(31)
+#define PROC_PIO_SM0_DMACTRL_RX_DREQ_EN_LSB    _u(31)
+#define PROC_PIO_SM0_DMACTRL_RX_DREQ_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_DMACTRL_RX_ACTIVE
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM0_DMACTRL_RX_ACTIVE_RESET  "-"
+#define PROC_PIO_SM0_DMACTRL_RX_ACTIVE_BITS   _u(0x40000000)
+#define PROC_PIO_SM0_DMACTRL_RX_ACTIVE_MSB    _u(30)
+#define PROC_PIO_SM0_DMACTRL_RX_ACTIVE_LSB    _u(30)
+#define PROC_PIO_SM0_DMACTRL_RX_ACTIVE_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_DMACTRL_RX_DWELL_TIME
+// Description : Delay in number of bus cycles before successive DREQs are
+//               generated.
+//               Used to account for system bus latency in write data arriving
+//               at the FIFO.
+#define PROC_PIO_SM0_DMACTRL_RX_DWELL_TIME_RESET  _u(0x02)
+#define PROC_PIO_SM0_DMACTRL_RX_DWELL_TIME_BITS   _u(0x00000f80)
+#define PROC_PIO_SM0_DMACTRL_RX_DWELL_TIME_MSB    _u(11)
+#define PROC_PIO_SM0_DMACTRL_RX_DWELL_TIME_LSB    _u(7)
+#define PROC_PIO_SM0_DMACTRL_RX_DWELL_TIME_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM0_DMACTRL_RX_FIFO_THRESHOLD
+// Description : Threshold control. If there are at least THRESHOLD items in the
+//               RX FIFO, DMA dreq and/or the interrupt line is asserted.
+#define PROC_PIO_SM0_DMACTRL_RX_FIFO_THRESHOLD_RESET  _u(0x04)
+#define PROC_PIO_SM0_DMACTRL_RX_FIFO_THRESHOLD_BITS   _u(0x0000001f)
+#define PROC_PIO_SM0_DMACTRL_RX_FIFO_THRESHOLD_MSB    _u(4)
+#define PROC_PIO_SM0_DMACTRL_RX_FIFO_THRESHOLD_LSB    _u(0)
+#define PROC_PIO_SM0_DMACTRL_RX_FIFO_THRESHOLD_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM1_CLKDIV
+// Description : Clock divider register for state machine 1
+//               Frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
+#define PROC_PIO_SM1_CLKDIV_OFFSET _u(0x000000ec)
+#define PROC_PIO_SM1_CLKDIV_BITS   _u(0xffffff00)
+#define PROC_PIO_SM1_CLKDIV_RESET  _u(0x00010000)
+#define PROC_PIO_SM1_CLKDIV_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_CLKDIV_INT
+// Description : Effective frequency is sysclk/int.
+//               Value of 0 is interpreted as max possible value
+#define PROC_PIO_SM1_CLKDIV_INT_RESET  _u(0x0001)
+#define PROC_PIO_SM1_CLKDIV_INT_BITS   _u(0xffff0000)
+#define PROC_PIO_SM1_CLKDIV_INT_MSB    _u(31)
+#define PROC_PIO_SM1_CLKDIV_INT_LSB    _u(16)
+#define PROC_PIO_SM1_CLKDIV_INT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_CLKDIV_FRAC
+// Description : Fractional part of clock divider
+#define PROC_PIO_SM1_CLKDIV_FRAC_RESET  _u(0x00)
+#define PROC_PIO_SM1_CLKDIV_FRAC_BITS   _u(0x0000ff00)
+#define PROC_PIO_SM1_CLKDIV_FRAC_MSB    _u(15)
+#define PROC_PIO_SM1_CLKDIV_FRAC_LSB    _u(8)
+#define PROC_PIO_SM1_CLKDIV_FRAC_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM1_EXECCTRL
+// Description : Execution/behavioural settings for state machine 1
+#define PROC_PIO_SM1_EXECCTRL_OFFSET _u(0x000000f0)
+#define PROC_PIO_SM1_EXECCTRL_BITS   _u(0xffffffbf)
+#define PROC_PIO_SM1_EXECCTRL_RESET  _u(0x0001f000)
+#define PROC_PIO_SM1_EXECCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_EXEC_STALLED
+// Description : An instruction written to SMx_INSTR is stalled, and latched by
+//               the
+//               state machine. Will clear once the instruction completes.
+#define PROC_PIO_SM1_EXECCTRL_EXEC_STALLED_RESET  _u(0x0)
+#define PROC_PIO_SM1_EXECCTRL_EXEC_STALLED_BITS   _u(0x80000000)
+#define PROC_PIO_SM1_EXECCTRL_EXEC_STALLED_MSB    _u(31)
+#define PROC_PIO_SM1_EXECCTRL_EXEC_STALLED_LSB    _u(31)
+#define PROC_PIO_SM1_EXECCTRL_EXEC_STALLED_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_SIDE_EN
+// Description : If 1, the delay MSB is used as side-set enable, rather than a
+//               side-set data bit. This allows instructions to perform side-set
+//               optionally,
+//               rather than on every instruction.
+#define PROC_PIO_SM1_EXECCTRL_SIDE_EN_RESET  _u(0x0)
+#define PROC_PIO_SM1_EXECCTRL_SIDE_EN_BITS   _u(0x40000000)
+#define PROC_PIO_SM1_EXECCTRL_SIDE_EN_MSB    _u(30)
+#define PROC_PIO_SM1_EXECCTRL_SIDE_EN_LSB    _u(30)
+#define PROC_PIO_SM1_EXECCTRL_SIDE_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_SIDE_PINDIR
+// Description : Side-set data is asserted to pin OEs instead of pin values
+#define PROC_PIO_SM1_EXECCTRL_SIDE_PINDIR_RESET  _u(0x0)
+#define PROC_PIO_SM1_EXECCTRL_SIDE_PINDIR_BITS   _u(0x20000000)
+#define PROC_PIO_SM1_EXECCTRL_SIDE_PINDIR_MSB    _u(29)
+#define PROC_PIO_SM1_EXECCTRL_SIDE_PINDIR_LSB    _u(29)
+#define PROC_PIO_SM1_EXECCTRL_SIDE_PINDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_JMP_PIN
+// Description : The GPIO number to use as condition for JMP PIN. Unaffected by
+//               input mapping.
+#define PROC_PIO_SM1_EXECCTRL_JMP_PIN_RESET  _u(0x00)
+#define PROC_PIO_SM1_EXECCTRL_JMP_PIN_BITS   _u(0x1f000000)
+#define PROC_PIO_SM1_EXECCTRL_JMP_PIN_MSB    _u(28)
+#define PROC_PIO_SM1_EXECCTRL_JMP_PIN_LSB    _u(24)
+#define PROC_PIO_SM1_EXECCTRL_JMP_PIN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_OUT_EN_SEL
+// Description : Which data bit to use for inline OUT enable
+#define PROC_PIO_SM1_EXECCTRL_OUT_EN_SEL_RESET  _u(0x00)
+#define PROC_PIO_SM1_EXECCTRL_OUT_EN_SEL_BITS   _u(0x00f80000)
+#define PROC_PIO_SM1_EXECCTRL_OUT_EN_SEL_MSB    _u(23)
+#define PROC_PIO_SM1_EXECCTRL_OUT_EN_SEL_LSB    _u(19)
+#define PROC_PIO_SM1_EXECCTRL_OUT_EN_SEL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_INLINE_OUT_EN
+// Description : If 1, use a bit of OUT data as an auxiliary write enable
+//               When used in conjunction with OUT_STICKY, writes with an enable
+//               of 0 will
+//               deassert the latest pin write. This can create useful
+//               masking/override behaviour
+//               due to the priority ordering of state machine pin writes (SM0 <
+//               SM1 < ...)
+#define PROC_PIO_SM1_EXECCTRL_INLINE_OUT_EN_RESET  _u(0x0)
+#define PROC_PIO_SM1_EXECCTRL_INLINE_OUT_EN_BITS   _u(0x00040000)
+#define PROC_PIO_SM1_EXECCTRL_INLINE_OUT_EN_MSB    _u(18)
+#define PROC_PIO_SM1_EXECCTRL_INLINE_OUT_EN_LSB    _u(18)
+#define PROC_PIO_SM1_EXECCTRL_INLINE_OUT_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_OUT_STICKY
+// Description : Continuously assert the most recent OUT/SET to the pins
+#define PROC_PIO_SM1_EXECCTRL_OUT_STICKY_RESET  _u(0x0)
+#define PROC_PIO_SM1_EXECCTRL_OUT_STICKY_BITS   _u(0x00020000)
+#define PROC_PIO_SM1_EXECCTRL_OUT_STICKY_MSB    _u(17)
+#define PROC_PIO_SM1_EXECCTRL_OUT_STICKY_LSB    _u(17)
+#define PROC_PIO_SM1_EXECCTRL_OUT_STICKY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_WRAP_TOP
+// Description : After reaching this address, execution is wrapped to
+//               wrap_bottom.
+//               If the instruction is a jump, and the jump condition is true,
+//               the jump takes priority.
+#define PROC_PIO_SM1_EXECCTRL_WRAP_TOP_RESET  _u(0x1f)
+#define PROC_PIO_SM1_EXECCTRL_WRAP_TOP_BITS   _u(0x0001f000)
+#define PROC_PIO_SM1_EXECCTRL_WRAP_TOP_MSB    _u(16)
+#define PROC_PIO_SM1_EXECCTRL_WRAP_TOP_LSB    _u(12)
+#define PROC_PIO_SM1_EXECCTRL_WRAP_TOP_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_WRAP_BOTTOM
+// Description : After reaching wrap_top, execution is wrapped to this address.
+#define PROC_PIO_SM1_EXECCTRL_WRAP_BOTTOM_RESET  _u(0x00)
+#define PROC_PIO_SM1_EXECCTRL_WRAP_BOTTOM_BITS   _u(0x00000f80)
+#define PROC_PIO_SM1_EXECCTRL_WRAP_BOTTOM_MSB    _u(11)
+#define PROC_PIO_SM1_EXECCTRL_WRAP_BOTTOM_LSB    _u(7)
+#define PROC_PIO_SM1_EXECCTRL_WRAP_BOTTOM_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_STATUS_SEL
+// Description : Comparison used for the MOV x, STATUS instruction.
+//               0x0 -> All-ones if TX FIFO level < N, otherwise all-zeroes
+//               0x1 -> All-ones if RX FIFO level < N, otherwise all-zeroes
+#define PROC_PIO_SM1_EXECCTRL_STATUS_SEL_RESET         _u(0x0)
+#define PROC_PIO_SM1_EXECCTRL_STATUS_SEL_BITS          _u(0x00000020)
+#define PROC_PIO_SM1_EXECCTRL_STATUS_SEL_MSB           _u(5)
+#define PROC_PIO_SM1_EXECCTRL_STATUS_SEL_LSB           _u(5)
+#define PROC_PIO_SM1_EXECCTRL_STATUS_SEL_ACCESS        "RW"
+#define PROC_PIO_SM1_EXECCTRL_STATUS_SEL_VALUE_TXLEVEL _u(0x0)
+#define PROC_PIO_SM1_EXECCTRL_STATUS_SEL_VALUE_RXLEVEL _u(0x1)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_EXECCTRL_STATUS_N
+// Description : Comparison level for the MOV x, STATUS instruction
+#define PROC_PIO_SM1_EXECCTRL_STATUS_N_RESET  _u(0x00)
+#define PROC_PIO_SM1_EXECCTRL_STATUS_N_BITS   _u(0x0000001f)
+#define PROC_PIO_SM1_EXECCTRL_STATUS_N_MSB    _u(4)
+#define PROC_PIO_SM1_EXECCTRL_STATUS_N_LSB    _u(0)
+#define PROC_PIO_SM1_EXECCTRL_STATUS_N_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM1_SHIFTCTRL
+// Description : Control behaviour of the input/output shift registers for state
+//               machine 1
+#define PROC_PIO_SM1_SHIFTCTRL_OFFSET _u(0x000000f4)
+#define PROC_PIO_SM1_SHIFTCTRL_BITS   _u(0xffff0000)
+#define PROC_PIO_SM1_SHIFTCTRL_RESET  _u(0x000c0000)
+#define PROC_PIO_SM1_SHIFTCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_SHIFTCTRL_FJOIN_RX
+// Description : When 1, RX FIFO steals the TX FIFO's storage, and becomes twice
+//               as deep.
+//               TX FIFO is disabled as a result (always reads as both full and
+//               empty).
+//               FIFOs are flushed when this bit is changed.
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_RX_RESET  _u(0x0)
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_RX_BITS   _u(0x80000000)
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_RX_MSB    _u(31)
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_RX_LSB    _u(31)
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_RX_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_SHIFTCTRL_FJOIN_TX
+// Description : When 1, TX FIFO steals the RX FIFO's storage, and becomes twice
+//               as deep.
+//               RX FIFO is disabled as a result (always reads as both full and
+//               empty).
+//               FIFOs are flushed when this bit is changed.
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_TX_RESET  _u(0x0)
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_TX_BITS   _u(0x40000000)
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_TX_MSB    _u(30)
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_TX_LSB    _u(30)
+#define PROC_PIO_SM1_SHIFTCTRL_FJOIN_TX_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_SHIFTCTRL_PULL_THRESH
+// Description : Number of bits shifted out of TXSR before autopull or
+//               conditional pull.
+//               Write 0 for value of 32.
+#define PROC_PIO_SM1_SHIFTCTRL_PULL_THRESH_RESET  _u(0x00)
+#define PROC_PIO_SM1_SHIFTCTRL_PULL_THRESH_BITS   _u(0x3e000000)
+#define PROC_PIO_SM1_SHIFTCTRL_PULL_THRESH_MSB    _u(29)
+#define PROC_PIO_SM1_SHIFTCTRL_PULL_THRESH_LSB    _u(25)
+#define PROC_PIO_SM1_SHIFTCTRL_PULL_THRESH_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_SHIFTCTRL_PUSH_THRESH
+// Description : Number of bits shifted into RXSR before autopush or conditional
+//               push.
+//               Write 0 for value of 32.
+#define PROC_PIO_SM1_SHIFTCTRL_PUSH_THRESH_RESET  _u(0x00)
+#define PROC_PIO_SM1_SHIFTCTRL_PUSH_THRESH_BITS   _u(0x01f00000)
+#define PROC_PIO_SM1_SHIFTCTRL_PUSH_THRESH_MSB    _u(24)
+#define PROC_PIO_SM1_SHIFTCTRL_PUSH_THRESH_LSB    _u(20)
+#define PROC_PIO_SM1_SHIFTCTRL_PUSH_THRESH_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_SHIFTCTRL_OUT_SHIFTDIR
+// Description : 1 = shift out of output shift register to right. 0 = to left.
+#define PROC_PIO_SM1_SHIFTCTRL_OUT_SHIFTDIR_RESET  _u(0x1)
+#define PROC_PIO_SM1_SHIFTCTRL_OUT_SHIFTDIR_BITS   _u(0x00080000)
+#define PROC_PIO_SM1_SHIFTCTRL_OUT_SHIFTDIR_MSB    _u(19)
+#define PROC_PIO_SM1_SHIFTCTRL_OUT_SHIFTDIR_LSB    _u(19)
+#define PROC_PIO_SM1_SHIFTCTRL_OUT_SHIFTDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_SHIFTCTRL_IN_SHIFTDIR
+// Description : 1 = shift input shift register to right (data enters from
+//               left). 0 = to left.
+#define PROC_PIO_SM1_SHIFTCTRL_IN_SHIFTDIR_RESET  _u(0x1)
+#define PROC_PIO_SM1_SHIFTCTRL_IN_SHIFTDIR_BITS   _u(0x00040000)
+#define PROC_PIO_SM1_SHIFTCTRL_IN_SHIFTDIR_MSB    _u(18)
+#define PROC_PIO_SM1_SHIFTCTRL_IN_SHIFTDIR_LSB    _u(18)
+#define PROC_PIO_SM1_SHIFTCTRL_IN_SHIFTDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_SHIFTCTRL_AUTOPULL
+// Description : Pull automatically when the output shift register is emptied
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPULL_RESET  _u(0x0)
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPULL_BITS   _u(0x00020000)
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPULL_MSB    _u(17)
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPULL_LSB    _u(17)
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_SHIFTCTRL_AUTOPUSH
+// Description : Push automatically when the input shift register is filled
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPUSH_RESET  _u(0x0)
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPUSH_BITS   _u(0x00010000)
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPUSH_MSB    _u(16)
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPUSH_LSB    _u(16)
+#define PROC_PIO_SM1_SHIFTCTRL_AUTOPUSH_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM1_ADDR
+// Description : Current instruction address of state machine 1
+#define PROC_PIO_SM1_ADDR_OFFSET _u(0x000000f8)
+#define PROC_PIO_SM1_ADDR_BITS   _u(0x0000001f)
+#define PROC_PIO_SM1_ADDR_RESET  _u(0x00000000)
+#define PROC_PIO_SM1_ADDR_WIDTH  _u(32)
+#define PROC_PIO_SM1_ADDR_MSB    _u(4)
+#define PROC_PIO_SM1_ADDR_LSB    _u(0)
+#define PROC_PIO_SM1_ADDR_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_SM1_INSTR
+// Description : Instruction currently being executed by state machine 1
+//               Write to execute an instruction immediately (including jumps)
+//               and then resume execution.
+#define PROC_PIO_SM1_INSTR_OFFSET _u(0x000000fc)
+#define PROC_PIO_SM1_INSTR_BITS   _u(0x0000ffff)
+#define PROC_PIO_SM1_INSTR_RESET  "-"
+#define PROC_PIO_SM1_INSTR_WIDTH  _u(32)
+#define PROC_PIO_SM1_INSTR_MSB    _u(15)
+#define PROC_PIO_SM1_INSTR_LSB    _u(0)
+#define PROC_PIO_SM1_INSTR_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM1_PINCTRL
+// Description : State machine pin control
+#define PROC_PIO_SM1_PINCTRL_OFFSET _u(0x00000100)
+#define PROC_PIO_SM1_PINCTRL_BITS   _u(0xffffffff)
+#define PROC_PIO_SM1_PINCTRL_RESET  _u(0x14000000)
+#define PROC_PIO_SM1_PINCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_PINCTRL_SIDESET_COUNT
+// Description : The number of delay bits co-opted for side-set. Inclusive of
+//               the enable bit, if present.
+#define PROC_PIO_SM1_PINCTRL_SIDESET_COUNT_RESET  _u(0x0)
+#define PROC_PIO_SM1_PINCTRL_SIDESET_COUNT_BITS   _u(0xe0000000)
+#define PROC_PIO_SM1_PINCTRL_SIDESET_COUNT_MSB    _u(31)
+#define PROC_PIO_SM1_PINCTRL_SIDESET_COUNT_LSB    _u(29)
+#define PROC_PIO_SM1_PINCTRL_SIDESET_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_PINCTRL_SET_COUNT
+// Description : The number of pins asserted by a SET. Max of 5
+#define PROC_PIO_SM1_PINCTRL_SET_COUNT_RESET  _u(0x5)
+#define PROC_PIO_SM1_PINCTRL_SET_COUNT_BITS   _u(0x1c000000)
+#define PROC_PIO_SM1_PINCTRL_SET_COUNT_MSB    _u(28)
+#define PROC_PIO_SM1_PINCTRL_SET_COUNT_LSB    _u(26)
+#define PROC_PIO_SM1_PINCTRL_SET_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_PINCTRL_OUT_COUNT
+// Description : The number of pins asserted by an OUT. Value of 0 -> 32 pins
+#define PROC_PIO_SM1_PINCTRL_OUT_COUNT_RESET  _u(0x00)
+#define PROC_PIO_SM1_PINCTRL_OUT_COUNT_BITS   _u(0x03f00000)
+#define PROC_PIO_SM1_PINCTRL_OUT_COUNT_MSB    _u(25)
+#define PROC_PIO_SM1_PINCTRL_OUT_COUNT_LSB    _u(20)
+#define PROC_PIO_SM1_PINCTRL_OUT_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_PINCTRL_IN_BASE
+// Description : The virtual pin corresponding to IN bit 0
+#define PROC_PIO_SM1_PINCTRL_IN_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM1_PINCTRL_IN_BASE_BITS   _u(0x000f8000)
+#define PROC_PIO_SM1_PINCTRL_IN_BASE_MSB    _u(19)
+#define PROC_PIO_SM1_PINCTRL_IN_BASE_LSB    _u(15)
+#define PROC_PIO_SM1_PINCTRL_IN_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_PINCTRL_SIDESET_BASE
+// Description : The virtual pin corresponding to delay field bit 0
+#define PROC_PIO_SM1_PINCTRL_SIDESET_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM1_PINCTRL_SIDESET_BASE_BITS   _u(0x00007c00)
+#define PROC_PIO_SM1_PINCTRL_SIDESET_BASE_MSB    _u(14)
+#define PROC_PIO_SM1_PINCTRL_SIDESET_BASE_LSB    _u(10)
+#define PROC_PIO_SM1_PINCTRL_SIDESET_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_PINCTRL_SET_BASE
+// Description : The virtual pin corresponding to SET bit 0
+#define PROC_PIO_SM1_PINCTRL_SET_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM1_PINCTRL_SET_BASE_BITS   _u(0x000003e0)
+#define PROC_PIO_SM1_PINCTRL_SET_BASE_MSB    _u(9)
+#define PROC_PIO_SM1_PINCTRL_SET_BASE_LSB    _u(5)
+#define PROC_PIO_SM1_PINCTRL_SET_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_PINCTRL_OUT_BASE
+// Description : The virtual pin corresponding to OUT bit 0
+#define PROC_PIO_SM1_PINCTRL_OUT_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM1_PINCTRL_OUT_BASE_BITS   _u(0x0000001f)
+#define PROC_PIO_SM1_PINCTRL_OUT_BASE_MSB    _u(4)
+#define PROC_PIO_SM1_PINCTRL_OUT_BASE_LSB    _u(0)
+#define PROC_PIO_SM1_PINCTRL_OUT_BASE_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM1_DMACTRL_TX
+// Description : State machine DMA control
+#define PROC_PIO_SM1_DMACTRL_TX_OFFSET _u(0x00000104)
+#define PROC_PIO_SM1_DMACTRL_TX_BITS   _u(0xc0000f9f)
+#define PROC_PIO_SM1_DMACTRL_TX_RESET  _u(0x00000104)
+#define PROC_PIO_SM1_DMACTRL_TX_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_DMACTRL_TX_DREQ_EN
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM1_DMACTRL_TX_DREQ_EN_RESET  _u(0x0)
+#define PROC_PIO_SM1_DMACTRL_TX_DREQ_EN_BITS   _u(0x80000000)
+#define PROC_PIO_SM1_DMACTRL_TX_DREQ_EN_MSB    _u(31)
+#define PROC_PIO_SM1_DMACTRL_TX_DREQ_EN_LSB    _u(31)
+#define PROC_PIO_SM1_DMACTRL_TX_DREQ_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_DMACTRL_TX_ACTIVE
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM1_DMACTRL_TX_ACTIVE_RESET  "-"
+#define PROC_PIO_SM1_DMACTRL_TX_ACTIVE_BITS   _u(0x40000000)
+#define PROC_PIO_SM1_DMACTRL_TX_ACTIVE_MSB    _u(30)
+#define PROC_PIO_SM1_DMACTRL_TX_ACTIVE_LSB    _u(30)
+#define PROC_PIO_SM1_DMACTRL_TX_ACTIVE_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_DMACTRL_TX_DWELL_TIME
+// Description : Delay in number of bus cycles before successive DREQs are
+//               generated.
+//               Used to account for system bus latency in write data arriving
+//               at the FIFO.
+#define PROC_PIO_SM1_DMACTRL_TX_DWELL_TIME_RESET  _u(0x02)
+#define PROC_PIO_SM1_DMACTRL_TX_DWELL_TIME_BITS   _u(0x00000f80)
+#define PROC_PIO_SM1_DMACTRL_TX_DWELL_TIME_MSB    _u(11)
+#define PROC_PIO_SM1_DMACTRL_TX_DWELL_TIME_LSB    _u(7)
+#define PROC_PIO_SM1_DMACTRL_TX_DWELL_TIME_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_DMACTRL_TX_FIFO_THRESHOLD
+// Description : Threshold control. If there are no more than THRESHOLD items in
+//               the TX FIFO, DMA dreq and/or the interrupt line is asserted.
+#define PROC_PIO_SM1_DMACTRL_TX_FIFO_THRESHOLD_RESET  _u(0x04)
+#define PROC_PIO_SM1_DMACTRL_TX_FIFO_THRESHOLD_BITS   _u(0x0000001f)
+#define PROC_PIO_SM1_DMACTRL_TX_FIFO_THRESHOLD_MSB    _u(4)
+#define PROC_PIO_SM1_DMACTRL_TX_FIFO_THRESHOLD_LSB    _u(0)
+#define PROC_PIO_SM1_DMACTRL_TX_FIFO_THRESHOLD_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM1_DMACTRL_RX
+// Description : State machine DMA control
+#define PROC_PIO_SM1_DMACTRL_RX_OFFSET _u(0x00000108)
+#define PROC_PIO_SM1_DMACTRL_RX_BITS   _u(0xc0000f9f)
+#define PROC_PIO_SM1_DMACTRL_RX_RESET  _u(0x00000104)
+#define PROC_PIO_SM1_DMACTRL_RX_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_DMACTRL_RX_DREQ_EN
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM1_DMACTRL_RX_DREQ_EN_RESET  _u(0x0)
+#define PROC_PIO_SM1_DMACTRL_RX_DREQ_EN_BITS   _u(0x80000000)
+#define PROC_PIO_SM1_DMACTRL_RX_DREQ_EN_MSB    _u(31)
+#define PROC_PIO_SM1_DMACTRL_RX_DREQ_EN_LSB    _u(31)
+#define PROC_PIO_SM1_DMACTRL_RX_DREQ_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_DMACTRL_RX_ACTIVE
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM1_DMACTRL_RX_ACTIVE_RESET  "-"
+#define PROC_PIO_SM1_DMACTRL_RX_ACTIVE_BITS   _u(0x40000000)
+#define PROC_PIO_SM1_DMACTRL_RX_ACTIVE_MSB    _u(30)
+#define PROC_PIO_SM1_DMACTRL_RX_ACTIVE_LSB    _u(30)
+#define PROC_PIO_SM1_DMACTRL_RX_ACTIVE_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_DMACTRL_RX_DWELL_TIME
+// Description : Delay in number of bus cycles before successive DREQs are
+//               generated.
+//               Used to account for system bus latency in write data arriving
+//               at the FIFO.
+#define PROC_PIO_SM1_DMACTRL_RX_DWELL_TIME_RESET  _u(0x02)
+#define PROC_PIO_SM1_DMACTRL_RX_DWELL_TIME_BITS   _u(0x00000f80)
+#define PROC_PIO_SM1_DMACTRL_RX_DWELL_TIME_MSB    _u(11)
+#define PROC_PIO_SM1_DMACTRL_RX_DWELL_TIME_LSB    _u(7)
+#define PROC_PIO_SM1_DMACTRL_RX_DWELL_TIME_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM1_DMACTRL_RX_FIFO_THRESHOLD
+// Description : Threshold control. If there are at least THRESHOLD items in the
+//               RX FIFO, DMA dreq and/or the interrupt line is asserted.
+#define PROC_PIO_SM1_DMACTRL_RX_FIFO_THRESHOLD_RESET  _u(0x04)
+#define PROC_PIO_SM1_DMACTRL_RX_FIFO_THRESHOLD_BITS   _u(0x0000001f)
+#define PROC_PIO_SM1_DMACTRL_RX_FIFO_THRESHOLD_MSB    _u(4)
+#define PROC_PIO_SM1_DMACTRL_RX_FIFO_THRESHOLD_LSB    _u(0)
+#define PROC_PIO_SM1_DMACTRL_RX_FIFO_THRESHOLD_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM2_CLKDIV
+// Description : Clock divider register for state machine 2
+//               Frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
+#define PROC_PIO_SM2_CLKDIV_OFFSET _u(0x0000010c)
+#define PROC_PIO_SM2_CLKDIV_BITS   _u(0xffffff00)
+#define PROC_PIO_SM2_CLKDIV_RESET  _u(0x00010000)
+#define PROC_PIO_SM2_CLKDIV_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_CLKDIV_INT
+// Description : Effective frequency is sysclk/int.
+//               Value of 0 is interpreted as max possible value
+#define PROC_PIO_SM2_CLKDIV_INT_RESET  _u(0x0001)
+#define PROC_PIO_SM2_CLKDIV_INT_BITS   _u(0xffff0000)
+#define PROC_PIO_SM2_CLKDIV_INT_MSB    _u(31)
+#define PROC_PIO_SM2_CLKDIV_INT_LSB    _u(16)
+#define PROC_PIO_SM2_CLKDIV_INT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_CLKDIV_FRAC
+// Description : Fractional part of clock divider
+#define PROC_PIO_SM2_CLKDIV_FRAC_RESET  _u(0x00)
+#define PROC_PIO_SM2_CLKDIV_FRAC_BITS   _u(0x0000ff00)
+#define PROC_PIO_SM2_CLKDIV_FRAC_MSB    _u(15)
+#define PROC_PIO_SM2_CLKDIV_FRAC_LSB    _u(8)
+#define PROC_PIO_SM2_CLKDIV_FRAC_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM2_EXECCTRL
+// Description : Execution/behavioural settings for state machine 2
+#define PROC_PIO_SM2_EXECCTRL_OFFSET _u(0x00000110)
+#define PROC_PIO_SM2_EXECCTRL_BITS   _u(0xffffffbf)
+#define PROC_PIO_SM2_EXECCTRL_RESET  _u(0x0001f000)
+#define PROC_PIO_SM2_EXECCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_EXEC_STALLED
+// Description : An instruction written to SMx_INSTR is stalled, and latched by
+//               the
+//               state machine. Will clear once the instruction completes.
+#define PROC_PIO_SM2_EXECCTRL_EXEC_STALLED_RESET  _u(0x0)
+#define PROC_PIO_SM2_EXECCTRL_EXEC_STALLED_BITS   _u(0x80000000)
+#define PROC_PIO_SM2_EXECCTRL_EXEC_STALLED_MSB    _u(31)
+#define PROC_PIO_SM2_EXECCTRL_EXEC_STALLED_LSB    _u(31)
+#define PROC_PIO_SM2_EXECCTRL_EXEC_STALLED_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_SIDE_EN
+// Description : If 1, the delay MSB is used as side-set enable, rather than a
+//               side-set data bit. This allows instructions to perform side-set
+//               optionally,
+//               rather than on every instruction.
+#define PROC_PIO_SM2_EXECCTRL_SIDE_EN_RESET  _u(0x0)
+#define PROC_PIO_SM2_EXECCTRL_SIDE_EN_BITS   _u(0x40000000)
+#define PROC_PIO_SM2_EXECCTRL_SIDE_EN_MSB    _u(30)
+#define PROC_PIO_SM2_EXECCTRL_SIDE_EN_LSB    _u(30)
+#define PROC_PIO_SM2_EXECCTRL_SIDE_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_SIDE_PINDIR
+// Description : Side-set data is asserted to pin OEs instead of pin values
+#define PROC_PIO_SM2_EXECCTRL_SIDE_PINDIR_RESET  _u(0x0)
+#define PROC_PIO_SM2_EXECCTRL_SIDE_PINDIR_BITS   _u(0x20000000)
+#define PROC_PIO_SM2_EXECCTRL_SIDE_PINDIR_MSB    _u(29)
+#define PROC_PIO_SM2_EXECCTRL_SIDE_PINDIR_LSB    _u(29)
+#define PROC_PIO_SM2_EXECCTRL_SIDE_PINDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_JMP_PIN
+// Description : The GPIO number to use as condition for JMP PIN. Unaffected by
+//               input mapping.
+#define PROC_PIO_SM2_EXECCTRL_JMP_PIN_RESET  _u(0x00)
+#define PROC_PIO_SM2_EXECCTRL_JMP_PIN_BITS   _u(0x1f000000)
+#define PROC_PIO_SM2_EXECCTRL_JMP_PIN_MSB    _u(28)
+#define PROC_PIO_SM2_EXECCTRL_JMP_PIN_LSB    _u(24)
+#define PROC_PIO_SM2_EXECCTRL_JMP_PIN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_OUT_EN_SEL
+// Description : Which data bit to use for inline OUT enable
+#define PROC_PIO_SM2_EXECCTRL_OUT_EN_SEL_RESET  _u(0x00)
+#define PROC_PIO_SM2_EXECCTRL_OUT_EN_SEL_BITS   _u(0x00f80000)
+#define PROC_PIO_SM2_EXECCTRL_OUT_EN_SEL_MSB    _u(23)
+#define PROC_PIO_SM2_EXECCTRL_OUT_EN_SEL_LSB    _u(19)
+#define PROC_PIO_SM2_EXECCTRL_OUT_EN_SEL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_INLINE_OUT_EN
+// Description : If 1, use a bit of OUT data as an auxiliary write enable
+//               When used in conjunction with OUT_STICKY, writes with an enable
+//               of 0 will
+//               deassert the latest pin write. This can create useful
+//               masking/override behaviour
+//               due to the priority ordering of state machine pin writes (SM0 <
+//               SM1 < ...)
+#define PROC_PIO_SM2_EXECCTRL_INLINE_OUT_EN_RESET  _u(0x0)
+#define PROC_PIO_SM2_EXECCTRL_INLINE_OUT_EN_BITS   _u(0x00040000)
+#define PROC_PIO_SM2_EXECCTRL_INLINE_OUT_EN_MSB    _u(18)
+#define PROC_PIO_SM2_EXECCTRL_INLINE_OUT_EN_LSB    _u(18)
+#define PROC_PIO_SM2_EXECCTRL_INLINE_OUT_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_OUT_STICKY
+// Description : Continuously assert the most recent OUT/SET to the pins
+#define PROC_PIO_SM2_EXECCTRL_OUT_STICKY_RESET  _u(0x0)
+#define PROC_PIO_SM2_EXECCTRL_OUT_STICKY_BITS   _u(0x00020000)
+#define PROC_PIO_SM2_EXECCTRL_OUT_STICKY_MSB    _u(17)
+#define PROC_PIO_SM2_EXECCTRL_OUT_STICKY_LSB    _u(17)
+#define PROC_PIO_SM2_EXECCTRL_OUT_STICKY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_WRAP_TOP
+// Description : After reaching this address, execution is wrapped to
+//               wrap_bottom.
+//               If the instruction is a jump, and the jump condition is true,
+//               the jump takes priority.
+#define PROC_PIO_SM2_EXECCTRL_WRAP_TOP_RESET  _u(0x1f)
+#define PROC_PIO_SM2_EXECCTRL_WRAP_TOP_BITS   _u(0x0001f000)
+#define PROC_PIO_SM2_EXECCTRL_WRAP_TOP_MSB    _u(16)
+#define PROC_PIO_SM2_EXECCTRL_WRAP_TOP_LSB    _u(12)
+#define PROC_PIO_SM2_EXECCTRL_WRAP_TOP_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_WRAP_BOTTOM
+// Description : After reaching wrap_top, execution is wrapped to this address.
+#define PROC_PIO_SM2_EXECCTRL_WRAP_BOTTOM_RESET  _u(0x00)
+#define PROC_PIO_SM2_EXECCTRL_WRAP_BOTTOM_BITS   _u(0x00000f80)
+#define PROC_PIO_SM2_EXECCTRL_WRAP_BOTTOM_MSB    _u(11)
+#define PROC_PIO_SM2_EXECCTRL_WRAP_BOTTOM_LSB    _u(7)
+#define PROC_PIO_SM2_EXECCTRL_WRAP_BOTTOM_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_STATUS_SEL
+// Description : Comparison used for the MOV x, STATUS instruction.
+//               0x0 -> All-ones if TX FIFO level < N, otherwise all-zeroes
+//               0x1 -> All-ones if RX FIFO level < N, otherwise all-zeroes
+#define PROC_PIO_SM2_EXECCTRL_STATUS_SEL_RESET         _u(0x0)
+#define PROC_PIO_SM2_EXECCTRL_STATUS_SEL_BITS          _u(0x00000020)
+#define PROC_PIO_SM2_EXECCTRL_STATUS_SEL_MSB           _u(5)
+#define PROC_PIO_SM2_EXECCTRL_STATUS_SEL_LSB           _u(5)
+#define PROC_PIO_SM2_EXECCTRL_STATUS_SEL_ACCESS        "RW"
+#define PROC_PIO_SM2_EXECCTRL_STATUS_SEL_VALUE_TXLEVEL _u(0x0)
+#define PROC_PIO_SM2_EXECCTRL_STATUS_SEL_VALUE_RXLEVEL _u(0x1)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_EXECCTRL_STATUS_N
+// Description : Comparison level for the MOV x, STATUS instruction
+#define PROC_PIO_SM2_EXECCTRL_STATUS_N_RESET  _u(0x00)
+#define PROC_PIO_SM2_EXECCTRL_STATUS_N_BITS   _u(0x0000001f)
+#define PROC_PIO_SM2_EXECCTRL_STATUS_N_MSB    _u(4)
+#define PROC_PIO_SM2_EXECCTRL_STATUS_N_LSB    _u(0)
+#define PROC_PIO_SM2_EXECCTRL_STATUS_N_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM2_SHIFTCTRL
+// Description : Control behaviour of the input/output shift registers for state
+//               machine 2
+#define PROC_PIO_SM2_SHIFTCTRL_OFFSET _u(0x00000114)
+#define PROC_PIO_SM2_SHIFTCTRL_BITS   _u(0xffff0000)
+#define PROC_PIO_SM2_SHIFTCTRL_RESET  _u(0x000c0000)
+#define PROC_PIO_SM2_SHIFTCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_SHIFTCTRL_FJOIN_RX
+// Description : When 1, RX FIFO steals the TX FIFO's storage, and becomes twice
+//               as deep.
+//               TX FIFO is disabled as a result (always reads as both full and
+//               empty).
+//               FIFOs are flushed when this bit is changed.
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_RX_RESET  _u(0x0)
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_RX_BITS   _u(0x80000000)
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_RX_MSB    _u(31)
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_RX_LSB    _u(31)
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_RX_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_SHIFTCTRL_FJOIN_TX
+// Description : When 1, TX FIFO steals the RX FIFO's storage, and becomes twice
+//               as deep.
+//               RX FIFO is disabled as a result (always reads as both full and
+//               empty).
+//               FIFOs are flushed when this bit is changed.
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_TX_RESET  _u(0x0)
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_TX_BITS   _u(0x40000000)
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_TX_MSB    _u(30)
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_TX_LSB    _u(30)
+#define PROC_PIO_SM2_SHIFTCTRL_FJOIN_TX_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_SHIFTCTRL_PULL_THRESH
+// Description : Number of bits shifted out of TXSR before autopull or
+//               conditional pull.
+//               Write 0 for value of 32.
+#define PROC_PIO_SM2_SHIFTCTRL_PULL_THRESH_RESET  _u(0x00)
+#define PROC_PIO_SM2_SHIFTCTRL_PULL_THRESH_BITS   _u(0x3e000000)
+#define PROC_PIO_SM2_SHIFTCTRL_PULL_THRESH_MSB    _u(29)
+#define PROC_PIO_SM2_SHIFTCTRL_PULL_THRESH_LSB    _u(25)
+#define PROC_PIO_SM2_SHIFTCTRL_PULL_THRESH_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_SHIFTCTRL_PUSH_THRESH
+// Description : Number of bits shifted into RXSR before autopush or conditional
+//               push.
+//               Write 0 for value of 32.
+#define PROC_PIO_SM2_SHIFTCTRL_PUSH_THRESH_RESET  _u(0x00)
+#define PROC_PIO_SM2_SHIFTCTRL_PUSH_THRESH_BITS   _u(0x01f00000)
+#define PROC_PIO_SM2_SHIFTCTRL_PUSH_THRESH_MSB    _u(24)
+#define PROC_PIO_SM2_SHIFTCTRL_PUSH_THRESH_LSB    _u(20)
+#define PROC_PIO_SM2_SHIFTCTRL_PUSH_THRESH_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_SHIFTCTRL_OUT_SHIFTDIR
+// Description : 1 = shift out of output shift register to right. 0 = to left.
+#define PROC_PIO_SM2_SHIFTCTRL_OUT_SHIFTDIR_RESET  _u(0x1)
+#define PROC_PIO_SM2_SHIFTCTRL_OUT_SHIFTDIR_BITS   _u(0x00080000)
+#define PROC_PIO_SM2_SHIFTCTRL_OUT_SHIFTDIR_MSB    _u(19)
+#define PROC_PIO_SM2_SHIFTCTRL_OUT_SHIFTDIR_LSB    _u(19)
+#define PROC_PIO_SM2_SHIFTCTRL_OUT_SHIFTDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_SHIFTCTRL_IN_SHIFTDIR
+// Description : 1 = shift input shift register to right (data enters from
+//               left). 0 = to left.
+#define PROC_PIO_SM2_SHIFTCTRL_IN_SHIFTDIR_RESET  _u(0x1)
+#define PROC_PIO_SM2_SHIFTCTRL_IN_SHIFTDIR_BITS   _u(0x00040000)
+#define PROC_PIO_SM2_SHIFTCTRL_IN_SHIFTDIR_MSB    _u(18)
+#define PROC_PIO_SM2_SHIFTCTRL_IN_SHIFTDIR_LSB    _u(18)
+#define PROC_PIO_SM2_SHIFTCTRL_IN_SHIFTDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_SHIFTCTRL_AUTOPULL
+// Description : Pull automatically when the output shift register is emptied
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPULL_RESET  _u(0x0)
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPULL_BITS   _u(0x00020000)
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPULL_MSB    _u(17)
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPULL_LSB    _u(17)
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_SHIFTCTRL_AUTOPUSH
+// Description : Push automatically when the input shift register is filled
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPUSH_RESET  _u(0x0)
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPUSH_BITS   _u(0x00010000)
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPUSH_MSB    _u(16)
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPUSH_LSB    _u(16)
+#define PROC_PIO_SM2_SHIFTCTRL_AUTOPUSH_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM2_ADDR
+// Description : Current instruction address of state machine 2
+#define PROC_PIO_SM2_ADDR_OFFSET _u(0x00000118)
+#define PROC_PIO_SM2_ADDR_BITS   _u(0x0000001f)
+#define PROC_PIO_SM2_ADDR_RESET  _u(0x00000000)
+#define PROC_PIO_SM2_ADDR_WIDTH  _u(32)
+#define PROC_PIO_SM2_ADDR_MSB    _u(4)
+#define PROC_PIO_SM2_ADDR_LSB    _u(0)
+#define PROC_PIO_SM2_ADDR_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_SM2_INSTR
+// Description : Instruction currently being executed by state machine 2
+//               Write to execute an instruction immediately (including jumps)
+//               and then resume execution.
+#define PROC_PIO_SM2_INSTR_OFFSET _u(0x0000011c)
+#define PROC_PIO_SM2_INSTR_BITS   _u(0x0000ffff)
+#define PROC_PIO_SM2_INSTR_RESET  "-"
+#define PROC_PIO_SM2_INSTR_WIDTH  _u(32)
+#define PROC_PIO_SM2_INSTR_MSB    _u(15)
+#define PROC_PIO_SM2_INSTR_LSB    _u(0)
+#define PROC_PIO_SM2_INSTR_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM2_PINCTRL
+// Description : State machine pin control
+#define PROC_PIO_SM2_PINCTRL_OFFSET _u(0x00000120)
+#define PROC_PIO_SM2_PINCTRL_BITS   _u(0xffffffff)
+#define PROC_PIO_SM2_PINCTRL_RESET  _u(0x14000000)
+#define PROC_PIO_SM2_PINCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_PINCTRL_SIDESET_COUNT
+// Description : The number of delay bits co-opted for side-set. Inclusive of
+//               the enable bit, if present.
+#define PROC_PIO_SM2_PINCTRL_SIDESET_COUNT_RESET  _u(0x0)
+#define PROC_PIO_SM2_PINCTRL_SIDESET_COUNT_BITS   _u(0xe0000000)
+#define PROC_PIO_SM2_PINCTRL_SIDESET_COUNT_MSB    _u(31)
+#define PROC_PIO_SM2_PINCTRL_SIDESET_COUNT_LSB    _u(29)
+#define PROC_PIO_SM2_PINCTRL_SIDESET_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_PINCTRL_SET_COUNT
+// Description : The number of pins asserted by a SET. Max of 5
+#define PROC_PIO_SM2_PINCTRL_SET_COUNT_RESET  _u(0x5)
+#define PROC_PIO_SM2_PINCTRL_SET_COUNT_BITS   _u(0x1c000000)
+#define PROC_PIO_SM2_PINCTRL_SET_COUNT_MSB    _u(28)
+#define PROC_PIO_SM2_PINCTRL_SET_COUNT_LSB    _u(26)
+#define PROC_PIO_SM2_PINCTRL_SET_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_PINCTRL_OUT_COUNT
+// Description : The number of pins asserted by an OUT. Value of 0 -> 32 pins
+#define PROC_PIO_SM2_PINCTRL_OUT_COUNT_RESET  _u(0x00)
+#define PROC_PIO_SM2_PINCTRL_OUT_COUNT_BITS   _u(0x03f00000)
+#define PROC_PIO_SM2_PINCTRL_OUT_COUNT_MSB    _u(25)
+#define PROC_PIO_SM2_PINCTRL_OUT_COUNT_LSB    _u(20)
+#define PROC_PIO_SM2_PINCTRL_OUT_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_PINCTRL_IN_BASE
+// Description : The virtual pin corresponding to IN bit 0
+#define PROC_PIO_SM2_PINCTRL_IN_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM2_PINCTRL_IN_BASE_BITS   _u(0x000f8000)
+#define PROC_PIO_SM2_PINCTRL_IN_BASE_MSB    _u(19)
+#define PROC_PIO_SM2_PINCTRL_IN_BASE_LSB    _u(15)
+#define PROC_PIO_SM2_PINCTRL_IN_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_PINCTRL_SIDESET_BASE
+// Description : The virtual pin corresponding to delay field bit 0
+#define PROC_PIO_SM2_PINCTRL_SIDESET_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM2_PINCTRL_SIDESET_BASE_BITS   _u(0x00007c00)
+#define PROC_PIO_SM2_PINCTRL_SIDESET_BASE_MSB    _u(14)
+#define PROC_PIO_SM2_PINCTRL_SIDESET_BASE_LSB    _u(10)
+#define PROC_PIO_SM2_PINCTRL_SIDESET_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_PINCTRL_SET_BASE
+// Description : The virtual pin corresponding to SET bit 0
+#define PROC_PIO_SM2_PINCTRL_SET_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM2_PINCTRL_SET_BASE_BITS   _u(0x000003e0)
+#define PROC_PIO_SM2_PINCTRL_SET_BASE_MSB    _u(9)
+#define PROC_PIO_SM2_PINCTRL_SET_BASE_LSB    _u(5)
+#define PROC_PIO_SM2_PINCTRL_SET_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_PINCTRL_OUT_BASE
+// Description : The virtual pin corresponding to OUT bit 0
+#define PROC_PIO_SM2_PINCTRL_OUT_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM2_PINCTRL_OUT_BASE_BITS   _u(0x0000001f)
+#define PROC_PIO_SM2_PINCTRL_OUT_BASE_MSB    _u(4)
+#define PROC_PIO_SM2_PINCTRL_OUT_BASE_LSB    _u(0)
+#define PROC_PIO_SM2_PINCTRL_OUT_BASE_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM2_DMACTRL_TX
+// Description : State machine DMA control
+#define PROC_PIO_SM2_DMACTRL_TX_OFFSET _u(0x00000124)
+#define PROC_PIO_SM2_DMACTRL_TX_BITS   _u(0xc0000f9f)
+#define PROC_PIO_SM2_DMACTRL_TX_RESET  _u(0x00000104)
+#define PROC_PIO_SM2_DMACTRL_TX_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_DMACTRL_TX_DREQ_EN
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM2_DMACTRL_TX_DREQ_EN_RESET  _u(0x0)
+#define PROC_PIO_SM2_DMACTRL_TX_DREQ_EN_BITS   _u(0x80000000)
+#define PROC_PIO_SM2_DMACTRL_TX_DREQ_EN_MSB    _u(31)
+#define PROC_PIO_SM2_DMACTRL_TX_DREQ_EN_LSB    _u(31)
+#define PROC_PIO_SM2_DMACTRL_TX_DREQ_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_DMACTRL_TX_ACTIVE
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM2_DMACTRL_TX_ACTIVE_RESET  "-"
+#define PROC_PIO_SM2_DMACTRL_TX_ACTIVE_BITS   _u(0x40000000)
+#define PROC_PIO_SM2_DMACTRL_TX_ACTIVE_MSB    _u(30)
+#define PROC_PIO_SM2_DMACTRL_TX_ACTIVE_LSB    _u(30)
+#define PROC_PIO_SM2_DMACTRL_TX_ACTIVE_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_DMACTRL_TX_DWELL_TIME
+// Description : Delay in number of bus cycles before successive DREQs are
+//               generated.
+//               Used to account for system bus latency in write data arriving
+//               at the FIFO.
+#define PROC_PIO_SM2_DMACTRL_TX_DWELL_TIME_RESET  _u(0x02)
+#define PROC_PIO_SM2_DMACTRL_TX_DWELL_TIME_BITS   _u(0x00000f80)
+#define PROC_PIO_SM2_DMACTRL_TX_DWELL_TIME_MSB    _u(11)
+#define PROC_PIO_SM2_DMACTRL_TX_DWELL_TIME_LSB    _u(7)
+#define PROC_PIO_SM2_DMACTRL_TX_DWELL_TIME_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_DMACTRL_TX_FIFO_THRESHOLD
+// Description : Threshold control. If there are no more than THRESHOLD items in
+//               the TX FIFO, DMA dreq and/or the interrupt line is asserted.
+#define PROC_PIO_SM2_DMACTRL_TX_FIFO_THRESHOLD_RESET  _u(0x04)
+#define PROC_PIO_SM2_DMACTRL_TX_FIFO_THRESHOLD_BITS   _u(0x0000001f)
+#define PROC_PIO_SM2_DMACTRL_TX_FIFO_THRESHOLD_MSB    _u(4)
+#define PROC_PIO_SM2_DMACTRL_TX_FIFO_THRESHOLD_LSB    _u(0)
+#define PROC_PIO_SM2_DMACTRL_TX_FIFO_THRESHOLD_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM2_DMACTRL_RX
+// Description : State machine DMA control
+#define PROC_PIO_SM2_DMACTRL_RX_OFFSET _u(0x00000128)
+#define PROC_PIO_SM2_DMACTRL_RX_BITS   _u(0xc0000f9f)
+#define PROC_PIO_SM2_DMACTRL_RX_RESET  _u(0x00000104)
+#define PROC_PIO_SM2_DMACTRL_RX_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_DMACTRL_RX_DREQ_EN
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM2_DMACTRL_RX_DREQ_EN_RESET  _u(0x0)
+#define PROC_PIO_SM2_DMACTRL_RX_DREQ_EN_BITS   _u(0x80000000)
+#define PROC_PIO_SM2_DMACTRL_RX_DREQ_EN_MSB    _u(31)
+#define PROC_PIO_SM2_DMACTRL_RX_DREQ_EN_LSB    _u(31)
+#define PROC_PIO_SM2_DMACTRL_RX_DREQ_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_DMACTRL_RX_ACTIVE
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM2_DMACTRL_RX_ACTIVE_RESET  "-"
+#define PROC_PIO_SM2_DMACTRL_RX_ACTIVE_BITS   _u(0x40000000)
+#define PROC_PIO_SM2_DMACTRL_RX_ACTIVE_MSB    _u(30)
+#define PROC_PIO_SM2_DMACTRL_RX_ACTIVE_LSB    _u(30)
+#define PROC_PIO_SM2_DMACTRL_RX_ACTIVE_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_DMACTRL_RX_DWELL_TIME
+// Description : Delay in number of bus cycles before successive DREQs are
+//               generated.
+//               Used to account for system bus latency in write data arriving
+//               at the FIFO.
+#define PROC_PIO_SM2_DMACTRL_RX_DWELL_TIME_RESET  _u(0x02)
+#define PROC_PIO_SM2_DMACTRL_RX_DWELL_TIME_BITS   _u(0x00000f80)
+#define PROC_PIO_SM2_DMACTRL_RX_DWELL_TIME_MSB    _u(11)
+#define PROC_PIO_SM2_DMACTRL_RX_DWELL_TIME_LSB    _u(7)
+#define PROC_PIO_SM2_DMACTRL_RX_DWELL_TIME_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM2_DMACTRL_RX_FIFO_THRESHOLD
+// Description : Threshold control. If there are at least THRESHOLD items in the
+//               RX FIFO, DMA dreq and/or the interrupt line is asserted.
+#define PROC_PIO_SM2_DMACTRL_RX_FIFO_THRESHOLD_RESET  _u(0x04)
+#define PROC_PIO_SM2_DMACTRL_RX_FIFO_THRESHOLD_BITS   _u(0x0000001f)
+#define PROC_PIO_SM2_DMACTRL_RX_FIFO_THRESHOLD_MSB    _u(4)
+#define PROC_PIO_SM2_DMACTRL_RX_FIFO_THRESHOLD_LSB    _u(0)
+#define PROC_PIO_SM2_DMACTRL_RX_FIFO_THRESHOLD_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM3_CLKDIV
+// Description : Clock divider register for state machine 3
+//               Frequency = clock freq / (CLKDIV_INT + CLKDIV_FRAC / 256)
+#define PROC_PIO_SM3_CLKDIV_OFFSET _u(0x0000012c)
+#define PROC_PIO_SM3_CLKDIV_BITS   _u(0xffffff00)
+#define PROC_PIO_SM3_CLKDIV_RESET  _u(0x00010000)
+#define PROC_PIO_SM3_CLKDIV_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_CLKDIV_INT
+// Description : Effective frequency is sysclk/int.
+//               Value of 0 is interpreted as max possible value
+#define PROC_PIO_SM3_CLKDIV_INT_RESET  _u(0x0001)
+#define PROC_PIO_SM3_CLKDIV_INT_BITS   _u(0xffff0000)
+#define PROC_PIO_SM3_CLKDIV_INT_MSB    _u(31)
+#define PROC_PIO_SM3_CLKDIV_INT_LSB    _u(16)
+#define PROC_PIO_SM3_CLKDIV_INT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_CLKDIV_FRAC
+// Description : Fractional part of clock divider
+#define PROC_PIO_SM3_CLKDIV_FRAC_RESET  _u(0x00)
+#define PROC_PIO_SM3_CLKDIV_FRAC_BITS   _u(0x0000ff00)
+#define PROC_PIO_SM3_CLKDIV_FRAC_MSB    _u(15)
+#define PROC_PIO_SM3_CLKDIV_FRAC_LSB    _u(8)
+#define PROC_PIO_SM3_CLKDIV_FRAC_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM3_EXECCTRL
+// Description : Execution/behavioural settings for state machine 3
+#define PROC_PIO_SM3_EXECCTRL_OFFSET _u(0x00000130)
+#define PROC_PIO_SM3_EXECCTRL_BITS   _u(0xffffffbf)
+#define PROC_PIO_SM3_EXECCTRL_RESET  _u(0x0001f000)
+#define PROC_PIO_SM3_EXECCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_EXEC_STALLED
+// Description : An instruction written to SMx_INSTR is stalled, and latched by
+//               the
+//               state machine. Will clear once the instruction completes.
+#define PROC_PIO_SM3_EXECCTRL_EXEC_STALLED_RESET  _u(0x0)
+#define PROC_PIO_SM3_EXECCTRL_EXEC_STALLED_BITS   _u(0x80000000)
+#define PROC_PIO_SM3_EXECCTRL_EXEC_STALLED_MSB    _u(31)
+#define PROC_PIO_SM3_EXECCTRL_EXEC_STALLED_LSB    _u(31)
+#define PROC_PIO_SM3_EXECCTRL_EXEC_STALLED_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_SIDE_EN
+// Description : If 1, the delay MSB is used as side-set enable, rather than a
+//               side-set data bit. This allows instructions to perform side-set
+//               optionally,
+//               rather than on every instruction.
+#define PROC_PIO_SM3_EXECCTRL_SIDE_EN_RESET  _u(0x0)
+#define PROC_PIO_SM3_EXECCTRL_SIDE_EN_BITS   _u(0x40000000)
+#define PROC_PIO_SM3_EXECCTRL_SIDE_EN_MSB    _u(30)
+#define PROC_PIO_SM3_EXECCTRL_SIDE_EN_LSB    _u(30)
+#define PROC_PIO_SM3_EXECCTRL_SIDE_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_SIDE_PINDIR
+// Description : Side-set data is asserted to pin OEs instead of pin values
+#define PROC_PIO_SM3_EXECCTRL_SIDE_PINDIR_RESET  _u(0x0)
+#define PROC_PIO_SM3_EXECCTRL_SIDE_PINDIR_BITS   _u(0x20000000)
+#define PROC_PIO_SM3_EXECCTRL_SIDE_PINDIR_MSB    _u(29)
+#define PROC_PIO_SM3_EXECCTRL_SIDE_PINDIR_LSB    _u(29)
+#define PROC_PIO_SM3_EXECCTRL_SIDE_PINDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_JMP_PIN
+// Description : The GPIO number to use as condition for JMP PIN. Unaffected by
+//               input mapping.
+#define PROC_PIO_SM3_EXECCTRL_JMP_PIN_RESET  _u(0x00)
+#define PROC_PIO_SM3_EXECCTRL_JMP_PIN_BITS   _u(0x1f000000)
+#define PROC_PIO_SM3_EXECCTRL_JMP_PIN_MSB    _u(28)
+#define PROC_PIO_SM3_EXECCTRL_JMP_PIN_LSB    _u(24)
+#define PROC_PIO_SM3_EXECCTRL_JMP_PIN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_OUT_EN_SEL
+// Description : Which data bit to use for inline OUT enable
+#define PROC_PIO_SM3_EXECCTRL_OUT_EN_SEL_RESET  _u(0x00)
+#define PROC_PIO_SM3_EXECCTRL_OUT_EN_SEL_BITS   _u(0x00f80000)
+#define PROC_PIO_SM3_EXECCTRL_OUT_EN_SEL_MSB    _u(23)
+#define PROC_PIO_SM3_EXECCTRL_OUT_EN_SEL_LSB    _u(19)
+#define PROC_PIO_SM3_EXECCTRL_OUT_EN_SEL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_INLINE_OUT_EN
+// Description : If 1, use a bit of OUT data as an auxiliary write enable
+//               When used in conjunction with OUT_STICKY, writes with an enable
+//               of 0 will
+//               deassert the latest pin write. This can create useful
+//               masking/override behaviour
+//               due to the priority ordering of state machine pin writes (SM0 <
+//               SM1 < ...)
+#define PROC_PIO_SM3_EXECCTRL_INLINE_OUT_EN_RESET  _u(0x0)
+#define PROC_PIO_SM3_EXECCTRL_INLINE_OUT_EN_BITS   _u(0x00040000)
+#define PROC_PIO_SM3_EXECCTRL_INLINE_OUT_EN_MSB    _u(18)
+#define PROC_PIO_SM3_EXECCTRL_INLINE_OUT_EN_LSB    _u(18)
+#define PROC_PIO_SM3_EXECCTRL_INLINE_OUT_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_OUT_STICKY
+// Description : Continuously assert the most recent OUT/SET to the pins
+#define PROC_PIO_SM3_EXECCTRL_OUT_STICKY_RESET  _u(0x0)
+#define PROC_PIO_SM3_EXECCTRL_OUT_STICKY_BITS   _u(0x00020000)
+#define PROC_PIO_SM3_EXECCTRL_OUT_STICKY_MSB    _u(17)
+#define PROC_PIO_SM3_EXECCTRL_OUT_STICKY_LSB    _u(17)
+#define PROC_PIO_SM3_EXECCTRL_OUT_STICKY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_WRAP_TOP
+// Description : After reaching this address, execution is wrapped to
+//               wrap_bottom.
+//               If the instruction is a jump, and the jump condition is true,
+//               the jump takes priority.
+#define PROC_PIO_SM3_EXECCTRL_WRAP_TOP_RESET  _u(0x1f)
+#define PROC_PIO_SM3_EXECCTRL_WRAP_TOP_BITS   _u(0x0001f000)
+#define PROC_PIO_SM3_EXECCTRL_WRAP_TOP_MSB    _u(16)
+#define PROC_PIO_SM3_EXECCTRL_WRAP_TOP_LSB    _u(12)
+#define PROC_PIO_SM3_EXECCTRL_WRAP_TOP_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_WRAP_BOTTOM
+// Description : After reaching wrap_top, execution is wrapped to this address.
+#define PROC_PIO_SM3_EXECCTRL_WRAP_BOTTOM_RESET  _u(0x00)
+#define PROC_PIO_SM3_EXECCTRL_WRAP_BOTTOM_BITS   _u(0x00000f80)
+#define PROC_PIO_SM3_EXECCTRL_WRAP_BOTTOM_MSB    _u(11)
+#define PROC_PIO_SM3_EXECCTRL_WRAP_BOTTOM_LSB    _u(7)
+#define PROC_PIO_SM3_EXECCTRL_WRAP_BOTTOM_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_STATUS_SEL
+// Description : Comparison used for the MOV x, STATUS instruction.
+//               0x0 -> All-ones if TX FIFO level < N, otherwise all-zeroes
+//               0x1 -> All-ones if RX FIFO level < N, otherwise all-zeroes
+#define PROC_PIO_SM3_EXECCTRL_STATUS_SEL_RESET         _u(0x0)
+#define PROC_PIO_SM3_EXECCTRL_STATUS_SEL_BITS          _u(0x00000020)
+#define PROC_PIO_SM3_EXECCTRL_STATUS_SEL_MSB           _u(5)
+#define PROC_PIO_SM3_EXECCTRL_STATUS_SEL_LSB           _u(5)
+#define PROC_PIO_SM3_EXECCTRL_STATUS_SEL_ACCESS        "RW"
+#define PROC_PIO_SM3_EXECCTRL_STATUS_SEL_VALUE_TXLEVEL _u(0x0)
+#define PROC_PIO_SM3_EXECCTRL_STATUS_SEL_VALUE_RXLEVEL _u(0x1)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_EXECCTRL_STATUS_N
+// Description : Comparison level for the MOV x, STATUS instruction
+#define PROC_PIO_SM3_EXECCTRL_STATUS_N_RESET  _u(0x00)
+#define PROC_PIO_SM3_EXECCTRL_STATUS_N_BITS   _u(0x0000001f)
+#define PROC_PIO_SM3_EXECCTRL_STATUS_N_MSB    _u(4)
+#define PROC_PIO_SM3_EXECCTRL_STATUS_N_LSB    _u(0)
+#define PROC_PIO_SM3_EXECCTRL_STATUS_N_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM3_SHIFTCTRL
+// Description : Control behaviour of the input/output shift registers for state
+//               machine 3
+#define PROC_PIO_SM3_SHIFTCTRL_OFFSET _u(0x00000134)
+#define PROC_PIO_SM3_SHIFTCTRL_BITS   _u(0xffff0000)
+#define PROC_PIO_SM3_SHIFTCTRL_RESET  _u(0x000c0000)
+#define PROC_PIO_SM3_SHIFTCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_SHIFTCTRL_FJOIN_RX
+// Description : When 1, RX FIFO steals the TX FIFO's storage, and becomes twice
+//               as deep.
+//               TX FIFO is disabled as a result (always reads as both full and
+//               empty).
+//               FIFOs are flushed when this bit is changed.
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_RX_RESET  _u(0x0)
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_RX_BITS   _u(0x80000000)
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_RX_MSB    _u(31)
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_RX_LSB    _u(31)
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_RX_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_SHIFTCTRL_FJOIN_TX
+// Description : When 1, TX FIFO steals the RX FIFO's storage, and becomes twice
+//               as deep.
+//               RX FIFO is disabled as a result (always reads as both full and
+//               empty).
+//               FIFOs are flushed when this bit is changed.
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_TX_RESET  _u(0x0)
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_TX_BITS   _u(0x40000000)
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_TX_MSB    _u(30)
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_TX_LSB    _u(30)
+#define PROC_PIO_SM3_SHIFTCTRL_FJOIN_TX_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_SHIFTCTRL_PULL_THRESH
+// Description : Number of bits shifted out of TXSR before autopull or
+//               conditional pull.
+//               Write 0 for value of 32.
+#define PROC_PIO_SM3_SHIFTCTRL_PULL_THRESH_RESET  _u(0x00)
+#define PROC_PIO_SM3_SHIFTCTRL_PULL_THRESH_BITS   _u(0x3e000000)
+#define PROC_PIO_SM3_SHIFTCTRL_PULL_THRESH_MSB    _u(29)
+#define PROC_PIO_SM3_SHIFTCTRL_PULL_THRESH_LSB    _u(25)
+#define PROC_PIO_SM3_SHIFTCTRL_PULL_THRESH_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_SHIFTCTRL_PUSH_THRESH
+// Description : Number of bits shifted into RXSR before autopush or conditional
+//               push.
+//               Write 0 for value of 32.
+#define PROC_PIO_SM3_SHIFTCTRL_PUSH_THRESH_RESET  _u(0x00)
+#define PROC_PIO_SM3_SHIFTCTRL_PUSH_THRESH_BITS   _u(0x01f00000)
+#define PROC_PIO_SM3_SHIFTCTRL_PUSH_THRESH_MSB    _u(24)
+#define PROC_PIO_SM3_SHIFTCTRL_PUSH_THRESH_LSB    _u(20)
+#define PROC_PIO_SM3_SHIFTCTRL_PUSH_THRESH_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_SHIFTCTRL_OUT_SHIFTDIR
+// Description : 1 = shift out of output shift register to right. 0 = to left.
+#define PROC_PIO_SM3_SHIFTCTRL_OUT_SHIFTDIR_RESET  _u(0x1)
+#define PROC_PIO_SM3_SHIFTCTRL_OUT_SHIFTDIR_BITS   _u(0x00080000)
+#define PROC_PIO_SM3_SHIFTCTRL_OUT_SHIFTDIR_MSB    _u(19)
+#define PROC_PIO_SM3_SHIFTCTRL_OUT_SHIFTDIR_LSB    _u(19)
+#define PROC_PIO_SM3_SHIFTCTRL_OUT_SHIFTDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_SHIFTCTRL_IN_SHIFTDIR
+// Description : 1 = shift input shift register to right (data enters from
+//               left). 0 = to left.
+#define PROC_PIO_SM3_SHIFTCTRL_IN_SHIFTDIR_RESET  _u(0x1)
+#define PROC_PIO_SM3_SHIFTCTRL_IN_SHIFTDIR_BITS   _u(0x00040000)
+#define PROC_PIO_SM3_SHIFTCTRL_IN_SHIFTDIR_MSB    _u(18)
+#define PROC_PIO_SM3_SHIFTCTRL_IN_SHIFTDIR_LSB    _u(18)
+#define PROC_PIO_SM3_SHIFTCTRL_IN_SHIFTDIR_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_SHIFTCTRL_AUTOPULL
+// Description : Pull automatically when the output shift register is emptied
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPULL_RESET  _u(0x0)
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPULL_BITS   _u(0x00020000)
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPULL_MSB    _u(17)
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPULL_LSB    _u(17)
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_SHIFTCTRL_AUTOPUSH
+// Description : Push automatically when the input shift register is filled
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPUSH_RESET  _u(0x0)
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPUSH_BITS   _u(0x00010000)
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPUSH_MSB    _u(16)
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPUSH_LSB    _u(16)
+#define PROC_PIO_SM3_SHIFTCTRL_AUTOPUSH_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM3_ADDR
+// Description : Current instruction address of state machine 3
+#define PROC_PIO_SM3_ADDR_OFFSET _u(0x00000138)
+#define PROC_PIO_SM3_ADDR_BITS   _u(0x0000001f)
+#define PROC_PIO_SM3_ADDR_RESET  _u(0x00000000)
+#define PROC_PIO_SM3_ADDR_WIDTH  _u(32)
+#define PROC_PIO_SM3_ADDR_MSB    _u(4)
+#define PROC_PIO_SM3_ADDR_LSB    _u(0)
+#define PROC_PIO_SM3_ADDR_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_SM3_INSTR
+// Description : Instruction currently being executed by state machine 3
+//               Write to execute an instruction immediately (including jumps)
+//               and then resume execution.
+#define PROC_PIO_SM3_INSTR_OFFSET _u(0x0000013c)
+#define PROC_PIO_SM3_INSTR_BITS   _u(0x0000ffff)
+#define PROC_PIO_SM3_INSTR_RESET  "-"
+#define PROC_PIO_SM3_INSTR_WIDTH  _u(32)
+#define PROC_PIO_SM3_INSTR_MSB    _u(15)
+#define PROC_PIO_SM3_INSTR_LSB    _u(0)
+#define PROC_PIO_SM3_INSTR_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM3_PINCTRL
+// Description : State machine pin control
+#define PROC_PIO_SM3_PINCTRL_OFFSET _u(0x00000140)
+#define PROC_PIO_SM3_PINCTRL_BITS   _u(0xffffffff)
+#define PROC_PIO_SM3_PINCTRL_RESET  _u(0x14000000)
+#define PROC_PIO_SM3_PINCTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_PINCTRL_SIDESET_COUNT
+// Description : The number of delay bits co-opted for side-set. Inclusive of
+//               the enable bit, if present.
+#define PROC_PIO_SM3_PINCTRL_SIDESET_COUNT_RESET  _u(0x0)
+#define PROC_PIO_SM3_PINCTRL_SIDESET_COUNT_BITS   _u(0xe0000000)
+#define PROC_PIO_SM3_PINCTRL_SIDESET_COUNT_MSB    _u(31)
+#define PROC_PIO_SM3_PINCTRL_SIDESET_COUNT_LSB    _u(29)
+#define PROC_PIO_SM3_PINCTRL_SIDESET_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_PINCTRL_SET_COUNT
+// Description : The number of pins asserted by a SET. Max of 5
+#define PROC_PIO_SM3_PINCTRL_SET_COUNT_RESET  _u(0x5)
+#define PROC_PIO_SM3_PINCTRL_SET_COUNT_BITS   _u(0x1c000000)
+#define PROC_PIO_SM3_PINCTRL_SET_COUNT_MSB    _u(28)
+#define PROC_PIO_SM3_PINCTRL_SET_COUNT_LSB    _u(26)
+#define PROC_PIO_SM3_PINCTRL_SET_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_PINCTRL_OUT_COUNT
+// Description : The number of pins asserted by an OUT. Value of 0 -> 32 pins
+#define PROC_PIO_SM3_PINCTRL_OUT_COUNT_RESET  _u(0x00)
+#define PROC_PIO_SM3_PINCTRL_OUT_COUNT_BITS   _u(0x03f00000)
+#define PROC_PIO_SM3_PINCTRL_OUT_COUNT_MSB    _u(25)
+#define PROC_PIO_SM3_PINCTRL_OUT_COUNT_LSB    _u(20)
+#define PROC_PIO_SM3_PINCTRL_OUT_COUNT_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_PINCTRL_IN_BASE
+// Description : The virtual pin corresponding to IN bit 0
+#define PROC_PIO_SM3_PINCTRL_IN_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM3_PINCTRL_IN_BASE_BITS   _u(0x000f8000)
+#define PROC_PIO_SM3_PINCTRL_IN_BASE_MSB    _u(19)
+#define PROC_PIO_SM3_PINCTRL_IN_BASE_LSB    _u(15)
+#define PROC_PIO_SM3_PINCTRL_IN_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_PINCTRL_SIDESET_BASE
+// Description : The virtual pin corresponding to delay field bit 0
+#define PROC_PIO_SM3_PINCTRL_SIDESET_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM3_PINCTRL_SIDESET_BASE_BITS   _u(0x00007c00)
+#define PROC_PIO_SM3_PINCTRL_SIDESET_BASE_MSB    _u(14)
+#define PROC_PIO_SM3_PINCTRL_SIDESET_BASE_LSB    _u(10)
+#define PROC_PIO_SM3_PINCTRL_SIDESET_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_PINCTRL_SET_BASE
+// Description : The virtual pin corresponding to SET bit 0
+#define PROC_PIO_SM3_PINCTRL_SET_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM3_PINCTRL_SET_BASE_BITS   _u(0x000003e0)
+#define PROC_PIO_SM3_PINCTRL_SET_BASE_MSB    _u(9)
+#define PROC_PIO_SM3_PINCTRL_SET_BASE_LSB    _u(5)
+#define PROC_PIO_SM3_PINCTRL_SET_BASE_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_PINCTRL_OUT_BASE
+// Description : The virtual pin corresponding to OUT bit 0
+#define PROC_PIO_SM3_PINCTRL_OUT_BASE_RESET  _u(0x00)
+#define PROC_PIO_SM3_PINCTRL_OUT_BASE_BITS   _u(0x0000001f)
+#define PROC_PIO_SM3_PINCTRL_OUT_BASE_MSB    _u(4)
+#define PROC_PIO_SM3_PINCTRL_OUT_BASE_LSB    _u(0)
+#define PROC_PIO_SM3_PINCTRL_OUT_BASE_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM3_DMACTRL_TX
+// Description : State machine DMA control
+#define PROC_PIO_SM3_DMACTRL_TX_OFFSET _u(0x00000144)
+#define PROC_PIO_SM3_DMACTRL_TX_BITS   _u(0xc0000f9f)
+#define PROC_PIO_SM3_DMACTRL_TX_RESET  _u(0x00000104)
+#define PROC_PIO_SM3_DMACTRL_TX_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_DMACTRL_TX_DREQ_EN
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM3_DMACTRL_TX_DREQ_EN_RESET  _u(0x0)
+#define PROC_PIO_SM3_DMACTRL_TX_DREQ_EN_BITS   _u(0x80000000)
+#define PROC_PIO_SM3_DMACTRL_TX_DREQ_EN_MSB    _u(31)
+#define PROC_PIO_SM3_DMACTRL_TX_DREQ_EN_LSB    _u(31)
+#define PROC_PIO_SM3_DMACTRL_TX_DREQ_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_DMACTRL_TX_ACTIVE
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM3_DMACTRL_TX_ACTIVE_RESET  "-"
+#define PROC_PIO_SM3_DMACTRL_TX_ACTIVE_BITS   _u(0x40000000)
+#define PROC_PIO_SM3_DMACTRL_TX_ACTIVE_MSB    _u(30)
+#define PROC_PIO_SM3_DMACTRL_TX_ACTIVE_LSB    _u(30)
+#define PROC_PIO_SM3_DMACTRL_TX_ACTIVE_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_DMACTRL_TX_DWELL_TIME
+// Description : Delay in number of bus cycles before successive DREQs are
+//               generated.
+//               Used to account for system bus latency in write data arriving
+//               at the FIFO.
+#define PROC_PIO_SM3_DMACTRL_TX_DWELL_TIME_RESET  _u(0x02)
+#define PROC_PIO_SM3_DMACTRL_TX_DWELL_TIME_BITS   _u(0x00000f80)
+#define PROC_PIO_SM3_DMACTRL_TX_DWELL_TIME_MSB    _u(11)
+#define PROC_PIO_SM3_DMACTRL_TX_DWELL_TIME_LSB    _u(7)
+#define PROC_PIO_SM3_DMACTRL_TX_DWELL_TIME_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_DMACTRL_TX_FIFO_THRESHOLD
+// Description : Threshold control. If there are no more than THRESHOLD items in
+//               the TX FIFO, DMA dreq and/or the interrupt line is asserted.
+#define PROC_PIO_SM3_DMACTRL_TX_FIFO_THRESHOLD_RESET  _u(0x04)
+#define PROC_PIO_SM3_DMACTRL_TX_FIFO_THRESHOLD_BITS   _u(0x0000001f)
+#define PROC_PIO_SM3_DMACTRL_TX_FIFO_THRESHOLD_MSB    _u(4)
+#define PROC_PIO_SM3_DMACTRL_TX_FIFO_THRESHOLD_LSB    _u(0)
+#define PROC_PIO_SM3_DMACTRL_TX_FIFO_THRESHOLD_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_SM3_DMACTRL_RX
+// Description : State machine DMA control
+#define PROC_PIO_SM3_DMACTRL_RX_OFFSET _u(0x00000148)
+#define PROC_PIO_SM3_DMACTRL_RX_BITS   _u(0xc0000f9f)
+#define PROC_PIO_SM3_DMACTRL_RX_RESET  _u(0x00000104)
+#define PROC_PIO_SM3_DMACTRL_RX_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_DMACTRL_RX_DREQ_EN
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM3_DMACTRL_RX_DREQ_EN_RESET  _u(0x0)
+#define PROC_PIO_SM3_DMACTRL_RX_DREQ_EN_BITS   _u(0x80000000)
+#define PROC_PIO_SM3_DMACTRL_RX_DREQ_EN_MSB    _u(31)
+#define PROC_PIO_SM3_DMACTRL_RX_DREQ_EN_LSB    _u(31)
+#define PROC_PIO_SM3_DMACTRL_RX_DREQ_EN_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_DMACTRL_RX_ACTIVE
+// Description : 1 - Assert DREQ to DMA when fewer than fifo_threshold spaces
+//               are available
+//               0 - Don't assert DREQ
+#define PROC_PIO_SM3_DMACTRL_RX_ACTIVE_RESET  "-"
+#define PROC_PIO_SM3_DMACTRL_RX_ACTIVE_BITS   _u(0x40000000)
+#define PROC_PIO_SM3_DMACTRL_RX_ACTIVE_MSB    _u(30)
+#define PROC_PIO_SM3_DMACTRL_RX_ACTIVE_LSB    _u(30)
+#define PROC_PIO_SM3_DMACTRL_RX_ACTIVE_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_DMACTRL_RX_DWELL_TIME
+// Description : Delay in number of bus cycles before successive DREQs are
+//               generated.
+//               Used to account for system bus latency in write data arriving
+//               at the FIFO.
+#define PROC_PIO_SM3_DMACTRL_RX_DWELL_TIME_RESET  _u(0x02)
+#define PROC_PIO_SM3_DMACTRL_RX_DWELL_TIME_BITS   _u(0x00000f80)
+#define PROC_PIO_SM3_DMACTRL_RX_DWELL_TIME_MSB    _u(11)
+#define PROC_PIO_SM3_DMACTRL_RX_DWELL_TIME_LSB    _u(7)
+#define PROC_PIO_SM3_DMACTRL_RX_DWELL_TIME_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_SM3_DMACTRL_RX_FIFO_THRESHOLD
+// Description : Threshold control. If there are at least THRESHOLD items in the
+//               RX FIFO, DMA dreq and/or the interrupt line is asserted.
+#define PROC_PIO_SM3_DMACTRL_RX_FIFO_THRESHOLD_RESET  _u(0x04)
+#define PROC_PIO_SM3_DMACTRL_RX_FIFO_THRESHOLD_BITS   _u(0x0000001f)
+#define PROC_PIO_SM3_DMACTRL_RX_FIFO_THRESHOLD_MSB    _u(4)
+#define PROC_PIO_SM3_DMACTRL_RX_FIFO_THRESHOLD_LSB    _u(0)
+#define PROC_PIO_SM3_DMACTRL_RX_FIFO_THRESHOLD_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_INTR
+// Description : Raw Interrupts
+#define PROC_PIO_INTR_OFFSET _u(0x0000014c)
+#define PROC_PIO_INTR_BITS   _u(0x00000fff)
+#define PROC_PIO_INTR_RESET  _u(0x00000000)
+#define PROC_PIO_INTR_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM3
+// Description : None
+#define PROC_PIO_INTR_SM3_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM3_BITS   _u(0x00000800)
+#define PROC_PIO_INTR_SM3_MSB    _u(11)
+#define PROC_PIO_INTR_SM3_LSB    _u(11)
+#define PROC_PIO_INTR_SM3_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM2
+// Description : None
+#define PROC_PIO_INTR_SM2_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM2_BITS   _u(0x00000400)
+#define PROC_PIO_INTR_SM2_MSB    _u(10)
+#define PROC_PIO_INTR_SM2_LSB    _u(10)
+#define PROC_PIO_INTR_SM2_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM1
+// Description : None
+#define PROC_PIO_INTR_SM1_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM1_BITS   _u(0x00000200)
+#define PROC_PIO_INTR_SM1_MSB    _u(9)
+#define PROC_PIO_INTR_SM1_LSB    _u(9)
+#define PROC_PIO_INTR_SM1_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM0
+// Description : None
+#define PROC_PIO_INTR_SM0_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM0_BITS   _u(0x00000100)
+#define PROC_PIO_INTR_SM0_MSB    _u(8)
+#define PROC_PIO_INTR_SM0_LSB    _u(8)
+#define PROC_PIO_INTR_SM0_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM3_TXNFULL
+// Description : None
+#define PROC_PIO_INTR_SM3_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM3_TXNFULL_BITS   _u(0x00000080)
+#define PROC_PIO_INTR_SM3_TXNFULL_MSB    _u(7)
+#define PROC_PIO_INTR_SM3_TXNFULL_LSB    _u(7)
+#define PROC_PIO_INTR_SM3_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM2_TXNFULL
+// Description : None
+#define PROC_PIO_INTR_SM2_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM2_TXNFULL_BITS   _u(0x00000040)
+#define PROC_PIO_INTR_SM2_TXNFULL_MSB    _u(6)
+#define PROC_PIO_INTR_SM2_TXNFULL_LSB    _u(6)
+#define PROC_PIO_INTR_SM2_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM1_TXNFULL
+// Description : None
+#define PROC_PIO_INTR_SM1_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM1_TXNFULL_BITS   _u(0x00000020)
+#define PROC_PIO_INTR_SM1_TXNFULL_MSB    _u(5)
+#define PROC_PIO_INTR_SM1_TXNFULL_LSB    _u(5)
+#define PROC_PIO_INTR_SM1_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM0_TXNFULL
+// Description : None
+#define PROC_PIO_INTR_SM0_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM0_TXNFULL_BITS   _u(0x00000010)
+#define PROC_PIO_INTR_SM0_TXNFULL_MSB    _u(4)
+#define PROC_PIO_INTR_SM0_TXNFULL_LSB    _u(4)
+#define PROC_PIO_INTR_SM0_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM3_RXNEMPTY
+// Description : None
+#define PROC_PIO_INTR_SM3_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM3_RXNEMPTY_BITS   _u(0x00000008)
+#define PROC_PIO_INTR_SM3_RXNEMPTY_MSB    _u(3)
+#define PROC_PIO_INTR_SM3_RXNEMPTY_LSB    _u(3)
+#define PROC_PIO_INTR_SM3_RXNEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM2_RXNEMPTY
+// Description : None
+#define PROC_PIO_INTR_SM2_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM2_RXNEMPTY_BITS   _u(0x00000004)
+#define PROC_PIO_INTR_SM2_RXNEMPTY_MSB    _u(2)
+#define PROC_PIO_INTR_SM2_RXNEMPTY_LSB    _u(2)
+#define PROC_PIO_INTR_SM2_RXNEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM1_RXNEMPTY
+// Description : None
+#define PROC_PIO_INTR_SM1_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM1_RXNEMPTY_BITS   _u(0x00000002)
+#define PROC_PIO_INTR_SM1_RXNEMPTY_MSB    _u(1)
+#define PROC_PIO_INTR_SM1_RXNEMPTY_LSB    _u(1)
+#define PROC_PIO_INTR_SM1_RXNEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_INTR_SM0_RXNEMPTY
+// Description : None
+#define PROC_PIO_INTR_SM0_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_INTR_SM0_RXNEMPTY_BITS   _u(0x00000001)
+#define PROC_PIO_INTR_SM0_RXNEMPTY_MSB    _u(0)
+#define PROC_PIO_INTR_SM0_RXNEMPTY_LSB    _u(0)
+#define PROC_PIO_INTR_SM0_RXNEMPTY_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_IRQ0_INTE
+// Description : Interrupt Enable for irq0
+#define PROC_PIO_IRQ0_INTE_OFFSET _u(0x00000150)
+#define PROC_PIO_IRQ0_INTE_BITS   _u(0x00000fff)
+#define PROC_PIO_IRQ0_INTE_RESET  _u(0x00000000)
+#define PROC_PIO_IRQ0_INTE_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM3
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM3_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM3_BITS   _u(0x00000800)
+#define PROC_PIO_IRQ0_INTE_SM3_MSB    _u(11)
+#define PROC_PIO_IRQ0_INTE_SM3_LSB    _u(11)
+#define PROC_PIO_IRQ0_INTE_SM3_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM2
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM2_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM2_BITS   _u(0x00000400)
+#define PROC_PIO_IRQ0_INTE_SM2_MSB    _u(10)
+#define PROC_PIO_IRQ0_INTE_SM2_LSB    _u(10)
+#define PROC_PIO_IRQ0_INTE_SM2_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM1
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM1_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM1_BITS   _u(0x00000200)
+#define PROC_PIO_IRQ0_INTE_SM1_MSB    _u(9)
+#define PROC_PIO_IRQ0_INTE_SM1_LSB    _u(9)
+#define PROC_PIO_IRQ0_INTE_SM1_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM0
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM0_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM0_BITS   _u(0x00000100)
+#define PROC_PIO_IRQ0_INTE_SM0_MSB    _u(8)
+#define PROC_PIO_IRQ0_INTE_SM0_LSB    _u(8)
+#define PROC_PIO_IRQ0_INTE_SM0_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM3_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM3_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM3_TXNFULL_BITS   _u(0x00000080)
+#define PROC_PIO_IRQ0_INTE_SM3_TXNFULL_MSB    _u(7)
+#define PROC_PIO_IRQ0_INTE_SM3_TXNFULL_LSB    _u(7)
+#define PROC_PIO_IRQ0_INTE_SM3_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM2_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM2_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM2_TXNFULL_BITS   _u(0x00000040)
+#define PROC_PIO_IRQ0_INTE_SM2_TXNFULL_MSB    _u(6)
+#define PROC_PIO_IRQ0_INTE_SM2_TXNFULL_LSB    _u(6)
+#define PROC_PIO_IRQ0_INTE_SM2_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM1_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM1_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM1_TXNFULL_BITS   _u(0x00000020)
+#define PROC_PIO_IRQ0_INTE_SM1_TXNFULL_MSB    _u(5)
+#define PROC_PIO_IRQ0_INTE_SM1_TXNFULL_LSB    _u(5)
+#define PROC_PIO_IRQ0_INTE_SM1_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM0_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM0_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM0_TXNFULL_BITS   _u(0x00000010)
+#define PROC_PIO_IRQ0_INTE_SM0_TXNFULL_MSB    _u(4)
+#define PROC_PIO_IRQ0_INTE_SM0_TXNFULL_LSB    _u(4)
+#define PROC_PIO_IRQ0_INTE_SM0_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM3_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM3_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM3_RXNEMPTY_BITS   _u(0x00000008)
+#define PROC_PIO_IRQ0_INTE_SM3_RXNEMPTY_MSB    _u(3)
+#define PROC_PIO_IRQ0_INTE_SM3_RXNEMPTY_LSB    _u(3)
+#define PROC_PIO_IRQ0_INTE_SM3_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM2_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM2_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM2_RXNEMPTY_BITS   _u(0x00000004)
+#define PROC_PIO_IRQ0_INTE_SM2_RXNEMPTY_MSB    _u(2)
+#define PROC_PIO_IRQ0_INTE_SM2_RXNEMPTY_LSB    _u(2)
+#define PROC_PIO_IRQ0_INTE_SM2_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM1_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM1_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM1_RXNEMPTY_BITS   _u(0x00000002)
+#define PROC_PIO_IRQ0_INTE_SM1_RXNEMPTY_MSB    _u(1)
+#define PROC_PIO_IRQ0_INTE_SM1_RXNEMPTY_LSB    _u(1)
+#define PROC_PIO_IRQ0_INTE_SM1_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTE_SM0_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTE_SM0_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTE_SM0_RXNEMPTY_BITS   _u(0x00000001)
+#define PROC_PIO_IRQ0_INTE_SM0_RXNEMPTY_MSB    _u(0)
+#define PROC_PIO_IRQ0_INTE_SM0_RXNEMPTY_LSB    _u(0)
+#define PROC_PIO_IRQ0_INTE_SM0_RXNEMPTY_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_IRQ0_INTF
+// Description : Interrupt Force for irq0
+#define PROC_PIO_IRQ0_INTF_OFFSET _u(0x00000154)
+#define PROC_PIO_IRQ0_INTF_BITS   _u(0x00000fff)
+#define PROC_PIO_IRQ0_INTF_RESET  _u(0x00000000)
+#define PROC_PIO_IRQ0_INTF_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM3
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM3_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM3_BITS   _u(0x00000800)
+#define PROC_PIO_IRQ0_INTF_SM3_MSB    _u(11)
+#define PROC_PIO_IRQ0_INTF_SM3_LSB    _u(11)
+#define PROC_PIO_IRQ0_INTF_SM3_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM2
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM2_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM2_BITS   _u(0x00000400)
+#define PROC_PIO_IRQ0_INTF_SM2_MSB    _u(10)
+#define PROC_PIO_IRQ0_INTF_SM2_LSB    _u(10)
+#define PROC_PIO_IRQ0_INTF_SM2_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM1
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM1_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM1_BITS   _u(0x00000200)
+#define PROC_PIO_IRQ0_INTF_SM1_MSB    _u(9)
+#define PROC_PIO_IRQ0_INTF_SM1_LSB    _u(9)
+#define PROC_PIO_IRQ0_INTF_SM1_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM0
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM0_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM0_BITS   _u(0x00000100)
+#define PROC_PIO_IRQ0_INTF_SM0_MSB    _u(8)
+#define PROC_PIO_IRQ0_INTF_SM0_LSB    _u(8)
+#define PROC_PIO_IRQ0_INTF_SM0_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM3_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM3_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM3_TXNFULL_BITS   _u(0x00000080)
+#define PROC_PIO_IRQ0_INTF_SM3_TXNFULL_MSB    _u(7)
+#define PROC_PIO_IRQ0_INTF_SM3_TXNFULL_LSB    _u(7)
+#define PROC_PIO_IRQ0_INTF_SM3_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM2_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM2_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM2_TXNFULL_BITS   _u(0x00000040)
+#define PROC_PIO_IRQ0_INTF_SM2_TXNFULL_MSB    _u(6)
+#define PROC_PIO_IRQ0_INTF_SM2_TXNFULL_LSB    _u(6)
+#define PROC_PIO_IRQ0_INTF_SM2_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM1_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM1_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM1_TXNFULL_BITS   _u(0x00000020)
+#define PROC_PIO_IRQ0_INTF_SM1_TXNFULL_MSB    _u(5)
+#define PROC_PIO_IRQ0_INTF_SM1_TXNFULL_LSB    _u(5)
+#define PROC_PIO_IRQ0_INTF_SM1_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM0_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM0_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM0_TXNFULL_BITS   _u(0x00000010)
+#define PROC_PIO_IRQ0_INTF_SM0_TXNFULL_MSB    _u(4)
+#define PROC_PIO_IRQ0_INTF_SM0_TXNFULL_LSB    _u(4)
+#define PROC_PIO_IRQ0_INTF_SM0_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM3_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM3_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM3_RXNEMPTY_BITS   _u(0x00000008)
+#define PROC_PIO_IRQ0_INTF_SM3_RXNEMPTY_MSB    _u(3)
+#define PROC_PIO_IRQ0_INTF_SM3_RXNEMPTY_LSB    _u(3)
+#define PROC_PIO_IRQ0_INTF_SM3_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM2_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM2_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM2_RXNEMPTY_BITS   _u(0x00000004)
+#define PROC_PIO_IRQ0_INTF_SM2_RXNEMPTY_MSB    _u(2)
+#define PROC_PIO_IRQ0_INTF_SM2_RXNEMPTY_LSB    _u(2)
+#define PROC_PIO_IRQ0_INTF_SM2_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM1_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM1_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM1_RXNEMPTY_BITS   _u(0x00000002)
+#define PROC_PIO_IRQ0_INTF_SM1_RXNEMPTY_MSB    _u(1)
+#define PROC_PIO_IRQ0_INTF_SM1_RXNEMPTY_LSB    _u(1)
+#define PROC_PIO_IRQ0_INTF_SM1_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTF_SM0_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTF_SM0_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTF_SM0_RXNEMPTY_BITS   _u(0x00000001)
+#define PROC_PIO_IRQ0_INTF_SM0_RXNEMPTY_MSB    _u(0)
+#define PROC_PIO_IRQ0_INTF_SM0_RXNEMPTY_LSB    _u(0)
+#define PROC_PIO_IRQ0_INTF_SM0_RXNEMPTY_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_IRQ0_INTS
+// Description : Interrupt status after masking & forcing for irq0
+#define PROC_PIO_IRQ0_INTS_OFFSET _u(0x00000158)
+#define PROC_PIO_IRQ0_INTS_BITS   _u(0x00000fff)
+#define PROC_PIO_IRQ0_INTS_RESET  _u(0x00000000)
+#define PROC_PIO_IRQ0_INTS_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM3
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM3_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM3_BITS   _u(0x00000800)
+#define PROC_PIO_IRQ0_INTS_SM3_MSB    _u(11)
+#define PROC_PIO_IRQ0_INTS_SM3_LSB    _u(11)
+#define PROC_PIO_IRQ0_INTS_SM3_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM2
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM2_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM2_BITS   _u(0x00000400)
+#define PROC_PIO_IRQ0_INTS_SM2_MSB    _u(10)
+#define PROC_PIO_IRQ0_INTS_SM2_LSB    _u(10)
+#define PROC_PIO_IRQ0_INTS_SM2_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM1
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM1_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM1_BITS   _u(0x00000200)
+#define PROC_PIO_IRQ0_INTS_SM1_MSB    _u(9)
+#define PROC_PIO_IRQ0_INTS_SM1_LSB    _u(9)
+#define PROC_PIO_IRQ0_INTS_SM1_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM0
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM0_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM0_BITS   _u(0x00000100)
+#define PROC_PIO_IRQ0_INTS_SM0_MSB    _u(8)
+#define PROC_PIO_IRQ0_INTS_SM0_LSB    _u(8)
+#define PROC_PIO_IRQ0_INTS_SM0_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM3_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM3_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM3_TXNFULL_BITS   _u(0x00000080)
+#define PROC_PIO_IRQ0_INTS_SM3_TXNFULL_MSB    _u(7)
+#define PROC_PIO_IRQ0_INTS_SM3_TXNFULL_LSB    _u(7)
+#define PROC_PIO_IRQ0_INTS_SM3_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM2_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM2_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM2_TXNFULL_BITS   _u(0x00000040)
+#define PROC_PIO_IRQ0_INTS_SM2_TXNFULL_MSB    _u(6)
+#define PROC_PIO_IRQ0_INTS_SM2_TXNFULL_LSB    _u(6)
+#define PROC_PIO_IRQ0_INTS_SM2_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM1_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM1_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM1_TXNFULL_BITS   _u(0x00000020)
+#define PROC_PIO_IRQ0_INTS_SM1_TXNFULL_MSB    _u(5)
+#define PROC_PIO_IRQ0_INTS_SM1_TXNFULL_LSB    _u(5)
+#define PROC_PIO_IRQ0_INTS_SM1_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM0_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM0_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM0_TXNFULL_BITS   _u(0x00000010)
+#define PROC_PIO_IRQ0_INTS_SM0_TXNFULL_MSB    _u(4)
+#define PROC_PIO_IRQ0_INTS_SM0_TXNFULL_LSB    _u(4)
+#define PROC_PIO_IRQ0_INTS_SM0_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM3_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM3_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM3_RXNEMPTY_BITS   _u(0x00000008)
+#define PROC_PIO_IRQ0_INTS_SM3_RXNEMPTY_MSB    _u(3)
+#define PROC_PIO_IRQ0_INTS_SM3_RXNEMPTY_LSB    _u(3)
+#define PROC_PIO_IRQ0_INTS_SM3_RXNEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM2_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM2_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM2_RXNEMPTY_BITS   _u(0x00000004)
+#define PROC_PIO_IRQ0_INTS_SM2_RXNEMPTY_MSB    _u(2)
+#define PROC_PIO_IRQ0_INTS_SM2_RXNEMPTY_LSB    _u(2)
+#define PROC_PIO_IRQ0_INTS_SM2_RXNEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM1_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM1_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM1_RXNEMPTY_BITS   _u(0x00000002)
+#define PROC_PIO_IRQ0_INTS_SM1_RXNEMPTY_MSB    _u(1)
+#define PROC_PIO_IRQ0_INTS_SM1_RXNEMPTY_LSB    _u(1)
+#define PROC_PIO_IRQ0_INTS_SM1_RXNEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ0_INTS_SM0_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ0_INTS_SM0_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ0_INTS_SM0_RXNEMPTY_BITS   _u(0x00000001)
+#define PROC_PIO_IRQ0_INTS_SM0_RXNEMPTY_MSB    _u(0)
+#define PROC_PIO_IRQ0_INTS_SM0_RXNEMPTY_LSB    _u(0)
+#define PROC_PIO_IRQ0_INTS_SM0_RXNEMPTY_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_IRQ1_INTE
+// Description : Interrupt Enable for irq1
+#define PROC_PIO_IRQ1_INTE_OFFSET _u(0x0000015c)
+#define PROC_PIO_IRQ1_INTE_BITS   _u(0x00000fff)
+#define PROC_PIO_IRQ1_INTE_RESET  _u(0x00000000)
+#define PROC_PIO_IRQ1_INTE_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM3
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM3_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM3_BITS   _u(0x00000800)
+#define PROC_PIO_IRQ1_INTE_SM3_MSB    _u(11)
+#define PROC_PIO_IRQ1_INTE_SM3_LSB    _u(11)
+#define PROC_PIO_IRQ1_INTE_SM3_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM2
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM2_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM2_BITS   _u(0x00000400)
+#define PROC_PIO_IRQ1_INTE_SM2_MSB    _u(10)
+#define PROC_PIO_IRQ1_INTE_SM2_LSB    _u(10)
+#define PROC_PIO_IRQ1_INTE_SM2_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM1
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM1_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM1_BITS   _u(0x00000200)
+#define PROC_PIO_IRQ1_INTE_SM1_MSB    _u(9)
+#define PROC_PIO_IRQ1_INTE_SM1_LSB    _u(9)
+#define PROC_PIO_IRQ1_INTE_SM1_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM0
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM0_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM0_BITS   _u(0x00000100)
+#define PROC_PIO_IRQ1_INTE_SM0_MSB    _u(8)
+#define PROC_PIO_IRQ1_INTE_SM0_LSB    _u(8)
+#define PROC_PIO_IRQ1_INTE_SM0_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM3_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM3_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM3_TXNFULL_BITS   _u(0x00000080)
+#define PROC_PIO_IRQ1_INTE_SM3_TXNFULL_MSB    _u(7)
+#define PROC_PIO_IRQ1_INTE_SM3_TXNFULL_LSB    _u(7)
+#define PROC_PIO_IRQ1_INTE_SM3_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM2_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM2_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM2_TXNFULL_BITS   _u(0x00000040)
+#define PROC_PIO_IRQ1_INTE_SM2_TXNFULL_MSB    _u(6)
+#define PROC_PIO_IRQ1_INTE_SM2_TXNFULL_LSB    _u(6)
+#define PROC_PIO_IRQ1_INTE_SM2_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM1_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM1_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM1_TXNFULL_BITS   _u(0x00000020)
+#define PROC_PIO_IRQ1_INTE_SM1_TXNFULL_MSB    _u(5)
+#define PROC_PIO_IRQ1_INTE_SM1_TXNFULL_LSB    _u(5)
+#define PROC_PIO_IRQ1_INTE_SM1_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM0_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM0_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM0_TXNFULL_BITS   _u(0x00000010)
+#define PROC_PIO_IRQ1_INTE_SM0_TXNFULL_MSB    _u(4)
+#define PROC_PIO_IRQ1_INTE_SM0_TXNFULL_LSB    _u(4)
+#define PROC_PIO_IRQ1_INTE_SM0_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM3_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM3_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM3_RXNEMPTY_BITS   _u(0x00000008)
+#define PROC_PIO_IRQ1_INTE_SM3_RXNEMPTY_MSB    _u(3)
+#define PROC_PIO_IRQ1_INTE_SM3_RXNEMPTY_LSB    _u(3)
+#define PROC_PIO_IRQ1_INTE_SM3_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM2_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM2_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM2_RXNEMPTY_BITS   _u(0x00000004)
+#define PROC_PIO_IRQ1_INTE_SM2_RXNEMPTY_MSB    _u(2)
+#define PROC_PIO_IRQ1_INTE_SM2_RXNEMPTY_LSB    _u(2)
+#define PROC_PIO_IRQ1_INTE_SM2_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM1_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM1_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM1_RXNEMPTY_BITS   _u(0x00000002)
+#define PROC_PIO_IRQ1_INTE_SM1_RXNEMPTY_MSB    _u(1)
+#define PROC_PIO_IRQ1_INTE_SM1_RXNEMPTY_LSB    _u(1)
+#define PROC_PIO_IRQ1_INTE_SM1_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTE_SM0_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTE_SM0_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTE_SM0_RXNEMPTY_BITS   _u(0x00000001)
+#define PROC_PIO_IRQ1_INTE_SM0_RXNEMPTY_MSB    _u(0)
+#define PROC_PIO_IRQ1_INTE_SM0_RXNEMPTY_LSB    _u(0)
+#define PROC_PIO_IRQ1_INTE_SM0_RXNEMPTY_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_IRQ1_INTF
+// Description : Interrupt Force for irq1
+#define PROC_PIO_IRQ1_INTF_OFFSET _u(0x00000160)
+#define PROC_PIO_IRQ1_INTF_BITS   _u(0x00000fff)
+#define PROC_PIO_IRQ1_INTF_RESET  _u(0x00000000)
+#define PROC_PIO_IRQ1_INTF_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM3
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM3_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM3_BITS   _u(0x00000800)
+#define PROC_PIO_IRQ1_INTF_SM3_MSB    _u(11)
+#define PROC_PIO_IRQ1_INTF_SM3_LSB    _u(11)
+#define PROC_PIO_IRQ1_INTF_SM3_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM2
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM2_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM2_BITS   _u(0x00000400)
+#define PROC_PIO_IRQ1_INTF_SM2_MSB    _u(10)
+#define PROC_PIO_IRQ1_INTF_SM2_LSB    _u(10)
+#define PROC_PIO_IRQ1_INTF_SM2_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM1
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM1_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM1_BITS   _u(0x00000200)
+#define PROC_PIO_IRQ1_INTF_SM1_MSB    _u(9)
+#define PROC_PIO_IRQ1_INTF_SM1_LSB    _u(9)
+#define PROC_PIO_IRQ1_INTF_SM1_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM0
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM0_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM0_BITS   _u(0x00000100)
+#define PROC_PIO_IRQ1_INTF_SM0_MSB    _u(8)
+#define PROC_PIO_IRQ1_INTF_SM0_LSB    _u(8)
+#define PROC_PIO_IRQ1_INTF_SM0_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM3_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM3_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM3_TXNFULL_BITS   _u(0x00000080)
+#define PROC_PIO_IRQ1_INTF_SM3_TXNFULL_MSB    _u(7)
+#define PROC_PIO_IRQ1_INTF_SM3_TXNFULL_LSB    _u(7)
+#define PROC_PIO_IRQ1_INTF_SM3_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM2_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM2_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM2_TXNFULL_BITS   _u(0x00000040)
+#define PROC_PIO_IRQ1_INTF_SM2_TXNFULL_MSB    _u(6)
+#define PROC_PIO_IRQ1_INTF_SM2_TXNFULL_LSB    _u(6)
+#define PROC_PIO_IRQ1_INTF_SM2_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM1_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM1_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM1_TXNFULL_BITS   _u(0x00000020)
+#define PROC_PIO_IRQ1_INTF_SM1_TXNFULL_MSB    _u(5)
+#define PROC_PIO_IRQ1_INTF_SM1_TXNFULL_LSB    _u(5)
+#define PROC_PIO_IRQ1_INTF_SM1_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM0_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM0_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM0_TXNFULL_BITS   _u(0x00000010)
+#define PROC_PIO_IRQ1_INTF_SM0_TXNFULL_MSB    _u(4)
+#define PROC_PIO_IRQ1_INTF_SM0_TXNFULL_LSB    _u(4)
+#define PROC_PIO_IRQ1_INTF_SM0_TXNFULL_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM3_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM3_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM3_RXNEMPTY_BITS   _u(0x00000008)
+#define PROC_PIO_IRQ1_INTF_SM3_RXNEMPTY_MSB    _u(3)
+#define PROC_PIO_IRQ1_INTF_SM3_RXNEMPTY_LSB    _u(3)
+#define PROC_PIO_IRQ1_INTF_SM3_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM2_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM2_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM2_RXNEMPTY_BITS   _u(0x00000004)
+#define PROC_PIO_IRQ1_INTF_SM2_RXNEMPTY_MSB    _u(2)
+#define PROC_PIO_IRQ1_INTF_SM2_RXNEMPTY_LSB    _u(2)
+#define PROC_PIO_IRQ1_INTF_SM2_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM1_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM1_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM1_RXNEMPTY_BITS   _u(0x00000002)
+#define PROC_PIO_IRQ1_INTF_SM1_RXNEMPTY_MSB    _u(1)
+#define PROC_PIO_IRQ1_INTF_SM1_RXNEMPTY_LSB    _u(1)
+#define PROC_PIO_IRQ1_INTF_SM1_RXNEMPTY_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTF_SM0_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTF_SM0_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTF_SM0_RXNEMPTY_BITS   _u(0x00000001)
+#define PROC_PIO_IRQ1_INTF_SM0_RXNEMPTY_MSB    _u(0)
+#define PROC_PIO_IRQ1_INTF_SM0_RXNEMPTY_LSB    _u(0)
+#define PROC_PIO_IRQ1_INTF_SM0_RXNEMPTY_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_IRQ1_INTS
+// Description : Interrupt status after masking & forcing for irq1
+#define PROC_PIO_IRQ1_INTS_OFFSET _u(0x00000164)
+#define PROC_PIO_IRQ1_INTS_BITS   _u(0x00000fff)
+#define PROC_PIO_IRQ1_INTS_RESET  _u(0x00000000)
+#define PROC_PIO_IRQ1_INTS_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM3
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM3_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM3_BITS   _u(0x00000800)
+#define PROC_PIO_IRQ1_INTS_SM3_MSB    _u(11)
+#define PROC_PIO_IRQ1_INTS_SM3_LSB    _u(11)
+#define PROC_PIO_IRQ1_INTS_SM3_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM2
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM2_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM2_BITS   _u(0x00000400)
+#define PROC_PIO_IRQ1_INTS_SM2_MSB    _u(10)
+#define PROC_PIO_IRQ1_INTS_SM2_LSB    _u(10)
+#define PROC_PIO_IRQ1_INTS_SM2_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM1
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM1_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM1_BITS   _u(0x00000200)
+#define PROC_PIO_IRQ1_INTS_SM1_MSB    _u(9)
+#define PROC_PIO_IRQ1_INTS_SM1_LSB    _u(9)
+#define PROC_PIO_IRQ1_INTS_SM1_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM0
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM0_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM0_BITS   _u(0x00000100)
+#define PROC_PIO_IRQ1_INTS_SM0_MSB    _u(8)
+#define PROC_PIO_IRQ1_INTS_SM0_LSB    _u(8)
+#define PROC_PIO_IRQ1_INTS_SM0_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM3_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM3_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM3_TXNFULL_BITS   _u(0x00000080)
+#define PROC_PIO_IRQ1_INTS_SM3_TXNFULL_MSB    _u(7)
+#define PROC_PIO_IRQ1_INTS_SM3_TXNFULL_LSB    _u(7)
+#define PROC_PIO_IRQ1_INTS_SM3_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM2_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM2_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM2_TXNFULL_BITS   _u(0x00000040)
+#define PROC_PIO_IRQ1_INTS_SM2_TXNFULL_MSB    _u(6)
+#define PROC_PIO_IRQ1_INTS_SM2_TXNFULL_LSB    _u(6)
+#define PROC_PIO_IRQ1_INTS_SM2_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM1_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM1_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM1_TXNFULL_BITS   _u(0x00000020)
+#define PROC_PIO_IRQ1_INTS_SM1_TXNFULL_MSB    _u(5)
+#define PROC_PIO_IRQ1_INTS_SM1_TXNFULL_LSB    _u(5)
+#define PROC_PIO_IRQ1_INTS_SM1_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM0_TXNFULL
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM0_TXNFULL_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM0_TXNFULL_BITS   _u(0x00000010)
+#define PROC_PIO_IRQ1_INTS_SM0_TXNFULL_MSB    _u(4)
+#define PROC_PIO_IRQ1_INTS_SM0_TXNFULL_LSB    _u(4)
+#define PROC_PIO_IRQ1_INTS_SM0_TXNFULL_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM3_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM3_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM3_RXNEMPTY_BITS   _u(0x00000008)
+#define PROC_PIO_IRQ1_INTS_SM3_RXNEMPTY_MSB    _u(3)
+#define PROC_PIO_IRQ1_INTS_SM3_RXNEMPTY_LSB    _u(3)
+#define PROC_PIO_IRQ1_INTS_SM3_RXNEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM2_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM2_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM2_RXNEMPTY_BITS   _u(0x00000004)
+#define PROC_PIO_IRQ1_INTS_SM2_RXNEMPTY_MSB    _u(2)
+#define PROC_PIO_IRQ1_INTS_SM2_RXNEMPTY_LSB    _u(2)
+#define PROC_PIO_IRQ1_INTS_SM2_RXNEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM1_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM1_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM1_RXNEMPTY_BITS   _u(0x00000002)
+#define PROC_PIO_IRQ1_INTS_SM1_RXNEMPTY_MSB    _u(1)
+#define PROC_PIO_IRQ1_INTS_SM1_RXNEMPTY_LSB    _u(1)
+#define PROC_PIO_IRQ1_INTS_SM1_RXNEMPTY_ACCESS "RO"
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_IRQ1_INTS_SM0_RXNEMPTY
+// Description : None
+#define PROC_PIO_IRQ1_INTS_SM0_RXNEMPTY_RESET  _u(0x0)
+#define PROC_PIO_IRQ1_INTS_SM0_RXNEMPTY_BITS   _u(0x00000001)
+#define PROC_PIO_IRQ1_INTS_SM0_RXNEMPTY_MSB    _u(0)
+#define PROC_PIO_IRQ1_INTS_SM0_RXNEMPTY_LSB    _u(0)
+#define PROC_PIO_IRQ1_INTS_SM0_RXNEMPTY_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_BLOCK_ID
+// Description : Block Identifier
+//               Hexadecimal representation of "pio2"
+#define PROC_PIO_BLOCK_ID_OFFSET _u(0x00000168)
+#define PROC_PIO_BLOCK_ID_BITS   _u(0xffffffff)
+#define PROC_PIO_BLOCK_ID_RESET  _u(0x70696f32)
+#define PROC_PIO_BLOCK_ID_WIDTH  _u(32)
+#define PROC_PIO_BLOCK_ID_MSB    _u(31)
+#define PROC_PIO_BLOCK_ID_LSB    _u(0)
+#define PROC_PIO_BLOCK_ID_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_INSTANCE_ID
+// Description : Block Instance Identifier
+#define PROC_PIO_INSTANCE_ID_OFFSET _u(0x0000016c)
+#define PROC_PIO_INSTANCE_ID_BITS   _u(0x0000000f)
+#define PROC_PIO_INSTANCE_ID_RESET  _u(0x00000000)
+#define PROC_PIO_INSTANCE_ID_WIDTH  _u(32)
+#define PROC_PIO_INSTANCE_ID_MSB    _u(3)
+#define PROC_PIO_INSTANCE_ID_LSB    _u(0)
+#define PROC_PIO_INSTANCE_ID_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_RSTSEQ_AUTO
+// Description : None
+#define PROC_PIO_RSTSEQ_AUTO_OFFSET _u(0x00000170)
+#define PROC_PIO_RSTSEQ_AUTO_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_AUTO_RESET  _u(0x00000001)
+#define PROC_PIO_RSTSEQ_AUTO_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_RSTSEQ_AUTO_BUSADAPTER
+// Description : 1 = reset is controlled by the sequencer
+//               0 = reset is controlled by rstseq_ctrl
+#define PROC_PIO_RSTSEQ_AUTO_BUSADAPTER_RESET  _u(0x1)
+#define PROC_PIO_RSTSEQ_AUTO_BUSADAPTER_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_AUTO_BUSADAPTER_MSB    _u(0)
+#define PROC_PIO_RSTSEQ_AUTO_BUSADAPTER_LSB    _u(0)
+#define PROC_PIO_RSTSEQ_AUTO_BUSADAPTER_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_RSTSEQ_PARALLEL
+// Description : None
+#define PROC_PIO_RSTSEQ_PARALLEL_OFFSET _u(0x00000174)
+#define PROC_PIO_RSTSEQ_PARALLEL_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_PARALLEL_RESET  _u(0x00000000)
+#define PROC_PIO_RSTSEQ_PARALLEL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_RSTSEQ_PARALLEL_BUSADAPTER
+// Description : Is this reset parallel (i.e. not part of the sequence)
+#define PROC_PIO_RSTSEQ_PARALLEL_BUSADAPTER_RESET  _u(0x0)
+#define PROC_PIO_RSTSEQ_PARALLEL_BUSADAPTER_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_PARALLEL_BUSADAPTER_MSB    _u(0)
+#define PROC_PIO_RSTSEQ_PARALLEL_BUSADAPTER_LSB    _u(0)
+#define PROC_PIO_RSTSEQ_PARALLEL_BUSADAPTER_ACCESS "RO"
+// =============================================================================
+// Register    : PROC_PIO_RSTSEQ_CTRL
+// Description : None
+#define PROC_PIO_RSTSEQ_CTRL_OFFSET _u(0x00000178)
+#define PROC_PIO_RSTSEQ_CTRL_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_CTRL_RESET  _u(0x00000000)
+#define PROC_PIO_RSTSEQ_CTRL_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_RSTSEQ_CTRL_BUSADAPTER
+// Description : 1 = keep the reset asserted
+//               0 = keep the reset deasserted
+//               This is ignored if rstseq_auto=1
+#define PROC_PIO_RSTSEQ_CTRL_BUSADAPTER_RESET  _u(0x0)
+#define PROC_PIO_RSTSEQ_CTRL_BUSADAPTER_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_CTRL_BUSADAPTER_MSB    _u(0)
+#define PROC_PIO_RSTSEQ_CTRL_BUSADAPTER_LSB    _u(0)
+#define PROC_PIO_RSTSEQ_CTRL_BUSADAPTER_ACCESS "RW"
+// =============================================================================
+// Register    : PROC_PIO_RSTSEQ_TRIG
+// Description : None
+#define PROC_PIO_RSTSEQ_TRIG_OFFSET _u(0x0000017c)
+#define PROC_PIO_RSTSEQ_TRIG_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_TRIG_RESET  _u(0x00000000)
+#define PROC_PIO_RSTSEQ_TRIG_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_RSTSEQ_TRIG_BUSADAPTER
+// Description : Pulses the reset output
+#define PROC_PIO_RSTSEQ_TRIG_BUSADAPTER_RESET  _u(0x0)
+#define PROC_PIO_RSTSEQ_TRIG_BUSADAPTER_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_TRIG_BUSADAPTER_MSB    _u(0)
+#define PROC_PIO_RSTSEQ_TRIG_BUSADAPTER_LSB    _u(0)
+#define PROC_PIO_RSTSEQ_TRIG_BUSADAPTER_ACCESS "SC"
+// =============================================================================
+// Register    : PROC_PIO_RSTSEQ_DONE
+// Description : None
+#define PROC_PIO_RSTSEQ_DONE_OFFSET _u(0x00000180)
+#define PROC_PIO_RSTSEQ_DONE_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_DONE_RESET  _u(0x00000000)
+#define PROC_PIO_RSTSEQ_DONE_WIDTH  _u(32)
+// -----------------------------------------------------------------------------
+// Field       : PROC_PIO_RSTSEQ_DONE_BUSADAPTER
+// Description : Indicates the current state of the reset
+#define PROC_PIO_RSTSEQ_DONE_BUSADAPTER_RESET  _u(0x0)
+#define PROC_PIO_RSTSEQ_DONE_BUSADAPTER_BITS   _u(0x00000001)
+#define PROC_PIO_RSTSEQ_DONE_BUSADAPTER_MSB    _u(0)
+#define PROC_PIO_RSTSEQ_DONE_BUSADAPTER_LSB    _u(0)
+#define PROC_PIO_RSTSEQ_DONE_BUSADAPTER_ACCESS "RO"
+// =============================================================================
+#endif // HARDWARE_REGS_PROC_PIO_DEFINED

--- a/lib/rp1/rp1_pio_vendor/piolib/include/pio_platform.h
+++ b/lib/rp1/rp1_pio_vendor/piolib/include/pio_platform.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2024 Raspberry Pi Ltd.
+ * All rights reserved.
+ */
+
+#ifndef _PIO_PLATFORM_H
+#define _PIO_PLATFORM_H
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+#ifndef __unused
+#define __unused __attribute__((unused))
+#endif
+
+#define PICO_DEFAULT_LED_PIN 4
+
+#ifndef PARAM_ASSERTIONS_ENABLE_ALL
+#define PARAM_ASSERTIONS_ENABLE_ALL 0
+#endif
+
+#ifndef PARAM_ASSERTIONS_DISABLE_ALL
+#define PARAM_ASSERTIONS_DISABLE_ALL 0
+#endif
+
+#define PARAM_ASSERTIONS_ENABLED(x) ((PARAM_ASSERTIONS_ENABLED_ ## x || PARAM_ASSERTIONS_ENABLE_ALL) && !PARAM_ASSERTIONS_DISABLE_ALL)
+#define invalid_params_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x)) assert(!(test));})
+#define valid_params_if(x, test) ({if (PARAM_ASSERTIONS_ENABLED(x)) assert(test);})
+
+#define STATIC_ASSERT(cond) static_assert(cond, #cond)
+
+#define _u(x) ((uint)(x))
+#define bool_to_bit(x) ((uint)!!(x))
+
+#ifndef count_of
+#define count_of(a) (sizeof(a)/sizeof((a)[0]))
+#endif
+
+typedef unsigned int uint;
+
+#endif

--- a/lib/rp1/rp1_pio_vendor/piolib/include/piolib.h
+++ b/lib/rp1/rp1_pio_vendor/piolib/include/piolib.h
@@ -1,0 +1,879 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2023-24 Raspberry Pi Ltd.
+ * All rights reserved.
+ */
+
+#ifndef _PIOLIB_H
+#define _PIOLIB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "pio_platform.h"
+#include "hardware/clocks.h"
+#include "hardware/gpio.h"
+
+#ifndef PARAM_ASSERTIONS_ENABLED_PIO
+#define PARAM_ASSERTIONS_ENABLED_PIO 0
+#endif
+
+#define PIO_ERR(x)((PIO)(uintptr_t)(x))
+#define PIO_IS_ERR(x)(((uintptr_t)(x) >= (uintptr_t)-200))
+#define PIO_ERR_VAL(x)((int)(uintptr_t)(x))
+
+#define PIO_ORIGIN_ANY          ((uint)(~0))
+#define PIO_ORIGIN_INVALID      PIO_ORIGIN_ANY
+
+#define pio0 pio_open_helper(0)
+
+enum pio_fifo_join {
+	PIO_FIFO_JOIN_NONE = 0,
+	PIO_FIFO_JOIN_TX = 1,
+	PIO_FIFO_JOIN_RX = 2,
+};
+
+enum pio_mov_status_type {
+	STATUS_TX_LESSTHAN = 0,
+	STATUS_RX_LESSTHAN = 1
+};
+
+enum pio_xfer_dir {
+    PIO_DIR_TO_SM,
+    PIO_DIR_FROM_SM,
+    PIO_DIR_COUNT
+};
+
+#ifndef PIOLIB_INTERNALS
+
+enum pio_instr_bits {
+    pio_instr_bits_jmp = 0x0000,
+    pio_instr_bits_wait = 0x2000,
+    pio_instr_bits_in = 0x4000,
+    pio_instr_bits_out = 0x6000,
+    pio_instr_bits_push = 0x8000,
+    pio_instr_bits_pull = 0x8080,
+    pio_instr_bits_mov = 0xa000,
+    pio_instr_bits_irq = 0xc000,
+    pio_instr_bits_set = 0xe000,
+};
+
+#ifndef NDEBUG
+#define _PIO_INVALID_IN_SRC    0x08u
+#define _PIO_INVALID_OUT_DEST 0x10u
+#define _PIO_INVALID_SET_DEST 0x20u
+#define _PIO_INVALID_MOV_SRC  0x40u
+#define _PIO_INVALID_MOV_DEST 0x80u
+#else
+#define _PIO_INVALID_IN_SRC    0u
+#define _PIO_INVALID_OUT_DEST 0u
+#define _PIO_INVALID_SET_DEST 0u
+#define _PIO_INVALID_MOV_SRC  0u
+#define _PIO_INVALID_MOV_DEST 0u
+#endif
+
+enum pio_src_dest {
+    pio_pins = 0u,
+    pio_x = 1u,
+    pio_y = 2u,
+    pio_null = 3u | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_DEST,
+    pio_pindirs = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_MOV_SRC | _PIO_INVALID_MOV_DEST,
+    pio_exec_mov = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC,
+    pio_status = 5u | _PIO_INVALID_IN_SRC | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_DEST,
+    pio_pc = 5u | _PIO_INVALID_IN_SRC | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC,
+    pio_isr = 6u | _PIO_INVALID_SET_DEST,
+    pio_osr = 7u | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST,
+    pio_exec_out = 7u | _PIO_INVALID_IN_SRC | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC | _PIO_INVALID_MOV_DEST,
+};
+
+#endif
+
+typedef struct pio_program {
+    const uint16_t *instructions;
+    uint8_t length;
+    int8_t origin; // required instruction memory origin or -1
+    uint8_t pio_version;
+} pio_program_t;
+
+typedef struct {
+    uint32_t content[4];
+} pio_sm_config;
+
+typedef struct pio_instance *PIO;
+typedef const struct pio_chip PIO_CHIP_T;
+
+struct pio_chip {
+    const char *name;
+    const char *compatible;
+    uint16_t instr_count;
+    uint16_t sm_count;
+    uint16_t fifo_depth;
+    void *hw_state;
+
+    PIO (*create_instance)(PIO_CHIP_T *chip, uint index);
+    int (*open_instance)(PIO pio);
+    void (*close_instance)(PIO pio);
+
+    int (*pio_sm_config_xfer)(PIO pio, uint sm, uint dir, uint buf_size, uint buf_count);
+    int (*pio_sm_xfer_data)(PIO pio, uint sm, uint dir, uint data_bytes, void *data);
+
+    bool (*pio_can_add_program_at_offset)(PIO pio, const pio_program_t *program, uint offset);
+    uint (*pio_add_program_at_offset)(PIO pio, const pio_program_t *program, uint offset);
+    bool (*pio_remove_program)(PIO pio, const pio_program_t *program, uint loaded_offset);
+    bool (*pio_clear_instruction_memory)(PIO pio);
+    uint (*pio_encode_delay)(PIO pio, uint cycles);
+    uint (*pio_encode_sideset)(PIO pio, uint sideset_bit_count, uint value);
+    uint (*pio_encode_sideset_opt)(PIO pio, uint sideset_bit_count, uint value);
+    uint (*pio_encode_jmp)(PIO pio, uint addr);
+    uint (*pio_encode_jmp_not_x)(PIO pio, uint addr);
+    uint (*pio_encode_jmp_x_dec)(PIO pio, uint addr);
+    uint (*pio_encode_jmp_not_y)(PIO pio, uint addr);
+    uint (*pio_encode_jmp_y_dec)(PIO pio, uint addr);
+    uint (*pio_encode_jmp_x_ne_y)(PIO pio, uint addr);
+    uint (*pio_encode_jmp_pin)(PIO pio, uint addr);
+    uint (*pio_encode_jmp_not_osre)(PIO pio, uint addr);
+    uint (*pio_encode_wait_gpio)(PIO pio, bool polarity, uint gpio);
+    uint (*pio_encode_wait_pin)(PIO pio, bool polarity, uint pin);
+    uint (*pio_encode_wait_irq)(PIO pio, bool polarity, bool relative, uint irq);
+    uint (*pio_encode_in)(PIO pio, enum pio_src_dest src, uint count);
+    uint (*pio_encode_out)(PIO pio, enum pio_src_dest dest, uint count);
+    uint (*pio_encode_push)(PIO pio, bool if_full, bool block);
+    uint (*pio_encode_pull)(PIO pio, bool if_empty, bool block);
+    uint (*pio_encode_mov)(PIO pio, enum pio_src_dest dest, enum pio_src_dest src);
+    uint (*pio_encode_mov_not)(PIO pio, enum pio_src_dest dest, enum pio_src_dest src);
+    uint (*pio_encode_mov_reverse)(PIO pio, enum pio_src_dest dest, enum pio_src_dest src);
+    uint (*pio_encode_irq_set)(PIO pio, bool relative, uint irq);
+    uint (*pio_encode_irq_wait)(PIO pio, bool relative, uint irq);
+    uint (*pio_encode_irq_clear)(PIO pio, bool relative, uint irq);
+    uint (*pio_encode_set)(PIO pio, enum pio_src_dest dest, uint value);
+    uint (*pio_encode_nop)(PIO pio);
+
+    bool (*pio_sm_claim)(PIO pio, uint sm);
+    bool (*pio_sm_claim_mask)(PIO pio, uint mask);
+    int (*pio_sm_claim_unused)(PIO pio, bool required);
+    bool (*pio_sm_unclaim)(PIO pio, uint sm);
+    bool (*pio_sm_is_claimed)(PIO pio, uint sm);
+
+    void (*pio_sm_init)(PIO pio, uint sm, uint initial_pc, const pio_sm_config *config);
+    void (*pio_sm_set_config)(PIO pio, uint sm, const pio_sm_config *config);
+    void (*pio_sm_exec)(PIO pio, uint sm, uint instr, bool blocking);
+    void (*pio_sm_clear_fifos)(PIO pio, uint sm);
+    void (*pio_sm_set_clkdiv_int_frac)(PIO pio, uint sm, uint16_t div_int, uint8_t div_frac);
+    void (*pio_sm_set_clkdiv)(PIO pio, uint sm, float div);
+    void (*pio_sm_set_pins)(PIO pio, uint sm, uint32_t pin_values);
+    void (*pio_sm_set_pins_with_mask)(PIO pio, uint sm, uint32_t pin_values, uint32_t pin_mask);
+    void (*pio_sm_set_pindirs_with_mask)(PIO pio, uint sm, uint32_t pin_dirs, uint32_t pin_mask);
+    void (*pio_sm_set_consecutive_pindirs)(PIO pio, uint sm, uint pin_base, uint pin_count, bool is_out);
+    void (*pio_sm_set_enabled)(PIO pio, uint sm, bool enabled);
+    void (*pio_sm_set_enabled_mask)(PIO pio, uint32_t mask, bool enabled);
+    void (*pio_sm_restart)(PIO pio, uint sm);
+    void (*pio_sm_restart_mask)(PIO pio, uint32_t mask);
+    void (*pio_sm_clkdiv_restart)(PIO pio, uint sm);
+    void (*pio_sm_clkdiv_restart_mask)(PIO pio, uint32_t mask);
+    void (*pio_sm_enable_sync)(PIO pio, uint32_t mask);
+    void (*pio_sm_put)(PIO pio, uint sm, uint32_t data, bool blocking);
+    uint32_t (*pio_sm_get)(PIO pio, uint sm, bool blocking);
+    void (*pio_sm_set_dmactrl)(PIO pio, uint sm, bool is_tx, uint32_t ctrl);
+    bool (*pio_sm_is_rx_fifo_empty)(PIO pio, uint sm);
+    bool (*pio_sm_is_rx_fifo_full)(PIO pio, uint sm);
+    uint (*pio_sm_get_rx_fifo_level)(PIO pio, uint sm);
+    bool (*pio_sm_is_tx_fifo_empty)(PIO pio, uint sm);
+    bool (*pio_sm_is_tx_fifo_full)(PIO pio, uint sm);
+    uint (*pio_sm_get_tx_fifo_level)(PIO pio, uint sm);
+    void (*pio_sm_drain_tx_fifo)(PIO pio, uint sm);
+
+    pio_sm_config (*pio_get_default_sm_config)(PIO pio);
+    void (*smc_set_out_pins)(PIO pio, pio_sm_config *c, uint out_base, uint out_count);
+    void (*smc_set_set_pins)(PIO pio, pio_sm_config *c, uint set_base, uint set_count);
+    void (*smc_set_in_pins)(PIO pio, pio_sm_config *c, uint in_base);
+    void (*smc_set_sideset_pins)(PIO pio, pio_sm_config *c, uint sideset_base);
+    void (*smc_set_sideset)(PIO pio, pio_sm_config *c, uint bit_count, bool optional, bool pindirs);
+    void (*smc_set_clkdiv_int_frac)(PIO pio, pio_sm_config *c, uint16_t div_int, uint8_t div_frac);
+    void (*smc_set_clkdiv)(PIO pio, pio_sm_config *c, float div);
+    void (*smc_set_wrap)(PIO pio, pio_sm_config *c, uint wrap_target, uint wrap);
+    void (*smc_set_jmp_pin)(PIO pio, pio_sm_config *c, uint pin);
+    void (*smc_set_in_shift)(PIO pio, pio_sm_config *c, bool shift_right, bool autopush, uint push_threshold);
+    void (*smc_set_out_shift)(PIO pio, pio_sm_config *c, bool shift_right, bool autopull, uint pull_threshold);
+    void (*smc_set_fifo_join)(PIO pio, pio_sm_config *c, enum pio_fifo_join join);
+    void (*smc_set_out_special)(PIO pio, pio_sm_config *c, bool sticky, bool has_enable_pin, uint enable_pin_index);
+    void (*smc_set_mov_status)(PIO pio, pio_sm_config *c, enum pio_mov_status_type status_sel, uint status_n);
+
+    uint32_t (*clock_get_hz)(PIO pio, enum clock_index clk_index);
+    void (*pio_gpio_init)(PIO, uint pin);
+    void (*gpio_init)(PIO pio, uint gpio);
+    void (*gpio_set_function)(PIO pio, uint gpio, enum gpio_function fn);
+    void (*gpio_set_pulls)(PIO pio, uint gpio, bool up, bool down);
+    void (*gpio_set_outover)(PIO pio, uint gpio, uint value);
+    void (*gpio_set_inover)(PIO pio, uint gpio, uint value);
+    void (*gpio_set_oeover)(PIO pio, uint gpio, uint value);
+    void (*gpio_set_input_enabled)(PIO pio, uint gpio, bool enabled);
+    void (*gpio_set_drive_strength)(PIO pio, uint gpio, enum gpio_drive_strength drive);
+};
+
+struct pio_instance {
+    const PIO_CHIP_T *chip;
+    int in_use;
+    bool errors_are_fatal;
+    bool error;
+};
+
+int pio_init(void);
+PIO pio_open(uint idx);
+PIO pio_open_by_name(const char *name);
+PIO pio_open_helper(uint idx);
+void pio_close(PIO pio);
+void pio_panic(const char *msg);
+int pio_get_index(PIO pio);
+void pio_select(PIO pio);
+PIO pio_get_current(void);
+
+static inline void pio_error(PIO pio, const char *msg)
+{
+    pio->error = true;
+    if (pio->errors_are_fatal)
+        pio_panic(msg);
+}
+
+static inline bool pio_get_error(PIO pio)
+{
+    return pio->error;
+}
+
+static inline void pio_clear_error(PIO pio)
+{
+    pio->error = false;
+}
+
+static inline void pio_enable_fatal_errors(PIO pio, bool enable)
+{
+    pio->errors_are_fatal = enable;
+}
+
+static inline uint pio_get_sm_count(PIO pio)
+{
+    return pio->chip->sm_count;
+}
+
+static inline uint pio_get_instruction_count(PIO pio)
+{
+    return pio->chip->instr_count;
+}
+
+static inline uint pio_get_fifo_depth(PIO pio)
+{
+    return pio->chip->fifo_depth;
+}
+
+static inline void check_pio_param(__unused PIO pio)
+{
+    valid_params_if(PIO, pio_get_index(pio) >= 0);
+}
+
+static inline int pio_sm_config_xfer(PIO pio, uint sm, uint dir, uint buf_size, uint buf_count)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_config_xfer(pio, sm, dir, buf_size, buf_count);
+}
+
+static inline int pio_sm_xfer_data(PIO pio, uint sm, uint dir, uint data_bytes, void *data)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_xfer_data(pio, sm, dir, data_bytes, data);
+}
+
+static inline bool pio_can_add_program(PIO pio, const pio_program_t *program)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_can_add_program_at_offset(pio, program, PIO_ORIGIN_ANY);
+}
+
+static inline bool pio_can_add_program_at_offset(PIO pio, const pio_program_t *program, uint offset)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_can_add_program_at_offset(pio, program, offset);
+}
+
+static inline uint pio_add_program(PIO pio, const pio_program_t *program)
+{
+    uint offset;
+    check_pio_param(pio);
+    offset = pio->chip->pio_add_program_at_offset(pio, program, PIO_ORIGIN_ANY);
+    if (offset == PIO_ORIGIN_INVALID)
+        pio_error(pio, "No program space");
+    return offset;
+}
+
+static inline void pio_add_program_at_offset(PIO pio, const pio_program_t *program, uint offset)
+{
+    check_pio_param(pio);
+    if (pio->chip->pio_add_program_at_offset(pio, program, offset) == PIO_ORIGIN_INVALID)
+        pio_error(pio, "No program space");
+}
+
+static inline void pio_remove_program(PIO pio, const pio_program_t *program, uint loaded_offset)
+{
+    check_pio_param(pio);
+    if (!pio->chip->pio_remove_program(pio, program, loaded_offset))
+        pio_error(pio, "Failed to remove program");
+}
+
+static inline void pio_clear_instruction_memory(PIO pio)
+{
+    check_pio_param(pio);
+    if (!pio->chip->pio_clear_instruction_memory(pio))
+        pio_error(pio, "Failed to clear instruction memory");
+}
+
+static inline uint pio_encode_delay(uint cycles)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_delay(pio, cycles);
+}
+
+static inline uint pio_encode_sideset(uint sideset_bit_count, uint value)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_sideset(pio, sideset_bit_count, value);
+}
+
+static inline uint pio_encode_sideset_opt(uint sideset_bit_count, uint value)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_sideset_opt(pio, sideset_bit_count, value);
+}
+
+static inline uint pio_encode_jmp(uint addr)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_jmp(pio, addr);
+}
+
+static inline uint pio_encode_jmp_not_x(uint addr)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_jmp_not_x(pio, addr);
+}
+
+static inline uint pio_encode_jmp_x_dec(uint addr)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_jmp_x_dec(pio, addr);
+}
+
+static inline uint pio_encode_jmp_not_y(uint addr)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_jmp_not_y(pio, addr);
+}
+
+static inline uint pio_encode_jmp_y_dec(uint addr)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_jmp_y_dec(pio, addr);
+}
+
+static inline uint pio_encode_jmp_x_ne_y(uint addr)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_jmp_x_ne_y(pio, addr);
+}
+
+static inline uint pio_encode_jmp_pin(uint addr)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_jmp_pin(pio, addr);
+}
+
+static inline uint pio_encode_jmp_not_osre(uint addr)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_jmp_not_osre(pio, addr);
+}
+
+static inline uint pio_encode_wait_gpio(bool polarity, uint gpio)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_wait_gpio(pio, polarity, gpio);
+}
+
+static inline uint pio_encode_wait_pin(bool polarity, uint pin)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_wait_pin(pio, polarity, pin);
+}
+
+static inline uint pio_encode_wait_irq(bool polarity, bool relative, uint irq)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_wait_irq(pio, polarity, relative, irq);
+}
+
+static inline uint pio_encode_in(enum pio_src_dest src, uint count)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_in(pio, src, count);
+}
+
+static inline uint pio_encode_out(enum pio_src_dest dest, uint count)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_out(pio, dest, count);
+}
+
+static inline uint pio_encode_push(bool if_full, bool block)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_push(pio, if_full, block);
+}
+
+static inline uint pio_encode_pull(bool if_empty, bool block)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_pull(pio, if_empty, block);
+}
+
+static inline uint pio_encode_mov(enum pio_src_dest dest, enum pio_src_dest src)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_mov(pio, dest, src);
+}
+
+static inline uint pio_encode_mov_not(enum pio_src_dest dest, enum pio_src_dest src)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_mov_not(pio, dest, src);
+}
+
+static inline uint pio_encode_mov_reverse(enum pio_src_dest dest, enum pio_src_dest src)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_mov_reverse(pio, dest, src);
+}
+
+static inline uint pio_encode_irq_set(bool relative, uint irq)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_irq_set(pio, relative, irq);
+}
+
+static inline uint pio_encode_irq_wait(bool relative, uint irq)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_irq_wait(pio, relative, irq);
+}
+
+static inline uint pio_encode_irq_clear(bool relative, uint irq)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_irq_clear(pio, relative, irq);
+}
+
+static inline uint pio_encode_set(enum pio_src_dest dest, uint value)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_set(pio, dest, value);
+}
+
+static inline uint pio_encode_nop(void)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_encode_nop(pio);
+}
+
+static inline void pio_sm_claim(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    if (!pio->chip->pio_sm_claim(pio, sm))
+        pio_error(pio, "Failed to claim SM");
+}
+
+static inline void pio_claim_sm_mask(PIO pio, uint mask)
+{
+    check_pio_param(pio);
+    if (!pio->chip->pio_sm_claim_mask(pio, mask))
+        pio_error(pio, "Failed to claim masked SMs");
+}
+
+static inline void pio_sm_unclaim(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_unclaim(pio, sm);
+}
+
+static inline int pio_claim_unused_sm(PIO pio, bool required)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_claim_unused(pio, required);
+}
+
+static inline bool pio_sm_is_claimed(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_is_claimed(pio, sm);
+}
+
+static inline void pio_sm_init(PIO pio, uint sm, uint initial_pc, const pio_sm_config *config)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_init(pio, sm, initial_pc, config);
+}
+
+static inline void pio_sm_set_config(PIO pio, uint sm, const pio_sm_config *config)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_config(pio, sm, config);
+}
+
+static inline void pio_sm_exec(PIO pio, uint sm, uint instr)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_exec(pio, sm, instr, false);
+}
+
+static inline void pio_sm_exec_wait_blocking(PIO pio, uint sm, uint instr)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_exec(pio, sm, instr, true);
+}
+
+static inline void pio_sm_clear_fifos(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_clear_fifos(pio, sm);
+}
+
+static inline void pio_sm_set_clkdiv_int_frac(PIO pio, uint sm, uint16_t div_int, uint8_t div_frac)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_clkdiv_int_frac(pio, sm, div_int, div_frac);
+}
+
+static inline void pio_sm_set_clkdiv(PIO pio, uint sm, float div)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_clkdiv(pio, sm, div);
+}
+
+static inline void pio_sm_set_pins(PIO pio, uint sm, uint32_t pin_values)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_pins(pio, sm, pin_values);
+}
+
+static inline void pio_sm_set_pins_with_mask(PIO pio, uint sm, uint32_t pin_values, uint32_t pin_mask)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_pins_with_mask(pio, sm, pin_values, pin_mask);
+}
+
+static inline void pio_sm_set_pindirs_with_mask(PIO pio, uint sm, uint32_t pin_dirs, uint32_t pin_mask)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_pindirs_with_mask(pio, sm, pin_dirs, pin_mask);
+}
+
+static inline void pio_sm_set_consecutive_pindirs(PIO pio, uint sm, uint pin_base, uint pin_count, bool is_out)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_consecutive_pindirs(pio, sm, pin_base, pin_count, is_out);
+}
+
+static inline void pio_sm_set_enabled(PIO pio, uint sm, bool enabled)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_enabled(pio, sm, enabled);
+}
+
+static inline void pio_set_sm_mask_enabled(PIO pio, uint32_t mask, bool enabled)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_enabled_mask(pio, mask, enabled);
+}
+
+static inline void pio_sm_restart(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_restart(pio, sm);
+}
+
+static inline void pio_restart_sm_mask(PIO pio, uint32_t mask)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_restart_mask(pio, mask);
+}
+
+static inline void pio_sm_clkdiv_restart(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_clkdiv_restart(pio, sm);
+}
+
+static inline void pio_clkdiv_restart_sm_mask(PIO pio, uint32_t mask)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_clkdiv_restart_mask(pio, mask);
+}
+
+static inline void pio_enable_sm_in_sync_mask(PIO pio, uint32_t mask)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_enable_sync(pio, mask);
+};
+
+static inline void pio_sm_set_dmactrl(PIO pio, uint sm, bool is_tx, uint32_t ctrl)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_set_dmactrl(pio, sm, is_tx, ctrl);
+};
+
+static inline bool pio_sm_is_rx_fifo_empty(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_is_rx_fifo_empty(pio, sm);
+}
+
+static inline bool pio_sm_is_rx_fifo_full(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_is_rx_fifo_full(pio, sm);
+}
+
+static inline uint pio_sm_get_rx_fifo_level(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_get_rx_fifo_level(pio, sm);
+}
+
+static inline bool pio_sm_is_tx_fifo_empty(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_is_tx_fifo_empty(pio, sm);
+}
+
+static inline bool pio_sm_is_tx_fifo_full(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_is_tx_fifo_full(pio, sm);
+}
+
+static inline uint pio_sm_get_tx_fifo_level(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_get_tx_fifo_level(pio, sm);
+}
+
+static inline void pio_sm_drain_tx_fifo(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_drain_tx_fifo(pio, sm);
+}
+
+static inline void pio_sm_put(PIO pio, uint sm, uint32_t data)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_put(pio, sm, data, false);
+}
+
+static inline void pio_sm_put_blocking(PIO pio, uint sm, uint32_t data)
+{
+    check_pio_param(pio);
+    pio->chip->pio_sm_put(pio, sm, data, true);
+}
+
+static inline uint32_t pio_sm_get(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_get(pio, sm, false);
+}
+
+static inline uint32_t pio_sm_get_blocking(PIO pio, uint sm)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_sm_get(pio, sm, true);
+}
+
+static inline pio_sm_config pio_get_default_sm_config_for_pio(PIO pio)
+{
+    check_pio_param(pio);
+    return pio->chip->pio_get_default_sm_config(pio);
+}
+
+static inline pio_sm_config pio_get_default_sm_config(void)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->pio_get_default_sm_config(pio);
+}
+
+static inline void sm_config_set_out_pins(pio_sm_config *c, uint out_base, uint out_count)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_out_pins(pio, c, out_base, out_count);
+}
+
+static inline void sm_config_set_set_pins(pio_sm_config *c, uint set_base, uint set_count)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_set_pins(pio, c, set_base, set_count);
+}
+
+static inline void sm_config_set_in_pins(pio_sm_config *c, uint in_base)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_in_pins(pio, c, in_base);
+}
+
+static inline void sm_config_set_sideset_pins(pio_sm_config *c, uint sideset_base)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_sideset_pins(pio, c, sideset_base);
+}
+
+static inline void sm_config_set_sideset(pio_sm_config *c, uint bit_count, bool optional, bool pindirs)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_sideset(pio, c, bit_count, optional, pindirs);
+}
+
+static inline void sm_config_set_clkdiv_int_frac(pio_sm_config *c, uint16_t div_int, uint8_t div_frac)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_clkdiv_int_frac(pio, c, div_int, div_frac);
+}
+
+static inline void sm_config_set_clkdiv(pio_sm_config *c, float div)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_clkdiv(pio, c, div);
+}
+
+static inline void sm_config_set_wrap(pio_sm_config *c, uint wrap_target, uint wrap)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_wrap(pio, c, wrap_target, wrap);
+}
+
+static inline void sm_config_set_jmp_pin(pio_sm_config *c, uint pin)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_jmp_pin(pio, c, pin);
+}
+
+static inline void sm_config_set_in_shift(pio_sm_config *c, bool shift_right, bool autopush, uint push_threshold)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_in_shift(pio, c, shift_right, autopush, push_threshold);
+}
+
+static inline void sm_config_set_out_shift(pio_sm_config *c, bool shift_right, bool autopull, uint pull_threshold)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_out_shift(pio, c, shift_right, autopull, pull_threshold);
+}
+
+static inline void sm_config_set_fifo_join(pio_sm_config *c, enum pio_fifo_join join)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_fifo_join(pio, c, join);
+}
+
+static inline void sm_config_set_out_special(pio_sm_config *c, bool sticky, bool has_enable_pin, uint enable_pin_index)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_out_special(pio, c, sticky, has_enable_pin, enable_pin_index);
+}
+
+static inline void sm_config_set_mov_status(pio_sm_config *c, enum pio_mov_status_type status_sel, uint status_n)
+{
+    PIO pio = pio_get_current();
+    pio->chip->smc_set_mov_status(pio, c, status_sel, status_n);
+}
+
+static inline void pio_gpio_init(PIO pio, uint pin)
+{
+    check_pio_param(pio);
+    pio->chip->pio_gpio_init(pio, pin);
+}
+
+static inline uint32_t clock_get_hz(enum clock_index clk_index)
+{
+    PIO pio = pio_get_current();
+    return pio->chip->clock_get_hz(pio, clk_index);
+}
+
+static inline void gpio_init(uint gpio)
+{
+    PIO pio = pio_get_current();
+    pio->chip->gpio_init(pio, gpio);
+}
+
+static inline void gpio_set_function(uint gpio, enum gpio_function fn)
+{
+    PIO pio = pio_get_current();
+    pio->chip->gpio_set_function(pio, gpio, fn);
+}
+
+
+static inline void gpio_set_pulls(uint gpio, bool up, bool down)
+{
+    PIO pio = pio_get_current();
+    pio->chip->gpio_set_pulls(pio, gpio, up, down);
+}
+
+static inline void gpio_set_outover(uint gpio, uint value)
+{
+    PIO pio = pio_get_current();
+    pio->chip->gpio_set_outover(pio, gpio, value);
+}
+
+static inline void gpio_set_inover(uint gpio, uint value)
+{
+    PIO pio = pio_get_current();
+    pio->chip->gpio_set_inover(pio, gpio, value);
+}
+
+static inline void gpio_set_oeover(uint gpio, uint value)
+{
+    PIO pio = pio_get_current();
+    pio->chip->gpio_set_oeover(pio, gpio, value);
+}
+
+static inline void gpio_set_input_enabled(uint gpio, bool enabled)
+{
+    PIO pio = pio_get_current();
+    pio->chip->gpio_set_input_enabled(pio, gpio, enabled);
+}
+
+static inline void gpio_set_drive_strength(uint gpio, enum gpio_drive_strength drive)
+{
+    PIO pio = pio_get_current();
+    pio->chip->gpio_set_drive_strength(pio, gpio, drive);
+}
+
+static inline void gpio_pull_up(uint gpio) {
+    gpio_set_pulls(gpio, true, false);
+}
+
+static inline void gpio_pull_down(uint gpio) {
+    gpio_set_pulls(gpio, false, true);
+}
+
+static inline void gpio_disable_pulls(uint gpio) {
+    gpio_set_pulls(gpio, false, false);
+}
+
+static inline void stdio_init_all(void)
+{
+}
+
+void sleep_us(uint64_t us);
+
+static inline void sleep_ms(uint32_t ms) {
+    sleep_us((uint64_t)(ms * (uint64_t)1000));
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/rp1/rp1_pio_vendor/piolib/include/piolib_priv.h
+++ b/lib/rp1/rp1_pio_vendor/piolib/include/piolib_priv.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2023-24 Raspberry Pi Ltd.
+ * All rights reserved.
+ */
+
+#ifndef _PIOLIB_PRIV_H
+#define _PIOLIB_PRIV_H
+
+#include "pio_platform.h"
+
+#define DECLARE_PIO_CHIP(chip) \
+    const PIO_CHIP_T *__ptr_ ## chip __attribute__ ((section ("piochips"))) __attribute__ ((used)) = \
+    &chip
+
+#endif

--- a/lib/rp1/rp1_pio_vendor/piolib/include/rp1_pio_if.h
+++ b/lib/rp1/rp1_pio_vendor/piolib/include/rp1_pio_if.h
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2023-24 Raspberry Pi Ltd.
+ * All rights reserved.
+ */
+#ifndef _RP1_PIO_IF_H
+#define _RP1_PIO_IF_H
+
+#include <sys/ioctl.h>
+
+#define RP1_PIO_INSTRUCTION_COUNT   32
+#define RP1_PIO_SM_COUNT            4
+#define RP1_PIO_GPIO_COUNT          28
+#define RP1_GPIO_FUNC_PIO           7
+
+#define RP1_PIO_ORIGIN_ANY          ((uint16_t)(~0))
+
+#define RP1_PIO_DIR_TO_SM           0
+#define RP1_PIO_DIR_FROM_SM         1
+#define RP1_PIO_DIR_COUNT           2
+
+typedef struct {
+    uint32_t clkdiv;
+    uint32_t execctrl;
+    uint32_t shiftctrl;
+    uint32_t pinctrl;
+} rp1_pio_sm_config;
+
+struct rp1_pio_add_program_args {
+    uint16_t num_instrs;
+    uint16_t origin;
+    uint16_t instrs[RP1_PIO_INSTRUCTION_COUNT];
+};
+
+struct rp1_pio_remove_program_args {
+    uint16_t num_instrs;
+    uint16_t origin;
+};
+
+struct rp1_pio_sm_claim_args {
+    uint16_t mask;
+};
+
+struct rp1_pio_sm_init_args {
+    uint16_t sm;
+    uint16_t initial_pc;
+    rp1_pio_sm_config config;
+};
+
+struct rp1_pio_sm_set_config_args {
+    uint16_t sm;
+    uint16_t rsvd;
+    rp1_pio_sm_config config;
+};
+
+struct rp1_pio_sm_exec_args {
+    uint16_t sm;
+    uint16_t instr;
+    uint8_t blocking;
+    uint8_t rsvd;
+};
+
+struct rp1_pio_sm_clear_fifos_args {
+    uint16_t sm;
+};
+
+struct rp1_pio_sm_set_clkdiv_args {
+    uint16_t sm;
+    uint16_t div_int;
+    uint8_t div_frac;
+    uint8_t rsvd;
+};
+
+struct rp1_pio_sm_set_pins_args {
+    uint16_t sm;
+    uint16_t rsvd;
+    uint32_t values;
+    uint32_t mask;
+};
+
+struct rp1_pio_sm_set_pindirs_args {
+    uint16_t sm;
+    uint16_t rsvd;
+    uint32_t dirs;
+    uint32_t mask;
+};
+
+struct rp1_pio_sm_set_enabled_args {
+    uint16_t mask;
+    uint8_t enable;
+    uint8_t rsvd;
+};
+
+struct rp1_pio_sm_restart_args {
+    uint16_t mask;
+};
+
+struct rp1_pio_sm_clkdiv_restart_args {
+    uint16_t mask;
+};
+
+struct rp1_pio_sm_enable_sync_args {
+    uint16_t mask;
+};
+
+struct rp1_pio_sm_put_args {
+    uint16_t sm;
+    uint8_t blocking;
+    uint8_t rsvd;
+    uint32_t data;
+};
+
+struct rp1_pio_sm_get_args {
+    uint16_t sm;
+    uint8_t blocking;
+    uint8_t rsvd;
+    uint32_t data; /* OUT */
+};
+
+struct rp1_pio_sm_set_dmactrl_args {
+    uint16_t sm;
+    uint8_t is_tx;
+    uint8_t rsvd;
+    uint32_t ctrl;
+};
+
+struct rp1_pio_sm_fifo_state_args {
+	uint16_t sm;
+	uint8_t tx;
+	uint8_t rsvd;
+	uint16_t level; /* OUT */
+	uint8_t empty; /* OUT */
+	uint8_t full; /* OUT */
+};
+
+struct rp1_gpio_init_args {
+    uint16_t gpio;
+};
+
+struct rp1_gpio_set_function_args {
+    uint16_t gpio;
+    uint16_t fn;
+};
+
+struct rp1_gpio_set_pulls_args {
+    uint16_t gpio;
+    uint8_t up;
+    uint8_t down;
+};
+
+struct rp1_gpio_set_args {
+    uint16_t gpio;
+    uint16_t value;
+};
+
+struct rp1_pio_sm_config_xfer_args {
+    uint16_t sm;
+    uint16_t dir;
+    uint16_t buf_size;
+    uint16_t buf_count;
+};
+
+struct rp1_pio_sm_config_xfer32_args {
+    uint16_t sm;
+    uint16_t dir;
+    uint32_t buf_size;
+    uint32_t buf_count;
+};
+
+struct rp1_pio_sm_xfer_data_args {
+    uint16_t sm;
+    uint16_t dir;
+    uint16_t data_bytes;
+    uint16_t rsvd;
+    void *data;
+};
+
+struct rp1_pio_sm_xfer_data32_args {
+    uint16_t sm;
+    uint16_t dir;
+    uint32_t data_bytes;
+    void *data;
+};
+
+struct rp1_access_hw_args {
+    uint32_t addr;
+    uint32_t len;
+    void *data;
+};
+
+#define PIO_IOC_MAGIC 102
+
+#define PIO_IOC_SM_CONFIG_XFER _IOW(PIO_IOC_MAGIC, 0, struct rp1_pio_sm_config_xfer_args)
+#define PIO_IOC_SM_XFER_DATA _IOW(PIO_IOC_MAGIC, 1, struct rp1_pio_sm_xfer_data_args)
+#define PIO_IOC_SM_XFER_DATA32 _IOW(PIO_IOC_MAGIC, 2, struct rp1_pio_sm_xfer_data32_args)
+#define PIO_IOC_SM_CONFIG_XFER32 _IOW(PIO_IOC_MAGIC, 3, struct rp1_pio_sm_config_xfer32_args)
+
+#define PIO_IOC_READ_HW _IOW(PIO_IOC_MAGIC, 8, struct rp1_access_hw_args)
+#define PIO_IOC_WRITE_HW _IOW(PIO_IOC_MAGIC, 9, struct rp1_access_hw_args)
+
+#define PIO_IOC_CAN_ADD_PROGRAM _IOW(PIO_IOC_MAGIC, 10, struct rp1_pio_add_program_args)
+#define PIO_IOC_ADD_PROGRAM _IOW(PIO_IOC_MAGIC, 11, struct rp1_pio_add_program_args)
+#define PIO_IOC_REMOVE_PROGRAM _IOW(PIO_IOC_MAGIC, 12, struct rp1_pio_remove_program_args)
+#define PIO_IOC_CLEAR_INSTR_MEM _IO(PIO_IOC_MAGIC, 13)
+
+#define PIO_IOC_SM_CLAIM _IOW(PIO_IOC_MAGIC, 20, struct rp1_pio_sm_claim_args)
+#define PIO_IOC_SM_UNCLAIM _IOW(PIO_IOC_MAGIC, 21, struct rp1_pio_sm_claim_args)
+#define PIO_IOC_SM_IS_CLAIMED _IOW(PIO_IOC_MAGIC, 22, struct rp1_pio_sm_claim_args)
+
+#define PIO_IOC_SM_INIT _IOW(PIO_IOC_MAGIC, 30, struct rp1_pio_sm_init_args)
+#define PIO_IOC_SM_SET_CONFIG _IOW(PIO_IOC_MAGIC, 31, struct rp1_pio_sm_set_config_args)
+#define PIO_IOC_SM_EXEC _IOW(PIO_IOC_MAGIC, 32, struct rp1_pio_sm_exec_args)
+#define PIO_IOC_SM_CLEAR_FIFOS _IOW(PIO_IOC_MAGIC, 33, struct rp1_pio_sm_clear_fifos_args)
+#define PIO_IOC_SM_SET_CLKDIV _IOW(PIO_IOC_MAGIC, 34, struct rp1_pio_sm_set_clkdiv_args)
+#define PIO_IOC_SM_SET_PINS _IOW(PIO_IOC_MAGIC, 35, struct rp1_pio_sm_set_pins_args)
+#define PIO_IOC_SM_SET_PINDIRS _IOW(PIO_IOC_MAGIC, 36, struct rp1_pio_sm_set_pindirs_args)
+#define PIO_IOC_SM_SET_ENABLED _IOW(PIO_IOC_MAGIC, 37, struct rp1_pio_sm_set_enabled_args)
+#define PIO_IOC_SM_RESTART _IOW(PIO_IOC_MAGIC, 38, struct rp1_pio_sm_restart_args)
+#define PIO_IOC_SM_CLKDIV_RESTART _IOW(PIO_IOC_MAGIC, 39, struct rp1_pio_sm_restart_args)
+#define PIO_IOC_SM_ENABLE_SYNC _IOW(PIO_IOC_MAGIC, 40, struct rp1_pio_sm_enable_sync_args)
+#define PIO_IOC_SM_PUT _IOW(PIO_IOC_MAGIC, 41, struct rp1_pio_sm_put_args)
+#define PIO_IOC_SM_GET _IOWR(PIO_IOC_MAGIC, 42, struct rp1_pio_sm_get_args)
+#define PIO_IOC_SM_SET_DMACTRL _IOW(PIO_IOC_MAGIC, 43, struct rp1_pio_sm_set_dmactrl_args)
+#define PIO_IOC_SM_FIFO_STATE _IOW(PIO_IOC_MAGIC, 44, struct rp1_pio_sm_fifo_state_args)
+#define PIO_IOC_SM_DRAIN_TX _IOW(PIO_IOC_MAGIC, 45, struct rp1_pio_sm_clear_fifos_args)
+
+#define PIO_IOC_GPIO_INIT _IOW(PIO_IOC_MAGIC, 50, struct rp1_gpio_init_args)
+#define PIO_IOC_GPIO_SET_FUNCTION _IOW(PIO_IOC_MAGIC, 51, struct rp1_gpio_set_function_args)
+#define PIO_IOC_GPIO_SET_PULLS _IOW(PIO_IOC_MAGIC, 52, struct rp1_gpio_set_pulls_args)
+#define PIO_IOC_GPIO_SET_OUTOVER _IOW(PIO_IOC_MAGIC, 53, struct rp1_gpio_set_args)
+#define PIO_IOC_GPIO_SET_INOVER _IOW(PIO_IOC_MAGIC, 54, struct rp1_gpio_set_args)
+#define PIO_IOC_GPIO_SET_OEOVER _IOW(PIO_IOC_MAGIC, 55, struct rp1_gpio_set_args)
+#define PIO_IOC_GPIO_SET_INPUT_ENABLED _IOW(PIO_IOC_MAGIC, 56, struct rp1_gpio_set_args)
+#define PIO_IOC_GPIO_SET_DRIVE_STRENGTH _IOW(PIO_IOC_MAGIC, 57, struct rp1_gpio_set_args)
+
+#endif

--- a/lib/rp1/rp1_pio_vendor/piolib/pio_rp1.c
+++ b/lib/rp1/rp1_pio_vendor/piolib/pio_rp1.c
@@ -1,0 +1,974 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2024 Raspberry Pi Ltd.
+ * All rights reserved.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <malloc.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#define PIOLIB_INTERNALS
+
+#include "pio_platform.h"
+
+#define pio_encode_delay _pio_encode_delay
+#define pio_encode_sideset _pio_encode_sideset
+#define pio_encode_sideset_opt _pio_encode_sideset_opt
+#define pio_encode_jmp _pio_encode_jmp
+#define pio_encode_jmp_not_x _pio_encode_jmp_not_x
+#define pio_encode_jmp_x_dec _pio_encode_jmp_x_dec
+#define pio_encode_jmp_not_y _pio_encode_jmp_not_y
+#define pio_encode_jmp_y_dec _pio_encode_jmp_y_dec
+#define pio_encode_jmp_x_ne_y _pio_encode_jmp_x_ne_y
+#define pio_encode_jmp_pin _pio_encode_jmp_pin
+#define pio_encode_jmp_not_osre _pio_encode_jmp_not_osre
+#define pio_encode_wait_gpio _pio_encode_wait_gpio
+#define pio_encode_wait_pin _pio_encode_wait_pin
+#define pio_encode_wait_irq _pio_encode_wait_irq
+#define pio_encode_in _pio_encode_in
+#define pio_encode_out _pio_encode_out
+#define pio_encode_push _pio_encode_push
+#define pio_encode_pull _pio_encode_pull
+#define pio_encode_mov _pio_encode_mov
+#define pio_encode_mov_not _pio_encode_mov_not
+#define pio_encode_mov_reverse _pio_encode_mov_reverse
+#define pio_encode_irq_set _pio_encode_irq_set
+#define pio_encode_irq_wait _pio_encode_irq_wait
+#define pio_encode_irq_clear _pio_encode_irq_clear
+#define pio_encode_set _pio_encode_set
+#define pio_encode_nop _pio_encode_nop
+#include "hardware/pio_instructions.h"
+#undef pio_encode_delay
+#undef pio_encode_sideset
+#undef pio_encode_sideset_opt
+#undef pio_encode_jmp
+#undef pio_encode_jmp_not_x
+#undef pio_encode_jmp_x_dec
+#undef pio_encode_jmp_not_y
+#undef pio_encode_jmp_y_dec
+#undef pio_encode_jmp_x_ne_y
+#undef pio_encode_jmp_pin
+#undef pio_encode_jmp_not_osre
+#undef pio_encode_wait_gpio
+#undef pio_encode_wait_pin
+#undef pio_encode_wait_irq
+#undef pio_encode_in
+#undef pio_encode_out
+#undef pio_encode_push
+#undef pio_encode_pull
+#undef pio_encode_mov
+#undef pio_encode_mov_not
+#undef pio_encode_mov_reverse
+#undef pio_encode_irq_set
+#undef pio_encode_irq_wait
+#undef pio_encode_irq_clear
+#undef pio_encode_set
+#undef pio_encode_nop
+
+#include "piolib.h"
+#include "piolib_priv.h"
+#include "hardware/gpio.h"
+#include "hardware/pio.h"
+#include "hardware/regs/proc_pio.h"
+#include "rp1_pio_if.h"
+
+typedef struct rp1_pio_handle {
+    struct pio_instance base;
+    const char *devname;
+    int fd;
+} *RP1_PIO;
+
+#define smc_to_rp1(_config, _c) rp1_pio_sm_config *_c = (rp1_pio_sm_config*)_config
+
+#define GPIOS_MASK ((1 << RP1_PIO_GPIO_COUNT) - 1)
+
+STATIC_ASSERT(sizeof(rp1_pio_sm_config) <= sizeof(pio_sm_config));
+
+static inline void check_sm_param(__unused uint sm)
+{
+    valid_params_if(PIO, sm < RP1_PIO_SM_COUNT);
+}
+
+static inline void check_sm_mask(__unused uint mask)
+{
+    valid_params_if(PIO, mask < (1u << RP1_PIO_SM_COUNT));
+}
+
+static pio_sm_config rp1_pio_get_default_sm_config(PIO)
+{
+    pio_sm_config c = { { 0 } };
+    sm_config_set_clkdiv_int_frac(&c, 1, 0);
+    sm_config_set_wrap(&c, 0, 31);
+    sm_config_set_in_shift(&c, true, false, 32);
+    sm_config_set_out_shift(&c, true, false, 32);
+    return c;
+}
+
+static uint rp1_pio_encode_delay(PIO, uint cycles)
+{
+    return _pio_encode_delay(cycles);
+}
+
+static uint rp1_pio_encode_sideset(PIO, uint sideset_bit_count, uint value)
+{
+    return _pio_encode_sideset(sideset_bit_count, value);
+}
+
+static uint rp1_pio_encode_sideset_opt(PIO, uint sideset_bit_count, uint value)
+{
+    return _pio_encode_sideset_opt(sideset_bit_count, value);
+}
+
+static uint rp1_pio_encode_jmp(PIO, uint addr)
+{
+    return _pio_encode_jmp(addr);
+}
+
+static uint rp1_pio_encode_jmp_not_x(PIO, uint addr)
+{
+    return _pio_encode_jmp_not_x(addr);
+}
+
+static uint rp1_pio_encode_jmp_x_dec(PIO, uint addr)
+{
+    return _pio_encode_jmp_x_dec(addr);
+}
+
+static uint rp1_pio_encode_jmp_not_y(PIO, uint addr)
+{
+    return _pio_encode_jmp_not_y(addr);
+}
+
+static uint rp1_pio_encode_jmp_y_dec(PIO, uint addr)
+{
+    return _pio_encode_jmp_y_dec(addr);
+}
+
+static uint rp1_pio_encode_jmp_x_ne_y(PIO, uint addr)
+{
+    return _pio_encode_jmp_x_ne_y(addr);
+}
+
+static uint rp1_pio_encode_jmp_pin(PIO, uint addr)
+{
+    return _pio_encode_jmp_pin(addr);
+}
+
+static uint rp1_pio_encode_jmp_not_osre(PIO, uint addr)
+{
+    return _pio_encode_jmp_not_osre(addr);
+}
+
+static uint rp1_pio_encode_wait_gpio(PIO, bool polarity, uint gpio)
+{
+    return _pio_encode_wait_gpio(polarity, gpio);
+}
+
+static uint rp1_pio_encode_wait_pin(PIO, bool polarity, uint pin)
+{
+    return _pio_encode_wait_pin(polarity, pin);
+}
+
+static uint rp1_pio_encode_wait_irq(PIO, bool polarity, bool relative, uint irq)
+{
+    return _pio_encode_wait_irq(polarity, relative, irq);
+}
+
+static uint rp1_pio_encode_in(PIO, enum pio_src_dest src, uint count)
+{
+    return _pio_encode_in(src, count);
+}
+
+static uint rp1_pio_encode_out(PIO, enum pio_src_dest dest, uint count)
+{
+    return _pio_encode_out(dest, count);
+}
+
+static uint rp1_pio_encode_push(PIO, bool if_full, bool block)
+{
+    return _pio_encode_push(if_full, block);
+}
+
+static uint rp1_pio_encode_pull(PIO, bool if_empty, bool block)
+{
+    return _pio_encode_pull(if_empty, block);
+}
+
+static uint rp1_pio_encode_mov(PIO, enum pio_src_dest dest, enum pio_src_dest src)
+{
+    return _pio_encode_mov(dest, src);
+}
+
+static uint rp1_pio_encode_mov_not(PIO, enum pio_src_dest dest, enum pio_src_dest src)
+{
+    return _pio_encode_mov_not(dest, src);
+}
+
+static uint rp1_pio_encode_mov_reverse(PIO, enum pio_src_dest dest, enum pio_src_dest src)
+{
+    return _pio_encode_mov_reverse(dest, src);
+}
+
+static uint rp1_pio_encode_irq_set(PIO, bool relative, uint irq)
+{
+    return _pio_encode_irq_set(relative, irq);
+}
+
+static uint rp1_pio_encode_irq_wait(PIO, bool relative, uint irq)
+{
+    return _pio_encode_irq_wait(relative, irq);
+}
+
+static uint rp1_pio_encode_irq_clear(PIO, bool relative, uint irq)
+{
+    return _pio_encode_irq_clear(relative, irq);
+}
+
+static uint rp1_pio_encode_set(PIO, enum pio_src_dest dest, uint value)
+{
+    return _pio_encode_set(dest, value);
+}
+
+static uint rp1_pio_encode_nop(PIO)
+{
+    return _pio_encode_nop();
+}
+
+static int rp1_ioctl(PIO pio, int request, void *args)
+{
+    RP1_PIO rp = (RP1_PIO)pio;
+    int err = ioctl(rp->fd, request, args);
+    switch (err) {
+    case -EREMOTEIO:
+    case -ETIMEDOUT:
+        pio_panic("Error communicating with RP1");
+        break;
+    default:
+        break;
+    }
+    return err;
+}
+
+static int rp1_pio_sm_config_xfer(PIO pio, uint sm, uint dir, uint buf_size, uint buf_count)
+{
+    struct rp1_pio_sm_config_xfer_args args = { .sm = sm, .dir = dir, .buf_size = buf_size, .buf_count = buf_count };
+    struct rp1_pio_sm_config_xfer32_args args32 = { .sm = sm, .dir = dir, .buf_size = buf_size, .buf_count = buf_count };
+    int err;
+    check_sm_param(sm);
+    if (buf_size > 0xffff || buf_count > 0xffff)
+        err = rp1_ioctl(pio, PIO_IOC_SM_CONFIG_XFER32, &args32);
+    else
+        err = rp1_ioctl(pio, PIO_IOC_SM_CONFIG_XFER, &args);
+    return err;
+}
+
+static int rp1_pio_sm_xfer_data(PIO pio, uint sm, uint dir, uint data_bytes, void *data)
+{
+    struct rp1_pio_sm_xfer_data_args args = { .sm = sm, .dir = dir, .data_bytes = data_bytes, .rsvd = 0, .data = data };
+    struct rp1_pio_sm_xfer_data32_args args32 = { .sm = sm, .dir = dir, .data_bytes = data_bytes, .data = data };
+    int err;
+    check_sm_param(sm);
+    if (data_bytes > 0xffff)
+        err = rp1_ioctl(pio, PIO_IOC_SM_XFER_DATA32, &args32);
+    else
+        err = rp1_ioctl(pio, PIO_IOC_SM_XFER_DATA, &args);
+    return err;
+}
+
+static bool rp1_pio_can_add_program_at_offset(PIO pio, const pio_program_t *program, uint offset)
+{
+    struct rp1_pio_add_program_args args = { .num_instrs = program->length, .origin = program->origin };
+    int err;
+    valid_params_if(PIO, offset < RP1_PIO_INSTRUCTION_COUNT || offset == PIO_ORIGIN_ANY);
+    valid_params_if(PIO, program->length <= RP1_PIO_INSTRUCTION_COUNT);
+    valid_params_if(PIO, offset + program->length <= RP1_PIO_INSTRUCTION_COUNT || offset == PIO_ORIGIN_ANY);
+    if (program->origin >= 0 && (uint)program->origin != offset)
+        return false;
+    if (offset != PIO_ORIGIN_ANY)
+        args.origin = offset;
+    memcpy(args.instrs, program->instructions, program->length * sizeof(uint16_t));
+    err = rp1_ioctl(pio, PIO_IOC_CAN_ADD_PROGRAM, &args);
+    return (err > 0);
+}
+
+static uint rp1_pio_add_program_at_offset(PIO pio, const pio_program_t *program, uint offset)
+{
+    struct rp1_pio_add_program_args args = { .num_instrs = program->length, .origin = program->origin };
+    valid_params_if(PIO, offset < RP1_PIO_INSTRUCTION_COUNT || offset == PIO_ORIGIN_ANY);
+    valid_params_if(PIO, program->length <= RP1_PIO_INSTRUCTION_COUNT);
+    valid_params_if(PIO, offset + program->length <= RP1_PIO_INSTRUCTION_COUNT || offset == PIO_ORIGIN_ANY);
+    if (offset != PIO_ORIGIN_ANY)
+        args.origin = offset;
+    memcpy(args.instrs, program->instructions, program->length * sizeof(uint16_t));
+    return rp1_ioctl(pio, PIO_IOC_ADD_PROGRAM, &args);
+}
+
+static bool rp1_pio_remove_program(PIO pio, const pio_program_t *program, uint offset)
+{
+    struct rp1_pio_remove_program_args args = { .num_instrs = program->length, .origin = offset };
+    valid_params_if(PIO, offset < RP1_PIO_INSTRUCTION_COUNT);
+    valid_params_if(PIO, offset + program->length <= RP1_PIO_INSTRUCTION_COUNT);
+    return !rp1_ioctl(pio, PIO_IOC_REMOVE_PROGRAM, &args);
+}
+
+static bool rp1_pio_clear_instruction_memory(PIO pio)
+{
+    return !rp1_ioctl(pio, PIO_IOC_CLEAR_INSTR_MEM, NULL);
+}
+
+static bool rp1_pio_sm_claim(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_claim_args args = { .mask = (1 << sm) };
+    check_sm_param(sm);
+    return (rp1_ioctl(pio, PIO_IOC_SM_CLAIM, &args) >= 0);
+}
+
+static bool rp1_pio_sm_claim_mask(PIO pio, uint mask)
+{
+    struct rp1_pio_sm_claim_args args = { .mask = mask };
+    valid_params_if(PIO, !!mask);
+    check_sm_mask(mask);
+    return (rp1_ioctl(pio, PIO_IOC_SM_CLAIM, &args) >= 0);
+}
+
+static bool rp1_pio_sm_unclaim(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_claim_args args = { .mask = (1 << sm) };
+    check_sm_param(sm);
+    return !rp1_ioctl(pio, PIO_IOC_SM_UNCLAIM, &args);
+}
+
+static int rp1_pio_sm_claim_unused(PIO pio, bool required)
+{
+    struct rp1_pio_sm_claim_args args = { .mask = 0 };
+    int sm = rp1_ioctl(pio, PIO_IOC_SM_CLAIM, &args);
+    if (sm < 0 && required)
+        pio_panic("No PIO state machines are available");
+    return sm;
+}
+
+static bool rp1_pio_sm_is_claimed(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_claim_args args = { .mask = (1 << sm) };
+    check_sm_param(sm);
+    int err = rp1_ioctl(pio, PIO_IOC_SM_IS_CLAIMED, &args);
+    return (err > 0);
+}
+
+static void rp1_pio_sm_init(PIO pio, uint sm, uint initial_pc, const pio_sm_config *config)
+{
+    smc_to_rp1(config, c);
+    struct rp1_pio_sm_init_args args = { .sm = sm, .initial_pc = initial_pc, .config = *c };
+    valid_params_if(PIO, initial_pc < RP1_PIO_INSTRUCTION_COUNT);
+
+    (void)rp1_ioctl(pio, PIO_IOC_SM_INIT, &args);
+}
+
+static void rp1_pio_sm_set_config(PIO pio, uint sm, const pio_sm_config *config)
+{
+    smc_to_rp1(config, c);
+    struct rp1_pio_sm_init_args args = { .sm = sm, .config = *c };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_SET_CONFIG, &args);
+}
+
+static void rp1_pio_sm_exec(PIO pio, uint sm, uint instr, bool blocking)
+{
+    struct rp1_pio_sm_exec_args args = { .sm = sm, .instr = instr, .blocking = blocking };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_EXEC, &args);
+}
+
+static void rp1_pio_sm_clear_fifos(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_clear_fifos_args args = { .sm = sm };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_CLEAR_FIFOS, &args);
+}
+
+static void rp1_pio_calculate_clkdiv_from_float(float div, uint16_t *div_int, uint8_t *div_frac)
+{
+    valid_params_if(PIO, div >= 1 && div <= 65536);
+    *div_int = (uint16_t)div;
+    if (*div_int == 0) {
+        *div_frac = 0;
+    } else {
+        *div_frac = (uint8_t)((div - (float)*div_int) * (1u << 8u));
+    }
+}
+
+static void rp1_pio_sm_set_clkdiv_int_frac(PIO pio, uint sm, uint16_t div_int, uint8_t div_frac)
+{
+    struct rp1_pio_sm_set_clkdiv_args args = { .sm = sm, .div_int = div_int, .div_frac = div_frac };
+
+    check_sm_param(sm);
+    invalid_params_if(PIO, div_int == 0 && div_frac != 0);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_SET_CLKDIV, &args);
+}
+
+static void rp1_pio_sm_set_clkdiv(PIO pio, uint sm, float div)
+{
+    uint16_t div_int;
+    uint8_t div_frac;
+
+    check_sm_param(sm);
+    rp1_pio_calculate_clkdiv_from_float(div, &div_int, &div_frac);
+    rp1_pio_sm_set_clkdiv_int_frac(pio, sm, div_int, div_frac);
+}
+
+static void rp1_pio_sm_set_pins(PIO pio, uint sm, uint32_t pin_values)
+{
+    struct rp1_pio_sm_set_pins_args args = { .sm = sm, .values = pin_values, .mask = GPIOS_MASK };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_SET_PINS, &args);
+}
+
+static void rp1_pio_sm_set_pins_with_mask(PIO pio, uint sm, uint32_t pin_values, uint32_t pin_mask)
+{
+    struct rp1_pio_sm_set_pins_args args = { .sm = sm, .values = pin_values, .mask = pin_mask };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_SET_PINS, &args);
+}
+
+static void rp1_pio_sm_set_pindirs_with_mask(PIO pio, uint sm, uint32_t pin_dirs, uint32_t pin_mask)
+{
+    struct rp1_pio_sm_set_pindirs_args args = { .sm = sm, .dirs = pin_dirs, .mask = pin_mask };
+
+    check_sm_param(sm);
+    valid_params_if(PIO, (pin_dirs & GPIOS_MASK) == pin_dirs);
+    valid_params_if(PIO, (pin_mask & pin_mask) == pin_mask);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_SET_PINDIRS, &args);
+}
+
+static void rp1_pio_sm_set_consecutive_pindirs(PIO pio, uint sm, uint pin_base, uint pin_count, bool is_out)
+{
+    uint32_t mask = ((1 << pin_count) - 1) << pin_base;
+    struct rp1_pio_sm_set_pindirs_args args = { .sm = sm, .dirs = is_out ? mask : 0, .mask = mask };
+
+    check_sm_param(sm);
+    valid_params_if(PIO, pin_base < RP1_PIO_GPIO_COUNT &&
+                    pin_count < RP1_PIO_GPIO_COUNT &&
+                    (pin_base + pin_count) < RP1_PIO_GPIO_COUNT);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_SET_PINDIRS, &args);
+}
+
+static void rp1_pio_sm_set_enabled(PIO pio, uint sm, bool enabled)
+{
+    struct rp1_pio_sm_set_enabled_args args = { .mask = (1 << sm), .enable = enabled };
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_SET_ENABLED, &args);
+}
+
+static void rp1_pio_sm_set_enabled_mask(PIO pio, uint32_t mask, bool enabled)
+{
+    struct rp1_pio_sm_set_enabled_args args = { .mask = (uint16_t)mask, .enable = enabled };
+    check_sm_mask(mask);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_SET_ENABLED, &args);
+}
+
+static void rp1_pio_sm_restart(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_restart_args args = { .mask = (1 << sm) };
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_RESTART, &args);
+}
+
+static void rp1_pio_sm_restart_mask(PIO pio, uint32_t mask)
+{
+    struct rp1_pio_sm_restart_args args = { .mask = (uint16_t)mask };
+    check_sm_mask(mask);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_RESTART, &args);
+}
+
+static void rp1_pio_sm_clkdiv_restart(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_restart_args args = { .mask = (1 << sm) };
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_CLKDIV_RESTART, &args);
+}
+
+static void rp1_pio_sm_clkdiv_restart_mask(PIO pio, uint32_t mask)
+{
+    struct rp1_pio_sm_restart_args args = { .mask = (uint16_t)mask };
+
+    check_sm_mask(mask);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_CLKDIV_RESTART, &args);
+}
+
+static void rp1_pio_sm_enable_sync(PIO pio, uint32_t mask)
+{
+    struct rp1_pio_sm_enable_sync_args args = { .mask = (uint16_t)mask };
+
+    check_sm_mask(mask);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_ENABLE_SYNC, &args);
+}
+
+static void rp1_pio_sm_put(PIO pio, uint sm, uint32_t data, bool blocking)
+{
+    struct rp1_pio_sm_put_args args = { .sm = (uint16_t)sm, .blocking = blocking, .data = data };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_PUT, &args);
+}
+
+static uint32_t rp1_pio_sm_get(PIO pio, uint sm, bool blocking)
+{
+    struct rp1_pio_sm_get_args args = { .sm = (uint16_t)sm, .blocking = blocking };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_GET, &args);
+    return args.data;
+}
+
+static void rp1_pio_sm_set_dmactrl(PIO pio, uint sm, bool is_tx, uint32_t ctrl)
+{
+    struct rp1_pio_sm_set_dmactrl_args args = { .sm = sm, .is_tx = is_tx, .ctrl = ctrl };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_SET_DMACTRL, &args);
+}
+
+static bool rp1_pio_sm_is_rx_fifo_empty(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_fifo_state_args args = { .sm = sm, .tx = false };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_FIFO_STATE, &args);
+    return args.empty;
+}
+
+static bool rp1_pio_sm_is_rx_fifo_full(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_fifo_state_args args = { .sm = sm, .tx = false };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_FIFO_STATE, &args);
+    return args.full;
+}
+
+static uint rp1_pio_sm_get_rx_fifo_level(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_fifo_state_args args = { .sm = sm, .tx = false };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_FIFO_STATE, &args);
+    return args.level;
+}
+
+static bool rp1_pio_sm_is_tx_fifo_empty(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_fifo_state_args args = { .sm = sm, .tx = true };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_FIFO_STATE, &args);
+    return args.empty;
+}
+
+static bool rp1_pio_sm_is_tx_fifo_full(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_fifo_state_args args = { .sm = sm, .tx = true };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_FIFO_STATE, &args);
+    return args.full;
+}
+
+static uint rp1_pio_sm_get_tx_fifo_level(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_fifo_state_args args = { .sm = sm, .tx = true };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_FIFO_STATE, &args);
+    return args.level;
+}
+
+static void rp1_pio_sm_drain_tx_fifo(PIO pio, uint sm)
+{
+    struct rp1_pio_sm_clear_fifos_args args = { .sm = sm };
+
+    check_sm_param(sm);
+    (void)rp1_ioctl(pio, PIO_IOC_SM_DRAIN_TX, &args);
+}
+
+static void rp1_smc_set_out_pins(PIO, pio_sm_config *config, uint out_base, uint out_count)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, out_base < RP1_PIO_GPIO_COUNT);
+    valid_params_if(PIO, out_count <= RP1_PIO_GPIO_COUNT);
+    c->pinctrl = (c->pinctrl & ~(PROC_PIO_SM0_PINCTRL_OUT_BASE_BITS | PROC_PIO_SM0_PINCTRL_OUT_COUNT_BITS)) |
+                 (out_base << PROC_PIO_SM0_PINCTRL_OUT_BASE_LSB) |
+                 (out_count << PROC_PIO_SM0_PINCTRL_OUT_COUNT_LSB);
+}
+
+static void rp1_smc_set_set_pins(PIO, pio_sm_config *config, uint set_base, uint set_count)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, set_base < RP1_PIO_GPIO_COUNT);
+    valid_params_if(PIO, set_count <= 5);
+    c->pinctrl = (c->pinctrl & ~(PROC_PIO_SM0_PINCTRL_SET_BASE_BITS | PROC_PIO_SM0_PINCTRL_SET_COUNT_BITS)) |
+                 (set_base << PROC_PIO_SM0_PINCTRL_SET_BASE_LSB) |
+                 (set_count << PROC_PIO_SM0_PINCTRL_SET_COUNT_LSB);
+}
+
+
+static void rp1_smc_set_in_pins(PIO, pio_sm_config *config, uint in_base)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, in_base < RP1_PIO_GPIO_COUNT);
+    c->pinctrl = (c->pinctrl & ~PROC_PIO_SM0_PINCTRL_IN_BASE_BITS) |
+                 (in_base << PROC_PIO_SM0_PINCTRL_IN_BASE_LSB);
+}
+
+static void rp1_smc_set_sideset_pins(PIO, pio_sm_config *config, uint sideset_base)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, sideset_base < RP1_PIO_GPIO_COUNT);
+    c->pinctrl = (c->pinctrl & ~PROC_PIO_SM0_PINCTRL_SIDESET_BASE_BITS) |
+                 (sideset_base << PROC_PIO_SM0_PINCTRL_SIDESET_BASE_LSB);
+}
+
+static void rp1_smc_set_sideset(PIO, pio_sm_config *config, uint bit_count, bool optional, bool pindirs)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, bit_count <= 5);
+    valid_params_if(PIO, !optional || bit_count >= 1);
+    c->pinctrl = (c->pinctrl & ~PROC_PIO_SM0_PINCTRL_SIDESET_COUNT_BITS) |
+                 (bit_count << PROC_PIO_SM0_PINCTRL_SIDESET_COUNT_LSB);
+
+    c->execctrl = (c->execctrl & ~(PROC_PIO_SM0_EXECCTRL_SIDE_EN_BITS | PROC_PIO_SM0_EXECCTRL_SIDE_PINDIR_BITS)) |
+                  (bool_to_bit(optional) << PROC_PIO_SM0_EXECCTRL_SIDE_EN_LSB) |
+                  (bool_to_bit(pindirs) << PROC_PIO_SM0_EXECCTRL_SIDE_PINDIR_LSB);
+}
+
+static void rp1_smc_set_clkdiv_int_frac(PIO, pio_sm_config *config, uint16_t div_int, uint8_t div_frac)
+{
+    smc_to_rp1(config, c);
+    invalid_params_if(PIO, div_int == 0 && div_frac != 0);
+    c->clkdiv =
+            (((uint)div_frac) << PROC_PIO_SM0_CLKDIV_FRAC_LSB) |
+            (((uint)div_int) << PROC_PIO_SM0_CLKDIV_INT_LSB);
+}
+
+static void rp1_smc_set_clkdiv(PIO, pio_sm_config *config, float div)
+{
+    uint16_t div_int;
+    uint8_t div_frac;
+    rp1_pio_calculate_clkdiv_from_float(div, &div_int, &div_frac);
+    sm_config_set_clkdiv_int_frac(config, div_int, div_frac);
+}
+
+static void rp1_smc_set_wrap(PIO, pio_sm_config *config, uint wrap_target, uint wrap)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, wrap < RP1_PIO_INSTRUCTION_COUNT);
+    valid_params_if(PIO, wrap_target < RP1_PIO_INSTRUCTION_COUNT);
+    c->execctrl = (c->execctrl & ~(PROC_PIO_SM0_EXECCTRL_WRAP_TOP_BITS | PROC_PIO_SM0_EXECCTRL_WRAP_BOTTOM_BITS)) |
+                  (wrap_target << PROC_PIO_SM0_EXECCTRL_WRAP_BOTTOM_LSB) |
+                  (wrap << PROC_PIO_SM0_EXECCTRL_WRAP_TOP_LSB);
+}
+
+static void rp1_smc_set_jmp_pin(PIO, pio_sm_config *config, uint pin)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, pin < RP1_PIO_GPIO_COUNT);
+    c->execctrl = (c->execctrl & ~PROC_PIO_SM0_EXECCTRL_JMP_PIN_BITS) |
+                  (pin << PROC_PIO_SM0_EXECCTRL_JMP_PIN_LSB);
+}
+
+static void rp1_smc_set_in_shift(PIO, pio_sm_config *config, bool shift_right, bool autopush, uint push_threshold)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, push_threshold <= 32);
+    c->shiftctrl = (c->shiftctrl &
+                    ~(PROC_PIO_SM0_SHIFTCTRL_IN_SHIFTDIR_BITS |
+                      PROC_PIO_SM0_SHIFTCTRL_AUTOPUSH_BITS |
+                      PROC_PIO_SM0_SHIFTCTRL_PUSH_THRESH_BITS)) |
+                   (bool_to_bit(shift_right) << PROC_PIO_SM0_SHIFTCTRL_IN_SHIFTDIR_LSB) |
+                   (bool_to_bit(autopush) << PROC_PIO_SM0_SHIFTCTRL_AUTOPUSH_LSB) |
+                   ((push_threshold & 0x1fu) << PROC_PIO_SM0_SHIFTCTRL_PUSH_THRESH_LSB);
+}
+
+static void rp1_smc_set_out_shift(PIO, pio_sm_config *config, bool shift_right, bool autopull, uint pull_threshold)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, pull_threshold <= 32);
+    c->shiftctrl = (c->shiftctrl &
+                    ~(PROC_PIO_SM0_SHIFTCTRL_OUT_SHIFTDIR_BITS |
+                      PROC_PIO_SM0_SHIFTCTRL_AUTOPULL_BITS |
+                      PROC_PIO_SM0_SHIFTCTRL_PULL_THRESH_BITS)) |
+                   (bool_to_bit(shift_right) << PROC_PIO_SM0_SHIFTCTRL_OUT_SHIFTDIR_LSB) |
+                   (bool_to_bit(autopull) << PROC_PIO_SM0_SHIFTCTRL_AUTOPULL_LSB) |
+                   ((pull_threshold & 0x1fu) << PROC_PIO_SM0_SHIFTCTRL_PULL_THRESH_LSB);
+}
+
+static void rp1_smc_set_fifo_join(PIO, pio_sm_config *config, enum pio_fifo_join join)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, join == PIO_FIFO_JOIN_NONE || join == PIO_FIFO_JOIN_TX || join == PIO_FIFO_JOIN_RX);
+    c->shiftctrl = (c->shiftctrl & (uint)~(PROC_PIO_SM0_SHIFTCTRL_FJOIN_TX_BITS | PROC_PIO_SM0_SHIFTCTRL_FJOIN_RX_BITS)) |
+                   (((uint)join) << PROC_PIO_SM0_SHIFTCTRL_FJOIN_TX_LSB);
+}
+
+static void rp1_smc_set_out_special(PIO, pio_sm_config *config, bool sticky, bool has_enable_pin, uint enable_pin_index)
+{
+    smc_to_rp1(config, c);
+    c->execctrl = (c->execctrl &
+                   (uint)~(PROC_PIO_SM0_EXECCTRL_OUT_STICKY_BITS | PROC_PIO_SM0_EXECCTRL_INLINE_OUT_EN_BITS |
+                     PROC_PIO_SM0_EXECCTRL_OUT_EN_SEL_BITS)) |
+                  (bool_to_bit(sticky) << PROC_PIO_SM0_EXECCTRL_OUT_STICKY_LSB) |
+                  (bool_to_bit(has_enable_pin) << PROC_PIO_SM0_EXECCTRL_INLINE_OUT_EN_LSB) |
+                  ((enable_pin_index << PROC_PIO_SM0_EXECCTRL_OUT_EN_SEL_LSB) & PROC_PIO_SM0_EXECCTRL_OUT_EN_SEL_BITS);
+}
+
+static void rp1_smc_set_mov_status(PIO, pio_sm_config *config, enum pio_mov_status_type status_sel, uint status_n)
+{
+    smc_to_rp1(config, c);
+    valid_params_if(PIO, status_sel == STATUS_TX_LESSTHAN || status_sel == STATUS_RX_LESSTHAN);
+    c->execctrl = (c->execctrl
+                  & ~(PROC_PIO_SM0_EXECCTRL_STATUS_SEL_BITS | PROC_PIO_SM0_EXECCTRL_STATUS_N_BITS))
+                  | ((((uint)status_sel) << PROC_PIO_SM0_EXECCTRL_STATUS_SEL_LSB) & PROC_PIO_SM0_EXECCTRL_STATUS_SEL_BITS)
+                  | ((status_n << PROC_PIO_SM0_EXECCTRL_STATUS_N_LSB) & PROC_PIO_SM0_EXECCTRL_STATUS_N_BITS);
+}
+
+static uint32_t rp1_clock_get_hz(PIO, enum clock_index clk_index)
+{
+    const uint32_t MHZ = 1000000;
+
+    switch (clk_index) {
+    case clk_sys:
+        return 200 * MHZ;
+    default:
+        break;
+    }
+    return PIO_ORIGIN_ANY;
+}
+
+static void rp1_gpio_init(PIO pio, uint gpio)
+{
+    struct rp1_gpio_init_args args = { .gpio = gpio };
+
+    valid_params_if(PIO, gpio < RP1_PIO_GPIO_COUNT);
+    (void)rp1_ioctl(pio, PIO_IOC_GPIO_INIT, &args);
+}
+
+static void rp1_gpio_set_function(PIO pio, uint gpio, enum gpio_function fn)
+{
+    struct rp1_gpio_set_function_args args = { .gpio = gpio, .fn = fn };
+
+    valid_params_if(PIO, gpio < RP1_PIO_GPIO_COUNT);
+    (void)rp1_ioctl(pio, PIO_IOC_GPIO_SET_FUNCTION, &args);
+}
+
+static void rp1_gpio_set_pulls(PIO pio, uint gpio, bool up, bool down)
+{
+    struct rp1_gpio_set_pulls_args args = { .gpio = gpio, .up = up, .down = down };
+
+    valid_params_if(PIO, gpio < RP1_PIO_GPIO_COUNT);
+    (void)rp1_ioctl(pio, PIO_IOC_GPIO_SET_PULLS, &args);
+}
+
+static void rp1_gpio_set_outover(PIO pio, uint gpio, uint value)
+{
+    struct rp1_gpio_set_args args = { .gpio = gpio, .value = value };
+
+    valid_params_if(PIO, gpio < RP1_PIO_GPIO_COUNT);
+    (void)rp1_ioctl(pio, PIO_IOC_GPIO_SET_OUTOVER, &args);
+}
+
+static void rp1_gpio_set_inover(PIO pio, uint gpio, uint value)
+{
+    struct rp1_gpio_set_args args = { .gpio = gpio, .value = value };
+
+    valid_params_if(PIO, gpio < RP1_PIO_GPIO_COUNT);
+    (void)rp1_ioctl(pio, PIO_IOC_GPIO_SET_INOVER, &args);
+}
+
+static void rp1_gpio_set_oeover(PIO pio, uint gpio, uint value)
+{
+    struct rp1_gpio_set_args args = { .gpio = gpio, .value = value };
+
+    valid_params_if(PIO, gpio < RP1_PIO_GPIO_COUNT);
+    (void)rp1_ioctl(pio, PIO_IOC_GPIO_SET_OEOVER, &args);
+}
+
+static void rp1_gpio_set_input_enabled(PIO pio, uint gpio, bool enabled)
+{
+    struct rp1_gpio_set_args args = { .gpio = gpio, .value = enabled };
+
+    valid_params_if(PIO, gpio < RP1_PIO_GPIO_COUNT);
+    (void)rp1_ioctl(pio, PIO_IOC_GPIO_SET_INPUT_ENABLED, &args);
+}
+
+static void rp1_gpio_set_drive_strength(PIO pio, uint gpio, enum gpio_drive_strength drive)
+{
+    struct rp1_gpio_set_args args = { .gpio = gpio, .value = drive };
+
+    valid_params_if(PIO, gpio < RP1_PIO_GPIO_COUNT);
+    (void)rp1_ioctl(pio, PIO_IOC_GPIO_SET_DRIVE_STRENGTH, &args);
+}
+
+static void rp1_pio_gpio_init(PIO pio, uint pin)
+{
+    valid_params_if(PIO, pin < RP1_PIO_GPIO_COUNT);
+    rp1_gpio_set_function(pio, pin, RP1_GPIO_FUNC_PIO);
+}
+
+PIO rp1_create_instance(PIO_CHIP_T *chip, uint index)
+{
+    char pathbuf[20];
+    RP1_PIO pio = NULL;
+
+    sprintf(pathbuf, "/dev/pio%u", index);
+
+    if (access(pathbuf, F_OK) != 0)
+        return NULL;
+
+    pio = calloc(1, sizeof(*pio));
+    if (!pio)
+        return PIO_ERR(-ENOMEM);
+
+    pio->base.chip = chip;
+    pio->fd = -1;
+    pio->devname = strdup(pathbuf);
+
+    rp1_pio_clear_instruction_memory(&pio->base);
+
+    return &pio->base;
+}
+
+int rp1_open_instance(PIO pio)
+{
+    RP1_PIO rp = (RP1_PIO)pio;
+    int fd;
+
+    fd = open(rp->devname, O_RDWR, O_CLOEXEC);
+    if (fd < 0)
+        return -errno;
+    rp->fd = fd;
+    return 0;
+}
+
+void rp1_close_instance(PIO pio)
+{
+    RP1_PIO rp = (RP1_PIO)pio;
+    close(rp->fd);
+}
+
+static const PIO_CHIP_T rp1_pio_chip = {
+    .name = "rp1",
+    .compatible = "raspberrypi,rp1-pio",
+    .instr_count = RP1_PIO_INSTRUCTION_COUNT,
+    .sm_count =  RP1_PIO_SM_COUNT,
+    .fifo_depth = 8,
+
+    .create_instance = rp1_create_instance,
+    .open_instance = rp1_open_instance,
+    .close_instance = rp1_close_instance,
+
+    .pio_sm_config_xfer = rp1_pio_sm_config_xfer,
+    .pio_sm_xfer_data = rp1_pio_sm_xfer_data,
+
+    .pio_can_add_program_at_offset = rp1_pio_can_add_program_at_offset,
+    .pio_add_program_at_offset = rp1_pio_add_program_at_offset,
+    .pio_remove_program = rp1_pio_remove_program,
+    .pio_clear_instruction_memory = rp1_pio_clear_instruction_memory,
+    .pio_encode_delay = rp1_pio_encode_delay,
+    .pio_encode_sideset = rp1_pio_encode_sideset,
+    .pio_encode_sideset_opt = rp1_pio_encode_sideset_opt,
+    .pio_encode_jmp = rp1_pio_encode_jmp,
+    .pio_encode_jmp_not_x = rp1_pio_encode_jmp_not_x,
+    .pio_encode_jmp_x_dec = rp1_pio_encode_jmp_x_dec,
+    .pio_encode_jmp_not_y = rp1_pio_encode_jmp_not_y,
+    .pio_encode_jmp_y_dec = rp1_pio_encode_jmp_y_dec,
+    .pio_encode_jmp_x_ne_y = rp1_pio_encode_jmp_x_ne_y,
+    .pio_encode_jmp_pin = rp1_pio_encode_jmp_pin,
+    .pio_encode_jmp_not_osre = rp1_pio_encode_jmp_not_osre,
+    .pio_encode_wait_gpio = rp1_pio_encode_wait_gpio,
+    .pio_encode_wait_pin = rp1_pio_encode_wait_pin,
+    .pio_encode_wait_irq = rp1_pio_encode_wait_irq,
+    .pio_encode_in = rp1_pio_encode_in,
+    .pio_encode_out = rp1_pio_encode_out,
+    .pio_encode_push = rp1_pio_encode_push,
+    .pio_encode_pull = rp1_pio_encode_pull,
+    .pio_encode_mov = rp1_pio_encode_mov,
+    .pio_encode_mov_not = rp1_pio_encode_mov_not,
+    .pio_encode_mov_reverse = rp1_pio_encode_mov_reverse,
+    .pio_encode_irq_set = rp1_pio_encode_irq_set,
+    .pio_encode_irq_wait = rp1_pio_encode_irq_wait,
+    .pio_encode_irq_clear = rp1_pio_encode_irq_clear,
+    .pio_encode_set = rp1_pio_encode_set,
+    .pio_encode_nop = rp1_pio_encode_nop,
+
+    .pio_sm_claim = rp1_pio_sm_claim,
+    .pio_sm_claim_mask = rp1_pio_sm_claim_mask,
+    .pio_sm_claim_unused = rp1_pio_sm_claim_unused,
+    .pio_sm_unclaim = rp1_pio_sm_unclaim,
+    .pio_sm_is_claimed = rp1_pio_sm_is_claimed,
+
+    .pio_sm_init = rp1_pio_sm_init,
+    .pio_sm_set_config = rp1_pio_sm_set_config,
+    .pio_sm_exec = rp1_pio_sm_exec,
+    .pio_sm_clear_fifos = rp1_pio_sm_clear_fifos,
+    .pio_sm_set_clkdiv_int_frac = &rp1_pio_sm_set_clkdiv_int_frac,
+    .pio_sm_set_clkdiv = rp1_pio_sm_set_clkdiv,
+    .pio_sm_set_pins = rp1_pio_sm_set_pins,
+    .pio_sm_set_pins_with_mask = rp1_pio_sm_set_pins_with_mask,
+    .pio_sm_set_pindirs_with_mask = rp1_pio_sm_set_pindirs_with_mask,
+    .pio_sm_set_consecutive_pindirs = rp1_pio_sm_set_consecutive_pindirs,
+    .pio_sm_set_enabled = rp1_pio_sm_set_enabled,
+    .pio_sm_set_enabled_mask = rp1_pio_sm_set_enabled_mask,
+    .pio_sm_restart = rp1_pio_sm_restart,
+    .pio_sm_restart_mask = rp1_pio_sm_restart_mask,
+    .pio_sm_clkdiv_restart = rp1_pio_sm_clkdiv_restart,
+    .pio_sm_clkdiv_restart_mask = rp1_pio_sm_clkdiv_restart_mask,
+    .pio_sm_enable_sync = rp1_pio_sm_enable_sync,
+    .pio_sm_put = rp1_pio_sm_put,
+    .pio_sm_get = rp1_pio_sm_get,
+    .pio_sm_set_dmactrl = rp1_pio_sm_set_dmactrl,
+    .pio_sm_is_rx_fifo_empty = rp1_pio_sm_is_rx_fifo_empty,
+    .pio_sm_is_rx_fifo_full = rp1_pio_sm_is_rx_fifo_full,
+    .pio_sm_get_rx_fifo_level = rp1_pio_sm_get_rx_fifo_level,
+    .pio_sm_is_tx_fifo_empty = rp1_pio_sm_is_tx_fifo_empty,
+    .pio_sm_is_tx_fifo_full = rp1_pio_sm_is_tx_fifo_full,
+    .pio_sm_get_tx_fifo_level = rp1_pio_sm_get_tx_fifo_level,
+    .pio_sm_drain_tx_fifo = rp1_pio_sm_drain_tx_fifo,
+
+    .pio_get_default_sm_config = rp1_pio_get_default_sm_config,
+    .smc_set_out_pins = rp1_smc_set_out_pins,
+    .smc_set_set_pins = rp1_smc_set_set_pins,
+    .smc_set_in_pins = rp1_smc_set_in_pins,
+    .smc_set_sideset_pins = rp1_smc_set_sideset_pins,
+    .smc_set_sideset = rp1_smc_set_sideset,
+    .smc_set_clkdiv_int_frac = rp1_smc_set_clkdiv_int_frac,
+    .smc_set_clkdiv = rp1_smc_set_clkdiv,
+    .smc_set_wrap = rp1_smc_set_wrap,
+    .smc_set_jmp_pin = rp1_smc_set_jmp_pin,
+    .smc_set_in_shift = rp1_smc_set_in_shift,
+    .smc_set_out_shift = rp1_smc_set_out_shift,
+    .smc_set_fifo_join = rp1_smc_set_fifo_join,
+    .smc_set_out_special = rp1_smc_set_out_special,
+    .smc_set_mov_status = rp1_smc_set_mov_status,
+
+    .clock_get_hz = rp1_clock_get_hz,
+
+    .pio_gpio_init = rp1_pio_gpio_init,
+    .gpio_init = rp1_gpio_init,
+    .gpio_set_function = rp1_gpio_set_function,
+    .gpio_set_pulls = rp1_gpio_set_pulls,
+    .gpio_set_outover = rp1_gpio_set_outover,
+    .gpio_set_inover = rp1_gpio_set_inover,
+    .gpio_set_oeover = rp1_gpio_set_oeover,
+    .gpio_set_input_enabled = rp1_gpio_set_input_enabled,
+    .gpio_set_drive_strength = rp1_gpio_set_drive_strength,
+};
+
+DECLARE_PIO_CHIP(rp1_pio_chip);

--- a/lib/rp1/rp1_pio_vendor/piolib/piolib.c
+++ b/lib/rp1/rp1_pio_vendor/piolib/piolib.c
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2023-24 Raspberry Pi Ltd.
+ * All rights reserved.
+ */
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "piolib.h"
+#include "piolib_priv.h"
+
+#define PIO_MAX_INSTANCES 4
+
+extern PIO_CHIP_T *__start_piochips;
+extern PIO_CHIP_T *__stop_piochips;
+
+static __thread PIO __pio;
+
+static PIO pio_instances[PIO_MAX_INSTANCES];
+static uint num_instances;
+static pthread_mutex_t pio_handle_lock;
+
+void pio_select(PIO pio)
+{
+    __pio = pio;
+}
+
+PIO pio_get_current(void)
+{
+    PIO pio = __pio;
+    check_pio_param(pio);
+    return pio;
+}
+
+int pio_get_index(PIO pio)
+{
+    int i;
+    for (i = 0; i < PIO_MAX_INSTANCES; i++)
+    {
+        if (pio == pio_instances[i])
+            return i;
+    }
+    return -1;
+}
+
+int pio_init(void)
+{
+    static bool initialised;
+    const PIO_CHIP_T * const *p;
+    uint i = 0;
+    int err;
+
+    if (initialised)
+        return 0;
+    num_instances = 0;
+    p = &__start_piochips;
+    while (p < &__stop_piochips && num_instances < PIO_MAX_INSTANCES)
+    {
+        PIO_CHIP_T *chip = *p;
+        PIO pio = chip->create_instance(chip, i);
+        if (pio && !PIO_IS_ERR(pio)) {
+            pio_instances[num_instances++] = pio;
+            i++;
+        } else {
+            p++;
+            i = 0;
+        }
+    }
+
+    err = pthread_mutex_init(&pio_handle_lock, NULL);
+    if (err)
+        return err;
+
+    initialised = true;
+    return 0;
+}
+
+PIO pio_open(uint idx)
+{
+    PIO pio = NULL;
+    int err;
+
+    err = pio_init();
+    if (err)
+        return PIO_ERR(err);
+
+    if (idx >= num_instances)
+        return PIO_ERR(-EINVAL);
+
+    pthread_mutex_lock(&pio_handle_lock);
+
+    pio = pio_instances[idx];
+    if (pio) {
+        if (pio->in_use)
+            err = -EBUSY;
+        else
+            pio->in_use = 1;
+    }
+
+    pthread_mutex_unlock(&pio_handle_lock);
+
+    if (err)
+        return PIO_ERR(err);
+
+    err = pio->chip->open_instance(pio);
+    if (err) {
+        pio->in_use = 0;
+        return PIO_ERR(err);
+    }
+
+    pio_select(pio);
+
+    return pio;
+}
+
+PIO pio_open_by_name(const char *name)
+{
+    int err = -ENOENT;
+    uint i;
+
+    err = pio_init();
+    if (err)
+        return PIO_ERR(err);
+
+    for (i = 0; i < num_instances; i++) {
+        PIO p = pio_instances[i];
+        if (!strcmp(name, p->chip->name))
+            break;
+    }
+
+    if (i == num_instances)
+        return PIO_ERR(-ENOENT);
+
+    return pio_open(i);
+}
+
+PIO pio_open_helper(uint idx)
+{
+    PIO pio = pio_instances[idx];
+    if (!pio || !pio->in_use) {
+        pio = pio_open(idx);
+        if (PIO_IS_ERR(pio)) {
+            printf("* Failed to open PIO device %d (error %d)\n",
+                   idx, PIO_ERR_VAL(pio));
+            exit(1);
+        }
+    }
+    return pio;
+}
+
+void pio_close(PIO pio)
+{
+    pio->chip->close_instance(pio);
+    pthread_mutex_lock(&pio_handle_lock);
+    pio->in_use = 0;
+    pthread_mutex_unlock(&pio_handle_lock);
+}
+
+void pio_panic(const char *msg)
+{
+    fprintf(stderr, "PANIC: %s\n", msg);
+    exit(1);
+}
+
+void sleep_us(uint64_t us) {
+    const struct timespec tv = {
+        .tv_sec = (us / 1000000),
+        .tv_nsec = 1000ull * (us % 1000000)
+    };
+    nanosleep(&tv, NULL);
+}

--- a/lib/rp1/rp1_rio_backend.cc
+++ b/lib/rp1/rp1_rio_backend.cc
@@ -1,0 +1,675 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+#include "rp1_rio_backend.h"
+
+#include <algorithm>
+#include <errno.h>
+#include <fcntl.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+#include "../framebuffer-internal.h"
+#include "../gpio.h"
+#include "../hardware-mapping.h"
+
+namespace rgb_matrix {
+namespace internal {
+namespace {
+
+// Pi 5 RIO path:
+// - this backend bypasses the RP1 PIO engine entirely and toggles the RP1 RIO
+//   GPIO fabric directly through MMIO.
+// - it shares the same framebuffer data and row-order decisions as the PIO
+//   path, but emits clock/latch/OE transitions from the CPU instead of from a
+//   state machine.
+// - because timing comes from busy-waits and MMIO stores, this path is opt-in
+//   and validates its GPIO mapping more aggressively than the generic backend.
+
+static const uint32_t kRioOutputPinCount = 28;
+static const uint32_t kGpioFunctionSysRio = 5;
+static const uint32_t kPadFastDrive = 0x15;
+static const uint32_t kPadSlowDrive = 0x01;
+static const off_t kPi5PeripheralBase = 0x1f000d0000ll;
+static const size_t kMapSizeBytes = 0x40000;
+static const uint32_t kGpioOffsetWords = 0x00000 / 4;
+static const uint32_t kRioOffsetWords = 0x10000 / 4;
+static const uint32_t kPadOffsetWords = 0x20000 / 4;
+static const double kBaseTargetPixelClockHz = 20000000.0;
+
+struct GpioCtrlRegs {
+  volatile uint32_t status;
+  volatile uint32_t ctrl;
+};
+
+struct RioRegs {
+  volatile uint32_t Out;
+  volatile uint32_t OE;
+  volatile uint32_t In;
+  volatile uint32_t InSync;
+};
+
+struct RioMapCandidate {
+  const char *path;
+  off_t offset;
+};
+
+struct Rp1RioState {
+  Rp1RioState()
+      : active(false),
+        panel_init_warned(false),
+        map_base(NULL),
+        gpio_regs(NULL),
+        pad_regs(NULL),
+        rio_out(NULL),
+        rio_set(NULL),
+        rio_clr(NULL),
+        row_address_type(0),
+        double_rows(0),
+        parallel(0),
+        gpio_slowdown(1),
+        output_enable_bit(0),
+        clock_bit(0),
+        latch_bit(0),
+        used_mask(0),
+        word_time_nanos(0.0) {
+  }
+
+  bool active;
+  bool panel_init_warned;
+  // map_base spans one contiguous RP1 aperture containing GPIO control,
+  // RIO data registers, and pad control registers.
+  volatile uint32_t *map_base;
+  GpioCtrlRegs *gpio_regs;
+  volatile uint32_t *pad_regs;
+  RioRegs *rio_out;
+  RioRegs *rio_set;
+  RioRegs *rio_clr;
+  int row_address_type;
+  int double_rows;
+  int parallel;
+  int gpio_slowdown;
+  uint32_t output_enable_bit;
+  uint32_t clock_bit;
+  uint32_t latch_bit;
+  uint32_t used_mask;
+  double word_time_nanos;
+  std::vector<int> bitplane_active_words;
+};
+
+Rp1RioState s_rio_state;
+bool s_rio_requested = false;
+
+static inline void ClockSetupDelay(int slowdown) {
+  const int loops = std::max(1, slowdown);
+  for (int i = 0; i < loops; ++i) {
+    asm volatile("nop; nop;" ::: "memory");
+  }
+}
+
+static inline void IoStoreBarrier() {
+#if defined(__arm__) || defined(__aarch64__)
+  asm volatile("dmb ishst" ::: "memory");
+#endif
+}
+
+static uint64_t MonotonicNanos() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ull + ts.tv_nsec;
+}
+
+static void BusyWaitNanos(uint64_t nanos) {
+  if (nanos == 0) return;
+  if (nanos <= 250) {
+    for (int i = 0; i < 8; ++i) {
+      asm volatile("nop" ::: "memory");
+    }
+    return;
+  }
+
+  const uint64_t start = MonotonicNanos();
+  while ((MonotonicNanos() - start) < nanos) {
+    asm volatile("" ::: "memory");
+  }
+}
+
+static void BusyWaitWords(int word_count) {
+  if (word_count <= 0) return;
+  BusyWaitNanos(static_cast<uint64_t>(word_count * s_rio_state.word_time_nanos));
+}
+
+static double TargetPixelClockHz() {
+  const int divisor = std::max(1, s_rio_state.gpio_slowdown);
+  return kBaseTargetPixelClockHz / divisor;
+}
+
+static bool ReadSmallTextFile(const char *path, std::string *result) {
+  const int fd = open(path, O_RDONLY);
+  if (fd < 0) return false;
+
+  char buffer[256];
+  const ssize_t len = read(fd, buffer, sizeof(buffer) - 1);
+  close(fd);
+  if (len <= 0) return false;
+
+  buffer[len] = '\0';
+  result->assign(buffer, buffer + len);
+  return true;
+}
+
+static bool FileExists(const char *path) {
+  struct stat st;
+  return stat(path, &st) == 0;
+}
+
+static bool MappingNameSupported(const char *hardware_mapping) {
+  if (hardware_mapping == NULL || *hardware_mapping == '\0') {
+    hardware_mapping = "regular";
+  }
+  // This list reflects the mappings we have validated against the RP1 0..27
+  // GPIO range and the one-bit-per-signal constraints below.
+  return strcmp(hardware_mapping, "regular") == 0
+      || strcmp(hardware_mapping, "classic") == 0
+      || strcmp(hardware_mapping, "adafruit-hat") == 0
+      || strcmp(hardware_mapping, "adafruit-hat-pwm") == 0;
+}
+
+static uint32_t CollectColorMask(const HardwareMapping &h, int parallel) {
+  uint32_t mask = 0;
+  mask |= h.p0_r1 | h.p0_g1 | h.p0_b1 | h.p0_r2 | h.p0_g2 | h.p0_b2;
+  if (parallel >= 2) {
+    mask |= h.p1_r1 | h.p1_g1 | h.p1_b1 | h.p1_r2 | h.p1_g2 | h.p1_b2;
+  }
+  if (parallel >= 3) {
+    mask |= h.p2_r1 | h.p2_g1 | h.p2_b1 | h.p2_r2 | h.p2_g2 | h.p2_b2;
+  }
+  return mask;
+}
+
+static uint32_t CollectAddressMask(const HardwareMapping &h, int double_rows,
+                                   int row_address_type) {
+  switch (row_address_type) {
+  case 0: {
+    uint32_t mask = h.a;
+    if (double_rows > 2) mask |= h.b;
+    if (double_rows > 4) mask |= h.c;
+    if (double_rows > 8) mask |= h.d;
+    if (double_rows > 16) mask |= h.e;
+    return mask;
+  }
+  case 2:
+    return h.a | h.b | h.c | h.d;
+  default:
+    return 0;
+  }
+}
+
+static uint32_t BuildUsedMask(const HardwareMapping &h, int double_rows,
+                              int parallel, int row_address_type) {
+  uint32_t mask = h.output_enable | h.clock | h.strobe;
+  mask |= CollectAddressMask(h, double_rows, row_address_type);
+  mask |= CollectColorMask(h, parallel);
+  return mask;
+}
+
+static bool FitsInRioWord(uint64_t bits) {
+  const uint64_t allowed_mask = (1ull << kRioOutputPinCount) - 1;
+  return (bits & ~allowed_mask) == 0;
+}
+
+static bool IsSingleBit(uint64_t bits) {
+  return bits != 0 && (bits & (bits - 1)) == 0;
+}
+
+static bool ValidatePinBits(const char *label, uint64_t bits) {
+  if (bits == 0) return true;
+  if (!FitsInRioWord(bits)) {
+    fprintf(stderr, "Pi 5-family RP1 RIO backend: %s uses GPIO bits outside 0..27.\n",
+            label);
+    return false;
+  }
+  if (!IsSingleBit(bits)) {
+    fprintf(stderr,
+            "Pi 5-family RP1 RIO backend: %s must map to exactly one GPIO pin.\n",
+            label);
+    return false;
+  }
+  return true;
+}
+
+static bool ValidateMappingSignals(const HardwareMapping &h, int double_rows,
+                                   int parallel, int row_address_type) {
+  // RIO writes exact GPIO bitmasks directly. Unlike the legacy bcm GPIO path,
+  // there is no notion of "either of these pins is acceptable", so each signal
+  // used by this backend must resolve to one concrete RP1 GPIO.
+  if (!ValidatePinBits("clock", h.clock)
+      || !ValidatePinBits("strobe", h.strobe)
+      || !ValidatePinBits("output_enable", h.output_enable)
+      || !ValidatePinBits("p0_r1", h.p0_r1)
+      || !ValidatePinBits("p0_g1", h.p0_g1)
+      || !ValidatePinBits("p0_b1", h.p0_b1)
+      || !ValidatePinBits("p0_r2", h.p0_r2)
+      || !ValidatePinBits("p0_g2", h.p0_g2)
+      || !ValidatePinBits("p0_b2", h.p0_b2)) {
+    return false;
+  }
+  if (parallel >= 2
+      && (!ValidatePinBits("p1_r1", h.p1_r1)
+          || !ValidatePinBits("p1_g1", h.p1_g1)
+          || !ValidatePinBits("p1_b1", h.p1_b1)
+          || !ValidatePinBits("p1_r2", h.p1_r2)
+          || !ValidatePinBits("p1_g2", h.p1_g2)
+          || !ValidatePinBits("p1_b2", h.p1_b2))) {
+    return false;
+  }
+  if (parallel >= 3
+      && (!ValidatePinBits("p2_r1", h.p2_r1)
+          || !ValidatePinBits("p2_g1", h.p2_g1)
+          || !ValidatePinBits("p2_b1", h.p2_b1)
+          || !ValidatePinBits("p2_r2", h.p2_r2)
+          || !ValidatePinBits("p2_g2", h.p2_g2)
+          || !ValidatePinBits("p2_b2", h.p2_b2))) {
+    return false;
+  }
+
+  if (row_address_type == 0) {
+    if (!ValidatePinBits("address A", h.a)) return false;
+    if (double_rows > 2 && !ValidatePinBits("address B", h.b)) return false;
+    if (double_rows > 4 && !ValidatePinBits("address C", h.c)) return false;
+    if (double_rows > 8 && !ValidatePinBits("address D", h.d)) return false;
+    if (double_rows > 16 && !ValidatePinBits("address E", h.e)) return false;
+  } else if (row_address_type == 2) {
+    if (!ValidatePinBits("address A", h.a)
+        || !ValidatePinBits("address B", h.b)
+        || !ValidatePinBits("address C", h.c)
+        || !ValidatePinBits("address D", h.d)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static uint32_t CalcRowAddressBits(const HardwareMapping &h,
+                                   int row_address_type, int row) {
+  switch (row_address_type) {
+  case 0: {
+    uint32_t bits = 0;
+    if (row & 0x01) bits |= h.a;
+    if (row & 0x02) bits |= h.b;
+    if (row & 0x04) bits |= h.c;
+    if (row & 0x08) bits |= h.d;
+    if (row & 0x10) bits |= h.e;
+    return bits;
+  }
+  case 2:
+    switch (row & 0x03) {
+    case 0: return h.b | h.c | h.d;
+    case 1: return h.a | h.c | h.d;
+    case 2: return h.a | h.b | h.d;
+    default: return h.a | h.b | h.c;
+    }
+  default:
+    return 0;
+  }
+}
+
+static int DisplayRowFromLoop(int row_loop, int double_rows, int scan_mode) {
+  if (scan_mode != 1) return row_loop;
+
+  const int half_double = double_rows / 2;
+  return (row_loop < half_double)
+             ? (row_loop << 1)
+             : (((row_loop - half_double) << 1) + 1);
+}
+
+static void PrepareBitplaneTimings(int pwm_lsb_nanoseconds, int dither_bits,
+                                   std::vector<int> *timings_out) {
+  timings_out->clear();
+  int timing_ns = pwm_lsb_nanoseconds;
+  for (int b = 0; b < Framebuffer::kBitPlanes; ++b) {
+    timings_out->push_back(timing_ns);
+    if (b >= dither_bits) timing_ns *= 2;
+  }
+}
+
+static void PrepareBitplaneActiveWords(int pwm_lsb_nanoseconds, int dither_bits,
+                                       std::vector<int> *active_words_out) {
+  std::vector<int> timings_ns;
+  PrepareBitplaneTimings(pwm_lsb_nanoseconds, dither_bits, &timings_ns);
+
+  const double word_ns = 1e9 / TargetPixelClockHz();
+  active_words_out->clear();
+  active_words_out->reserve(timings_ns.size());
+  for (size_t i = 0; i < timings_ns.size(); ++i) {
+    const int word_count = std::max(
+        1, static_cast<int>(ceil(static_cast<double>(timings_ns[i]) / word_ns)));
+    active_words_out->push_back(word_count);
+  }
+  s_rio_state.word_time_nanos = word_ns;
+}
+
+static volatile uint32_t *TryMmapGpio(const RioMapCandidate &candidate) {
+  const int fd = open(candidate.path, O_RDWR | O_SYNC);
+  if (fd < 0) return NULL;
+
+  void *map = mmap(NULL, kMapSizeBytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd,
+                   candidate.offset);
+  close(fd);
+  if (map == MAP_FAILED) return NULL;
+  return static_cast<volatile uint32_t *>(map);
+}
+
+static volatile uint32_t *MapGpioOrDie() {
+  static const RioMapCandidate kCandidates[] = {
+      // Pi 5 user-space notes and the bitslip reference both use gpiomem0 for
+      // the RP1 GPIO/RIO/PADS aperture. gpiomem4 appears suitable for generic
+      // line access, but not for this contiguous MMIO window.
+      {"/dev/gpiomem0", 0},
+      {"/dev/gpiomem0", kPi5PeripheralBase},
+      {"/dev/mem", kPi5PeripheralBase},
+  };
+
+  for (size_t i = 0; i < sizeof(kCandidates) / sizeof(kCandidates[0]); ++i) {
+    volatile uint32_t *map = TryMmapGpio(kCandidates[i]);
+    if (map != NULL) return map;
+  }
+
+  fprintf(stderr,
+          "Pi 5-family RP1 RIO backend: could not map RP1 GPIO registers via "
+          "/dev/gpiomem0 or /dev/mem.\n");
+  abort();
+}
+
+static void ConfigureUsedPins() {
+  Rp1RioState &state = s_rio_state;
+
+  for (uint32_t pin = 0; pin < kRioOutputPinCount; ++pin) {
+    const uint32_t bit = (1u << pin);
+    if ((state.used_mask & bit) == 0) continue;
+
+    state.gpio_regs[pin].ctrl = kGpioFunctionSysRio;
+    // Clock and latch transitions are the sharpest edges in the interface, so
+    // keep them on a gentler pad drive than the bulk color/address outputs.
+    state.pad_regs[pin] =
+        (bit == state.clock_bit || bit == state.latch_bit) ? kPadSlowDrive
+                                                           : kPadFastDrive;
+    state.rio_set->OE = bit;
+  }
+
+  IoStoreBarrier();
+  state.rio_out->Out = state.output_enable_bit;
+}
+
+static void WriteClockedWord(uint32_t pins) {
+  Rp1RioState &state = s_rio_state;
+  // One framebuffer word corresponds to one panel clock period: present the
+  // GPIO data first, then raise the clock bit, then return to idle-low clock.
+  state.rio_out->Out = pins;
+  ClockSetupDelay(state.gpio_slowdown);
+  state.rio_out->Out = pins | state.clock_bit;
+  ClockSetupDelay(state.gpio_slowdown);
+}
+
+static void SendRawWordsBlanked(const std::vector<uint32_t> &pins) {
+  if (pins.empty()) return;
+
+  for (size_t i = 0; i < pins.size(); ++i) {
+    WriteClockedWord(pins[i] | s_rio_state.output_enable_bit);
+  }
+  s_rio_state.rio_out->Out = s_rio_state.output_enable_bit;
+}
+
+static void SendFM6126Init(const HardwareMapping &h, int columns) {
+  const uint32_t bits_on = CollectColorMask(h, s_rio_state.parallel)
+                           | static_cast<uint32_t>(h.a);
+  const uint32_t bits_off = h.a;
+  static const char *init_b12 = "0111111111111111";
+  static const char *init_b13 = "0000000001000000";
+
+  std::vector<uint32_t> pins;
+  pins.reserve(columns * 2);
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b12[i % 16] == '0') ? bits_off : bits_on;
+    if (i > columns - 12) value |= h.strobe;
+    pins.push_back(value);
+  }
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b13[i % 16] == '0') ? bits_off : bits_on;
+    if (i > columns - 13) value |= h.strobe;
+    pins.push_back(value);
+  }
+  SendRawWordsBlanked(pins);
+}
+
+static void SendFM6127Init(const HardwareMapping &h, int columns) {
+  const uint32_t bits_r_on = h.p0_r1 | h.p0_r2;
+  const uint32_t bits_g_on = h.p0_g1 | h.p0_g2;
+  const uint32_t bits_b_on = h.p0_b1 | h.p0_b2;
+  const uint32_t bits_on = bits_r_on | bits_g_on | bits_b_on;
+  static const char *init_b12 = "1111111111001110";
+  static const char *init_b13 = "1110000001100010";
+  static const char *init_b11 = "0101111100000000";
+
+  std::vector<uint32_t> pins;
+  pins.reserve(columns * 3);
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b12[i % 16] == '0') ? 0 : bits_on;
+    if (i > columns - 12) value |= h.strobe;
+    pins.push_back(value);
+  }
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b13[i % 16] == '0') ? 0 : bits_on;
+    if (i > columns - 13) value |= h.strobe;
+    pins.push_back(value);
+  }
+  for (int i = 0; i < columns; ++i) {
+    uint32_t value = (init_b11[i % 16] == '0') ? 0 : bits_on;
+    if (i > columns - 11) value |= h.strobe;
+    pins.push_back(value);
+  }
+  SendRawWordsBlanked(pins);
+}
+
+}  // namespace
+
+bool Rp1RioPlatformDetected() {
+  if (!GPIO::IsPi5Family()) {
+    std::string model;
+    if (!ReadSmallTextFile("/proc/device-tree/model", &model)) {
+      return false;
+    }
+    if (model.find("Raspberry Pi 5") == std::string::npos
+        && model.find("Compute Module 5") == std::string::npos) {
+      return false;
+    }
+  }
+  return FileExists("/dev/gpiomem0") || FileExists("/dev/mem");
+}
+
+void Rp1RioSetEnabled(bool enabled) { s_rio_requested = enabled; }
+
+bool Rp1RioBackendRequested() { return s_rio_requested; }
+
+bool Rp1RioShouldActivate(const char *hardware_mapping, int row_address_type,
+                          int parallel) {
+  if (!s_rio_requested) return false;
+  if (!Rp1RioPlatformDetected()) return false;
+  if (!MappingNameSupported(hardware_mapping)) return false;
+  if (!(row_address_type == 0 || row_address_type == 2)) return false;
+  return parallel >= 1 && parallel <= 3;
+}
+
+void Rp1RioSetGpioSlowdown(int slowdown) {
+  s_rio_state.gpio_slowdown = slowdown <= 1 ? 1 : slowdown;
+}
+
+bool Rp1RioIsActive() { return s_rio_state.active; }
+
+void Rp1RioInitOrDie(const HardwareMapping &mapping, int double_rows,
+                     int parallel, int pwm_lsb_nanoseconds, int dither_bits,
+                     int row_address_type) {
+  Rp1RioState &state = s_rio_state;
+  if (state.active) return;
+
+  state.row_address_type = row_address_type;
+  state.double_rows = double_rows;
+  state.parallel = parallel;
+  state.output_enable_bit = mapping.output_enable;
+  state.clock_bit = mapping.clock;
+  state.latch_bit = mapping.strobe;
+  state.used_mask = BuildUsedMask(mapping, double_rows, parallel,
+                                  row_address_type);
+
+  if (!FitsInRioWord(state.used_mask)) {
+    fprintf(stderr,
+            "Pi 5-family RP1 RIO backend: the selected GPIO mapping uses pins "
+            "outside the RP1 0..27 GPIO range.\n");
+    abort();
+  }
+  if (!ValidateMappingSignals(mapping, double_rows, parallel, row_address_type)) {
+    abort();
+  }
+
+  PrepareBitplaneActiveWords(pwm_lsb_nanoseconds, dither_bits,
+                             &state.bitplane_active_words);
+
+  state.map_base = MapGpioOrDie();
+  state.gpio_regs =
+      reinterpret_cast<GpioCtrlRegs *>(const_cast<uint32_t *>(
+          state.map_base + kGpioOffsetWords));
+  state.pad_regs = const_cast<uint32_t *>(state.map_base + kPadOffsetWords + 1);
+  state.rio_out = reinterpret_cast<RioRegs *>(
+      const_cast<uint32_t *>(state.map_base + kRioOffsetWords));
+  state.rio_set = reinterpret_cast<RioRegs *>(
+      const_cast<uint32_t *>(state.map_base + kRioOffsetWords + (0x2000 / 4)));
+  state.rio_clr = reinterpret_cast<RioRegs *>(
+      const_cast<uint32_t *>(state.map_base + kRioOffsetWords + (0x3000 / 4)));
+
+  ConfigureUsedPins();
+  state.active = true;
+}
+
+void Rp1RioInitializePanels(const HardwareMapping &mapping,
+                            const char *panel_type, int columns) {
+  if (!s_rio_state.active || panel_type == NULL || *panel_type == '\0') return;
+
+  if (strncasecmp(panel_type, "fm6126", 6) == 0) {
+    SendFM6126Init(mapping, columns);
+  } else if (strncasecmp(panel_type, "fm6127", 6) == 0) {
+    SendFM6127Init(mapping, columns);
+  } else if (!s_rio_state.panel_init_warned) {
+    fprintf(stderr,
+            "Pi 5-family RP1 RIO backend: panel init '%s' is not implemented; "
+            "continuing without panel init.\n",
+            panel_type);
+    s_rio_state.panel_init_warned = true;
+  }
+}
+
+void Rp1RioDumpFramebuffer(Framebuffer *framebuffer, int pwm_low_bit) {
+  if (!s_rio_state.active || framebuffer == NULL) return;
+
+  Rp1RioState &state = s_rio_state;
+  // As in the PIO path, the framebuffer already holds the per-column color
+  // bits. The RIO dump loop layers row addresses and panel control timing on
+  // top of those words and uses busy-waits to hold the PWM bitplane on-time.
+  const HardwareMapping &h = framebuffer->hardware_mapping();
+  const int start_bit =
+      std::max(pwm_low_bit, Framebuffer::kBitPlanes - framebuffer->pwmbits());
+  const int double_rows = framebuffer->double_rows();
+  const int columns = framebuffer->columns();
+  const int scan_mode = framebuffer->scan_mode();
+
+  uint32_t previous_addr = CalcRowAddressBits(
+      h, state.row_address_type,
+      DisplayRowFromLoop(double_rows - 1, double_rows, scan_mode));
+  int previous_active_words = 0;
+
+  for (int row_loop = 0; row_loop < double_rows; ++row_loop) {
+    const int display_row =
+        DisplayRowFromLoop(row_loop, double_rows, scan_mode);
+    const uint32_t current_addr =
+        CalcRowAddressBits(h, state.row_address_type, display_row);
+
+    for (int bit = start_bit; bit < Framebuffer::kBitPlanes; ++bit) {
+      const gpio_bits_t *row_data = framebuffer->RowDataAt(display_row, bit);
+
+      int remaining_overlap_words = previous_active_words;
+      for (int col = 0; col < columns; ++col) {
+        uint32_t pins = static_cast<uint32_t>(row_data[col]) | previous_addr;
+        if (remaining_overlap_words <= 0) {
+          pins |= state.output_enable_bit;
+        }
+        WriteClockedWord(pins);
+        if (remaining_overlap_words > 0) --remaining_overlap_words;
+      }
+
+      if (remaining_overlap_words > 0) {
+        state.rio_out->Out = previous_addr;
+        BusyWaitWords(remaining_overlap_words);
+      }
+
+      state.rio_out->Out = current_addr | state.output_enable_bit;
+      ClockSetupDelay(state.gpio_slowdown);
+      state.rio_out->Out =
+          current_addr | state.output_enable_bit | state.latch_bit;
+      ClockSetupDelay(state.gpio_slowdown);
+      state.rio_out->Out = current_addr | state.output_enable_bit;
+      ClockSetupDelay(state.gpio_slowdown);
+
+      previous_addr = current_addr;
+      previous_active_words = state.bitplane_active_words[bit];
+    }
+  }
+
+  if (previous_active_words > 0) {
+    state.rio_out->Out = previous_addr;
+    BusyWaitWords(previous_active_words);
+  }
+  state.rio_out->Out = previous_addr | state.output_enable_bit;
+}
+
+void Rp1RioDeinit() {
+  Rp1RioState &state = s_rio_state;
+  if (!state.active) return;
+
+  state.rio_out->Out = state.output_enable_bit;
+  ClockSetupDelay(state.gpio_slowdown);
+  state.rio_clr->OE = state.used_mask;
+  IoStoreBarrier();
+
+  if (state.map_base != NULL) {
+    munmap(const_cast<uint32_t *>(state.map_base), kMapSizeBytes);
+  }
+
+  state.active = false;
+  state.panel_init_warned = false;
+  state.map_base = NULL;
+  state.gpio_regs = NULL;
+  state.pad_regs = NULL;
+  state.rio_out = NULL;
+  state.rio_set = NULL;
+  state.rio_clr = NULL;
+  state.row_address_type = 0;
+  state.double_rows = 0;
+  state.parallel = 0;
+  state.gpio_slowdown = 1;
+  state.output_enable_bit = 0;
+  state.clock_bit = 0;
+  state.latch_bit = 0;
+  state.used_mask = 0;
+  state.word_time_nanos = 0.0;
+  state.bitplane_active_words.clear();
+}
+
+}  // namespace internal
+}  // namespace rgb_matrix

--- a/lib/rp1/rp1_rio_backend.h
+++ b/lib/rp1/rp1_rio_backend.h
@@ -1,0 +1,35 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+#ifndef RPI_RP1_RIO_BACKEND_H
+#define RPI_RP1_RIO_BACKEND_H
+
+struct HardwareMapping;
+
+namespace rgb_matrix {
+namespace internal {
+class Framebuffer;
+
+// Internal Pi 5-family RP1 RIO renderer.
+//
+// This backend is explicitly opt-in, because it drives the RP1 GPIO fabric
+// directly through MMIO instead of using the default PIO path. The lifecycle is
+// the same as the PIO backend, with SetEnabled()/BackendRequested() carrying
+// the user-facing runtime choice before activation.
+bool Rp1RioPlatformDetected();
+void Rp1RioSetEnabled(bool enabled);
+bool Rp1RioBackendRequested();
+bool Rp1RioShouldActivate(const char *hardware_mapping, int row_address_type,
+                          int parallel);
+void Rp1RioSetGpioSlowdown(int slowdown);
+bool Rp1RioIsActive();
+void Rp1RioInitOrDie(const HardwareMapping &mapping, int double_rows,
+                     int parallel, int pwm_lsb_nanoseconds, int dither_bits,
+                     int row_address_type);
+void Rp1RioInitializePanels(const HardwareMapping &mapping,
+                            const char *panel_type, int columns);
+void Rp1RioDumpFramebuffer(Framebuffer *framebuffer, int pwm_low_bit);
+void Rp1RioDeinit();
+
+}  // namespace internal
+}  // namespace rgb_matrix
+
+#endif  // RPI_RP1_RIO_BACKEND_H


### PR DESCRIPTION
#### Raspberry Pi 5 support has now been added.
There are two modes to run this on the Pi 5 

**--led-rp1-rio=0** - Uses the Pi 5 coprocessor RP1 to perform the work (default) - Very minimal CPU usage

**--led-rp1-rio=1** - Uses Registered IO block of RP1 to communicate with the GPIO - Higher CPU usage but much faster performance.\
**NOTE: --led-slowdown-gpio** can have the opposite effect in this mode, so going from 2 to 3 may increase performance slightly with --led-rp1-rio=1.

Most of the code is under /lib/rp1
