### PR TITLE
[Bindings/C#] Upgrade TargetFramework(s) to .NET 10.0

### DIFF
--- a/bindings/c#/README.md
+++ b/bindings/c#/README.md
@@ -8,7 +8,7 @@ To build the C# wrapper for the RGB Matrix C library you need to first have __.N
 
 ### Install .NET SDK
 
-`sudo apt install dotnet8` should work in most cases.  
+`sudo apt install dotnet10` should work in most cases.
 For some old distributions, read [docs](https://learn.microsoft.com/dotnet/core/install/linux)
 Then, in the `bindings/c#` directory type: `dotnet build`
 To run the example applications in the c#\examples\EXAMPLE folder: `sudo dotnet run`

--- a/bindings/c#/RPiRgbLEDMatrix.csproj
+++ b/bindings/c#/RPiRgbLEDMatrix.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/bindings/c#/examples/BoxesBoxesBoxes/BoxesBoxesBoxes.csproj
+++ b/bindings/c#/examples/BoxesBoxesBoxes/BoxesBoxesBoxes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/FontExample/FontExample.csproj
+++ b/bindings/c#/examples/FontExample/FontExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/MatrixRain/MatrixRain.csproj
+++ b/bindings/c#/examples/MatrixRain/MatrixRain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/MinimalExample/MinimalExample.csproj
+++ b/bindings/c#/examples/MinimalExample/MinimalExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/PlayGIF/PlayGIF.csproj
+++ b/bindings/c#/examples/PlayGIF/PlayGIF.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/bindings/c#/examples/PulsingBrightness/PulsingBrightness.csproj
+++ b/bindings/c#/examples/PulsingBrightness/PulsingBrightness.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/Rotating3DCube/Rotating3DCube.csproj
+++ b/bindings/c#/examples/Rotating3DCube/Rotating3DCube.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/bindings/c#/examples/StreamPlayer/StreamPlayer.csproj
+++ b/bindings/c#/examples/StreamPlayer/StreamPlayer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This PR updates the `TargetFramework(s)` in each project file from `net8.0` to `net10.0`.

.NET 10.0 LTS packages are already available on major platforms where .NET can be installed, such as Ubuntu (`dotnet10`).
In addition, .NET 8.0 LTS will reach EOL this November.
For these reasons, updating to .NET 10.0 at this point is preferable.

This PR updates the target .NET versions as follows:

### `bindings/c#/RPiRgbLEDMatrix.csproj`
`TargetFrameworks` is updated by adding `net10.0` alongside the existing `net8.0`.

If this project file is referenced directly for builds, removing `net8.0` would cause build failures. Therefore, this project should retain `net8.0` for the time being and remove it once it reaches EOL.

### other *.csproj under `bindings/c#/examples`
`TargetFramework` is changed from `net8.0` to `net10.0`.

These project files are unlikely to be referenced by other projects, so simply switching to `net10.0` should have minimal impact.

For reference, the update from .NET 6.0 to .NET 8.0 was made in #1832.