### PR TITLE
Check ARM architecture for memory barrier compatibility

### DIFF
--- a/lib/rp1/rp1_rio_backend.cc
+++ b/lib/rp1/rp1_rio_backend.cc
@@ -116,7 +116,7 @@ static inline void ClockSetupDelay(int slowdown) {
 }
 
 static inline void IoStoreBarrier() {
-#if defined(__arm__) || defined(__aarch64__)
+#if defined(__ARM_ARCH) && __ARM_ARCH >= 7
   asm volatile("dmb ishst" ::: "memory");
 #endif
 }


### PR DESCRIPTION
:warning: I have _not_ tested this extensively, this comes from a compilation error one of our users experienced on a Pi4

Building from source via:
`pip install --force-reinstall --no-cache-dir git+https://github.com/hzeller/rpi-rgb-led-matrix@8907235`

Some processors do not support `dmb` instructions, which requires ARMv7+. There's also a secondary issue that Pi5s are expected to be 64bit compatible whereas other Pis are not. This PR fixes the former problem and allows Pi4s to compile the library by implementing the appropriate guard for `__ARM_ARCH >= 7` which is only implied by the current guard

Relevant failure (full backtrace is below)

```
  [19/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o
  FAILED: [code=1] CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o
  /usr/bin/arm-linux-gnueabihf-g++ -Drgbmatrix_EXPORTS -I/tmp/pip-req-build-zo42t619/include -I/tmp/pip-req-build-zo42t619/lib/rp1/rp1_pio_vendor/piolib/include -I/tmp/pip-req-build-zo42t619/lib/rp1/rp1_pio_vendor/include -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o -MF CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o.d -o CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o -c /tmp/pip-req-build-zo42t619/lib/rp1/rp1_rio_backend.cc
  /tmp/pip-req-build-zo42t619/lib/rp1/rp1_rio_backend.cc:41:41: warning: overflow in conversion from 'long long int' to 'off_t' {aka 'long int'} changes value from '133144838144' to '851968' [-Woverflow]
     41 | static const off_t kPi5PeripheralBase = 0x1f000d0000ll;
        |                                         ^~~~~~~~~~~~~~
  /tmp/ccyOHpNh.s: Assembler messages:
  /tmp/ccyOHpNh.s:1115: Error: selected processor does not support `dmb ishst' in ARM mode
  /tmp/ccyOHpNh.s:1678: Error: selected processor does not support `dmb ishst' in ARM mode
```

---

CPU info

```
$ cat /proc/cpuinfo
processor       : 0
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 1
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 2
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 3
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

Revision        : c03111
Serial          : 1000000006783327
Model           : Raspberry Pi 4 Model B Rev 1.1
```

GCC compiles with ARMv6 compatibility:

```
$ gcc -dM -E - </dev/null | grep ARM_ARCH
#define ARM_ARCH_ISA_ARM 1
#define ARM_ARCH_6 1
#define ARM_ARCH_ISA_THUMB 1
#define ARM_ARCH 6
```

---

Full backtrace below:

```
------------------------------------
  Rebuilding RGB matrix binding...
------------------------------------

Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting git+https://github.com/hzeller/rpi-rgb-led-matrix@8907235 (from -r requirements.rpi.txt (line 1))
  Cloning https://github.com/hzeller/rpi-rgb-led-matrix (to revision 8907235) to /tmp/pip-req-build-zo42t619
  Running command git clone --filter=blob:none --quiet https://github.com/hzeller/rpi-rgb-led-matrix /tmp/pip-req-build-zo42t619
  WARNING: Did not find branch or tag '8907235', assuming revision or ref.
  Running command git checkout -q 8907235
  Resolved https://github.com/hzeller/rpi-rgb-led-matrix to commit 8907235
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: rgbmatrix
  Building wheel for rgbmatrix (pyproject.toml): started
  Building wheel for rgbmatrix (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error

  Building wheel for rgbmatrix (pyproject.toml) did not run successfully.
  exit code: 1

  [60 lines of output]
  *** scikit-build-core 0.12.2 using CMake 4.3.2 (wheel)
  *** Configuring CMake...
  loading initial cache file /tmp/tmpq23spqy0/build/CMakeInit.txt
  -- The C compiler identification is GNU 12.2.0
  -- The CXX compiler identification is GNU 12.2.0
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /usr/bin/arm-linux-gnueabihf-gcc - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /usr/bin/arm-linux-gnueabihf-g++ - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Found Python: /home/pi/mlb-led-scoreboard/venv/bin/python3 (found suitable version "3.11.2", minimum required is "3.11") found components: Interpreter Development.Module Development.Embed
  -- RGBMATRIX_HEADERS="/tmp/pip-req-build-zo42t619/include/canvas.h;/tmp/pip-req-build-zo42t619/include/content-streamer.h;/tmp/pip-req-build-zo42t619/include/graphics.h;/tmp/pip-req-build-zo42t619/include/led-matrix.h;/tmp/pip-req-build-zo42t619/include/led-matrix-c.h;/tmp/pip-req-build-zo42t619/include/pixel-mapper.h;/tmp/pip-req-build-zo42t619/include/thread.h;/tmp/pip-req-build-zo42t619/include/threaded-canvas-manipulator.h"
  -- RGBMATRIX_SOURCES="/tmp/pip-req-build-zo42t619/lib/bdf-font.cc;/tmp/pip-req-build-zo42t619/lib/content-streamer.cc;/tmp/pip-req-build-zo42t619/lib/framebuffer.cc;/tmp/pip-req-build-zo42t619/lib/gpio.cc;/tmp/pip-req-build-zo42t619/lib/graphics.cc;/tmp/pip-req-build-zo42t619/lib/hardware-mapping.c;/tmp/pip-req-build-zo42t619/lib/led-matrix.cc;/tmp/pip-req-build-zo42t619/lib/led-matrix-c.cc;/tmp/pip-req-build-zo42t619/lib/multiplex-mappers.cc;/tmp/pip-req-build-zo42t619/lib/options-initialize.cc;/tmp/pip-req-build-zo42t619/lib/pixel-mapper.cc;/tmp/pip-req-build-zo42t619/lib/rp1/rp1_pio_backend.cc;/tmp/pip-req-build-zo42t619/lib/rp1/rp1_pio_support.c;/tmp/pip-req-build-zo42t619/lib/rp1/rp1_rio_backend.cc;/tmp/pip-req-build-zo42t619/lib/thread.cc"
  -- Configuring done (1.5s)
  -- Generating done (0.0s)
  -- Build files have been written to: /tmp/tmpq23spqy0/build
  *** Building project with Ninja...
  [1/53] Making /tmp/pip-req-build-zo42t619/bindings/python/rgbmatrix/core.cpp from /tmp/pip-req-build-zo42t619/bindings/python/rgbmatrix/core.pyx
  warning: /tmp/pip-req-build-zo42t619/bindings/python/rgbmatrix/core.pyx:107:39: Not all members given for struct 'Options'
  warning: /tmp/pip-req-build-zo42t619/bindings/python/rgbmatrix/core.pyx:107:39: Not all members given for struct 'Options'
  warning: /tmp/pip-req-build-zo42t619/bindings/python/rgbmatrix/core.pyx:108:54: Not all members given for struct 'RuntimeOptions'
  warning: /tmp/pip-req-build-zo42t619/bindings/python/rgbmatrix/core.pyx:108:54: Not all members given for struct 'RuntimeOptions'
  [2/53] Making /tmp/pip-req-build-zo42t619/bindings/python/rgbmatrix/graphics.cpp from /tmp/pip-req-build-zo42t619/bindings/python/rgbmatrix/graphics.pyx
  [3/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/bdf-font.cc.o
  [4/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/content-streamer.cc.o
  [5/53] Building C object CMakeFiles/rgbmatrix.dir/lib/hardware-mapping.c.o
  [6/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/framebuffer.cc.o
  [7/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/gpio.cc.o
  [8/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/graphics.cc.o
  [9/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/led-matrix-c.cc.o
  [10/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/multiplex-mappers.cc.o
  [11/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/led-matrix.cc.o
  [12/53] Building C object CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_pio_support.c.o
  [13/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/options-initialize.cc.o
  [14/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/pixel-mapper.cc.o
  [15/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_pio_backend.cc.o
  [16/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/thread.cc.o
  [17/53] Building C object CMakeFiles/core.dir/bindings/python/rgbmatrix/shims/pillow.c.o
  [18/53] Building CXX object CMakeFiles/core.dir/lib/content-streamer.cc.o
  [19/53] Building CXX object CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o
  FAILED: [code=1] CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o
  /usr/bin/arm-linux-gnueabihf-g++ -Drgbmatrix_EXPORTS -I/tmp/pip-req-build-zo42t619/include -I/tmp/pip-req-build-zo42t619/lib/rp1/rp1_pio_vendor/piolib/include -I/tmp/pip-req-build-zo42t619/lib/rp1/rp1_pio_vendor/include -O3 -DNDEBUG -std=gnu++17 -fPIC -MD -MT CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o -MF CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o.d -o CMakeFiles/rgbmatrix.dir/lib/rp1/rp1_rio_backend.cc.o -c /tmp/pip-req-build-zo42t619/lib/rp1/rp1_rio_backend.cc
  /tmp/pip-req-build-zo42t619/lib/rp1/rp1_rio_backend.cc:41:41: warning: overflow in conversion from 'long long int' to 'off_t' {aka 'long int'} changes value from '133144838144' to '851968' [-Woverflow]
     41 | static const off_t kPi5PeripheralBase = 0x1f000d0000ll;
        |                                         ^~~~~~~~~~~~~~
  /tmp/ccyOHpNh.s: Assembler messages:
  /tmp/ccyOHpNh.s:1115: Error: selected processor does not support `dmb ishst' in ARM mode
  /tmp/ccyOHpNh.s:1678: Error: selected processor does not support `dmb ishst' in ARM mode
  [20/53] Building CXX object CMakeFiles/core.dir/lib/bdf-font.cc.o
  [21/53] Building CXX object CMakeFiles/core.dir/lib/framebuffer.cc.o
  [22/53] Building CXX object CMakeFiles/core.dir/lib/gpio.cc.o
  [23/53] Building CXX object CMakeFiles/core.dir/bindings/python/rgbmatrix/core.cpp.o
  ninja: build stopped: subcommand failed.

  *** CMake build failed
  [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for rgbmatrix
Failed to build rgbmatrix
ERROR: Could not build wheels for rgbmatrix, which is required to install pyproject.toml-based projects
```
