### PR TITLE
Add Frame Sequence support

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -110,6 +110,21 @@
             ]
         },
         {
+            "label": "Remote build C++ API (lib only)",
+            "type": "shell",
+            "command": "ssh",
+            "args": [
+                "${env:RGBLEDMATRIX_REMOTE_MACHINE}",
+                "cd ${env:RGBLEDMATRIX_REMOTE_DIR}&&",
+                "make -C lib"
+            ],
+            "problemMatcher": [],
+            "group": "build",
+            "dependsOn": [
+                "Sync C++"
+            ]
+        },
+        {
             "label": "Deploy C++",
             "type": "shell",
             "command": "ssh",

--- a/bindings/c#/Bindings.cs
+++ b/bindings/c#/Bindings.cs
@@ -108,4 +108,64 @@ internal static class Bindings
 
     [DllImport(Lib, EntryPoint = "content_stream_reader_rewind")]
     public static extern void content_stream_reader_rewind(IntPtr reader);
+
+    /* Frame-sequence bindings */
+    [DllImport(Lib, EntryPoint = "frame_sequence_create")]
+    public static extern IntPtr frame_sequence_create(int width, int height);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_destroy")]
+    public static extern void frame_sequence_destroy(IntPtr sequence);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_width")]
+    public static extern int frame_sequence_width(IntPtr sequence);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_height")]
+    public static extern int frame_sequence_height(IntPtr sequence);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_frame_count")]
+    public static extern nuint frame_sequence_frame_count(IntPtr sequence);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_add_frame")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool frame_sequence_add_frame(IntPtr sequence,
+                                                       byte[] rgb24,
+                                                       nuint byteCount,
+                                                       uint holdTimeUs);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_clear")]
+    public static extern void frame_sequence_clear(IntPtr sequence);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_write_to_file", CharSet = CharSet.Ansi)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool frame_sequence_write_to_file(IntPtr sequence, string path);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_read_from_file", CharSet = CharSet.Ansi)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool frame_sequence_read_from_file(IntPtr sequence, string path);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_play_forever")]
+    public static extern void frame_sequence_play_forever(IntPtr sequence,
+                                                           IntPtr matrix,
+                                                           IntPtr interruptReceived,
+                                                           IntPtr brightnessPercent);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_play_count")]
+    public static extern void frame_sequence_play_count(IntPtr sequence,
+                                                        IntPtr matrix,
+                                                        uint playCount,
+                                                        IntPtr interruptReceived,
+                                                        IntPtr brightnessPercent);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_play_duration")]
+    public static extern void frame_sequence_play_duration(IntPtr sequence,
+                                                           IntPtr matrix,
+                                                           uint durationMs,
+                                                           IntPtr interruptReceived,
+                                                           IntPtr brightnessPercent);
+
+    [DllImport(Lib, EntryPoint = "frame_sequence_play")]
+    public static extern void frame_sequence_play(IntPtr sequence,
+                                                  IntPtr matrix,
+                                                  IntPtr interruptReceived,
+                                                  IntPtr brightnessPercent);
 }

--- a/bindings/c#/FrameSequence.cs
+++ b/bindings/c#/FrameSequence.cs
@@ -1,0 +1,180 @@
+using System.Runtime.InteropServices;
+
+namespace RPiRgbLEDMatrix;
+
+/// <summary>
+/// Managed wrapper for the native FrameSequence API.
+/// Frames are packed RGB24 bytes in display order.
+/// </summary>
+public sealed class FrameSequence : IDisposable
+{
+    private IntPtr _sequence;
+    private bool _disposed;
+
+    public FrameSequence(int width, int height)
+    {
+        _sequence = frame_sequence_create(width, height);
+        if (_sequence == IntPtr.Zero)
+            throw new ArgumentException("Failed to create FrameSequence");
+    }
+
+    public int Width => frame_sequence_width(_sequence);
+    public int Height => frame_sequence_height(_sequence);
+    public nuint FrameCount => frame_sequence_frame_count(_sequence);
+
+    public void AddFrame(byte[] rgb24, uint holdTimeUs)
+    {
+        ObjectDisposedException.ThrowIf(_sequence == IntPtr.Zero, GetType());
+        ArgumentNullException.ThrowIfNull(rgb24);
+        if (!frame_sequence_add_frame(_sequence, rgb24, (nuint)rgb24.Length, holdTimeUs))
+            throw new ArgumentException("Failed to add frame. Ensure RGB24 length is width*height*3.");
+    }
+
+    public void Clear()
+    {
+        ObjectDisposedException.ThrowIf(_sequence == IntPtr.Zero, GetType());
+        frame_sequence_clear(_sequence);
+    }
+
+    public void ReadFromFile(string path)
+    {
+        ObjectDisposedException.ThrowIf(_sequence == IntPtr.Zero, GetType());
+        if (!frame_sequence_read_from_file(_sequence, path))
+            throw new InvalidOperationException($"Failed to read frame sequence from '{path}'.");
+    }
+
+    public void WriteToFile(string path)
+    {
+        ObjectDisposedException.ThrowIf(_sequence == IntPtr.Zero, GetType());
+        if (!frame_sequence_write_to_file(_sequence, path))
+            throw new InvalidOperationException($"Failed to write frame sequence to '{path}'.");
+    }
+
+    /// <summary>
+    /// Play the sequence forever.
+    /// Stop by setting interruptReceived[0] to non-zero.
+    /// Adjust brightness dynamically by updating brightnessPercent[0].
+    /// </summary>
+    public void PlayForever(RGBLedMatrix matrix, int[] interruptReceived, int[] brightnessPercent)
+    {
+        ObjectDisposedException.ThrowIf(_sequence == IntPtr.Zero, GetType());
+        ArgumentNullException.ThrowIfNull(matrix);
+        ArgumentNullException.ThrowIfNull(interruptReceived);
+        ArgumentNullException.ThrowIfNull(brightnessPercent);
+        if (interruptReceived.Length < 1)
+            throw new ArgumentException("interruptReceived must have at least one element.");
+        if (brightnessPercent.Length < 1)
+            throw new ArgumentException("brightnessPercent must have at least one element.");
+
+        var stopHandle = GCHandle.Alloc(interruptReceived, GCHandleType.Pinned);
+        var brightHandle = GCHandle.Alloc(brightnessPercent, GCHandleType.Pinned);
+        try
+        {
+            frame_sequence_play_forever(_sequence, matrix.NativeHandle,
+                                        stopHandle.AddrOfPinnedObject(),
+                                        brightHandle.AddrOfPinnedObject());
+        }
+        finally
+        {
+            brightHandle.Free();
+            stopHandle.Free();
+        }
+    }
+
+    /// <summary>
+    /// Play the sequence a fixed number of times.
+    /// Stop by setting interruptReceived[0] to non-zero.
+    /// Adjust brightness dynamically by updating brightnessPercent[0].
+    /// </summary>
+    public void PlayCount(RGBLedMatrix matrix, uint playCount, int[] interruptReceived, int[] brightnessPercent)
+    {
+        ObjectDisposedException.ThrowIf(_sequence == IntPtr.Zero, GetType());
+        ArgumentNullException.ThrowIfNull(matrix);
+        ArgumentNullException.ThrowIfNull(interruptReceived);
+        ArgumentNullException.ThrowIfNull(brightnessPercent);
+        if (interruptReceived.Length < 1)
+            throw new ArgumentException("interruptReceived must have at least one element.");
+        if (brightnessPercent.Length < 1)
+            throw new ArgumentException("brightnessPercent must have at least one element.");
+
+        var stopHandle = GCHandle.Alloc(interruptReceived, GCHandleType.Pinned);
+        var brightHandle = GCHandle.Alloc(brightnessPercent, GCHandleType.Pinned);
+        try
+        {
+            frame_sequence_play_count(_sequence, matrix.NativeHandle, playCount,
+                                      stopHandle.AddrOfPinnedObject(),
+                                      brightHandle.AddrOfPinnedObject());
+        }
+        finally
+        {
+            brightHandle.Free();
+            stopHandle.Free();
+        }
+    }
+
+    /// <summary>
+    /// Play the sequence for a fixed duration in milliseconds.
+    /// </summary>
+    public void PlayDuration(RGBLedMatrix matrix, uint durationMs, int[] interruptReceived, int[] brightnessPercent)
+    {
+        ObjectDisposedException.ThrowIf(_sequence == IntPtr.Zero, GetType());
+        ArgumentNullException.ThrowIfNull(matrix);
+        ArgumentNullException.ThrowIfNull(interruptReceived);
+        ArgumentNullException.ThrowIfNull(brightnessPercent);
+        if (interruptReceived.Length < 1)
+            throw new ArgumentException("interruptReceived must have at least one element.");
+        if (brightnessPercent.Length < 1)
+            throw new ArgumentException("brightnessPercent must have at least one element.");
+
+        var stopHandle = GCHandle.Alloc(interruptReceived, GCHandleType.Pinned);
+        var brightHandle = GCHandle.Alloc(brightnessPercent, GCHandleType.Pinned);
+        try
+        {
+            frame_sequence_play_duration(_sequence, matrix.NativeHandle, durationMs,
+                                         stopHandle.AddrOfPinnedObject(),
+                                         brightHandle.AddrOfPinnedObject());
+        }
+        finally
+        {
+            brightHandle.Free();
+            stopHandle.Free();
+        }
+    }
+
+    /// <summary>
+    /// Legacy alias for forever playback.
+    /// </summary>
+    public void PlayForever(RGBLedMatrix matrix)
+    {
+        ObjectDisposedException.ThrowIf(_sequence == IntPtr.Zero, GetType());
+        ArgumentNullException.ThrowIfNull(matrix);
+        frame_sequence_play_forever(_sequence, matrix.NativeHandle, IntPtr.Zero, IntPtr.Zero);
+    }
+
+    /// <summary>
+    /// Legacy alias for forever playback.
+    /// </summary>
+    public void Play(RGBLedMatrix matrix)
+    {
+        PlayForever(matrix);
+    }
+
+    /// <summary>
+    /// Legacy alias for forever playback.
+    /// </summary>
+    public void Play(RGBLedMatrix matrix, int[] interruptReceived, int[] brightnessPercent)
+    {
+        PlayForever(matrix, interruptReceived, brightnessPercent);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        if (_sequence != IntPtr.Zero)
+        {
+            frame_sequence_destroy(_sequence);
+            _sequence = IntPtr.Zero;
+        }
+        _disposed = true;
+    }
+}

--- a/bindings/c#/README.md
+++ b/bindings/c#/README.md
@@ -12,3 +12,8 @@ To build the C# wrapper for the RGB Matrix C library you need to first have __.N
 For some old distributions, read [docs](https://learn.microsoft.com/dotnet/core/install/linux)
 Then, in the `bindings/c#` directory type: `dotnet build`
 To run the example applications in the c#\examples\EXAMPLE folder: `sudo dotnet run`
+
+FrameSequence example:
+
+- `bindings/c#/examples/FseqPlayer` plays `.fseq` files using the managed
+	`FrameSequence` wrapper.

--- a/bindings/c#/RGBLedMatrix.cs
+++ b/bindings/c#/RGBLedMatrix.cs
@@ -11,6 +11,8 @@ public class RGBLedMatrix : IDisposable
     private IntPtr matrix;
     private bool disposedValue = false;
 
+    internal IntPtr NativeHandle => matrix;
+
     /// <summary>
     /// Initializes a new matrix.
     /// </summary>

--- a/bindings/c#/examples/FseqPlayer/FseqPlayer.cs
+++ b/bindings/c#/examples/FseqPlayer/FseqPlayer.cs
@@ -1,0 +1,72 @@
+using RPiRgbLEDMatrix;
+
+public sealed class FseqPlayer : IDisposable
+{
+    private readonly RGBLedMatrix _matrix;
+    private readonly int _width;
+    private readonly int _height;
+    private readonly int[] _stop = new[] { 0 };
+    private readonly int[] _brightness;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FseqPlayer"/> class.
+    /// </summary>
+    /// <param name="options">The matrix options.</param>
+    public FseqPlayer(RGBLedMatrixOptions options)
+    {
+        _matrix = new RGBLedMatrix(options);
+        _width = options.Cols * options.ChainLength;
+        _height = options.Rows * options.Parallel;
+        _brightness = new[] { (int)_matrix.Brightness };
+    }
+
+    public int BrightnessPercent => _brightness[0];
+
+    /// <summary>
+    /// Plays an fseq file on the LED matrix.
+    /// </summary>
+    /// <param name="sequencePath">The path to the .fseq file.</param>
+    public void PlayForever(string sequencePath)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, GetType());
+        using var sequence = new FrameSequence(_width, _height);
+        sequence.ReadFromFile(sequencePath);
+        _stop[0] = 0;
+        sequence.PlayForever(_matrix, _stop, _brightness);
+    }
+
+    public void Stop()
+    {
+        _stop[0] = 1;
+    }
+
+    public void SetBrightness(int percent)
+    {
+        _brightness[0] = ClampBrightness(percent);
+    }
+
+    public void IncreaseBrightness(int step = 5)
+    {
+        _brightness[0] = ClampBrightness(_brightness[0] + step);
+    }
+
+    public void DecreaseBrightness(int step = 5)
+    {
+        _brightness[0] = ClampBrightness(_brightness[0] - step);
+    }
+
+    private static int ClampBrightness(int percent)
+    {
+        return Math.Max(1, Math.Min(100, percent));
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _matrix.Dispose();
+        _disposed = true;
+    }
+}

--- a/bindings/c#/examples/FseqPlayer/FseqPlayer.csproj
+++ b/bindings/c#/examples/FseqPlayer/FseqPlayer.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RPiRgbLEDMatrix.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/bindings/c#/examples/FseqPlayer/Program.cs
+++ b/bindings/c#/examples/FseqPlayer/Program.cs
@@ -1,0 +1,73 @@
+using RPiRgbLEDMatrix;
+
+string path;
+if (args.Length > 0 && File.Exists(args[^1]))
+{
+    path = args[^1];
+}
+else
+{
+    path = "";
+    const string defaultPath = "/root/sample.fseq";
+    Console.WriteLine("Usage: FseqPlayer [fseq_path]");
+    Console.WriteLine("Where [fseq_path] points to a .fseq file created by frame-sequence-player -O");
+    Console.WriteLine($"Or hit ENTER to use default: {defaultPath}");
+
+    while (path == "")
+    {
+        var enteredPath = Console.ReadLine();
+        if (string.IsNullOrWhiteSpace(enteredPath))
+        {
+            path = defaultPath;
+        }
+        else if (File.Exists(enteredPath))
+        {
+            path = enteredPath;
+        }
+        else
+        {
+            Console.WriteLine($"File '{enteredPath}' does not exist. Try again or hit ENTER for default.");
+        }
+    }
+}
+
+var matrixOptions = new RGBLedMatrixOptions
+{
+    Cols = 128,
+    Rows = 64,
+    Parallel = 2,
+    GpioSlowdown = 4,
+    RowAddressType = 5
+};
+
+using var player = new FseqPlayer(matrixOptions);
+
+Console.WriteLine("Playing .fseq. Controls: '+'/'-' brightness, 'q' quit.");
+
+var keyThread = new Thread(() =>
+{
+    while (true)
+    {
+        var key = Console.ReadKey(intercept: true).KeyChar;
+        if (key == '+' || key == '=')
+        {
+            player.IncreaseBrightness();
+            Console.Write($"\rBrightness: {player.BrightnessPercent}   ");
+        }
+        else if (key == '-' || key == '_')
+        {
+            player.DecreaseBrightness();
+            Console.Write($"\rBrightness: {player.BrightnessPercent}   ");
+        }
+        else if (key == 'q' || key == 'Q')
+        {
+            player.Stop();
+            return;
+        }
+    }
+});
+keyThread.IsBackground = true;
+keyThread.Start();
+
+player.PlayForever(path);
+Console.WriteLine("\nDone.");

--- a/examples-api-use/README.md
+++ b/examples-api-use/README.md
@@ -83,6 +83,9 @@ page.
 
  * [minimal-example](./minimal-example.cc) Good to get started with the API
  * [image-example](./image-example.cc) How to show an image (requires to install the graphics magic library, see in the header of that demo)
+ * Frame-sequence playback and `.fseq` export/import are provided in the
+   [utils/frame-sequence-player](../utils/frame-sequence-player.cc) utility.
+   For managed usage, see [bindings/c#/examples/FseqPlayer](../bindings/c%23/examples/FseqPlayer).
  * [text-example](./text-example.cc) Reads text from stdin and displays it.
  * [scrolling-text-example](./scrolling-text-example.cc) Scrolls a text
    given on the command-line.

--- a/include/frame-sequence-c.h
+++ b/include/frame-sequence-c.h
@@ -1,0 +1,68 @@
+/* C API for frame-sequence (C wrapper for frame-sequence.h) */
+#ifndef FRAME_SEQUENCE_C_H
+#define FRAME_SEQUENCE_C_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque FrameSequence handle */
+typedef void* FrameSequenceHandle;
+
+/* Forward declaration from led-matrix-c.h */
+struct RGBLedMatrix;
+
+/* Lifetime */
+FrameSequenceHandle frame_sequence_create(int width, int height);
+void frame_sequence_destroy(FrameSequenceHandle sequence);
+
+/* Metadata */
+int frame_sequence_width(FrameSequenceHandle sequence);
+int frame_sequence_height(FrameSequenceHandle sequence);
+size_t frame_sequence_frame_count(FrameSequenceHandle sequence);
+
+/* Content mutation */
+int frame_sequence_add_frame(FrameSequenceHandle sequence,
+                             const uint8_t *rgb24,
+                             size_t byte_count,
+                             uint32_t hold_time_us);
+void frame_sequence_clear(FrameSequenceHandle sequence);
+
+/* File I/O */
+int frame_sequence_write_to_file(FrameSequenceHandle sequence, const char *path);
+int frame_sequence_read_from_file(FrameSequenceHandle sequence, const char *path);
+
+/*
+ * Playback:
+ * - interrupt_received: optional pointer; playback stops when *interrupt_received != 0.
+ * - brightness_percent: optional pointer; if set, value is polled per frame.
+ */
+void frame_sequence_play_forever(FrameSequenceHandle sequence,
+                                 struct RGBLedMatrix *matrix,
+                                 const volatile int *interrupt_received,
+                                 const int *brightness_percent);
+void frame_sequence_play_count(FrameSequenceHandle sequence,
+                               struct RGBLedMatrix *matrix,
+                               uint32_t play_count,
+                               const volatile int *interrupt_received,
+                               const int *brightness_percent);
+void frame_sequence_play_duration(FrameSequenceHandle sequence,
+                                  struct RGBLedMatrix *matrix,
+                                  uint32_t duration_ms,
+                                  const volatile int *interrupt_received,
+                                  const int *brightness_percent);
+
+/* Legacy compatibility wrapper for older callers. */
+void frame_sequence_play(FrameSequenceHandle sequence,
+                         struct RGBLedMatrix *matrix,
+                         const volatile int *interrupt_received,
+                         const int *brightness_percent);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/frame-sequence.h
+++ b/include/frame-sequence.h
@@ -1,0 +1,88 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+// Copyright (C) 2026
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation version 2.
+
+#ifndef RPI_FRAME_SEQUENCE_H
+#define RPI_FRAME_SEQUENCE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <functional>
+#include <vector>
+
+namespace rgb_matrix {
+class RGBMatrix;
+
+// A lightweight in-memory sequence of RGB frames and hold-times.
+//
+// Frames are stored as packed RGB24 rows in display order (R,G,B per pixel).
+// This allows simple playback without requiring stream files.
+class FrameSequence {
+public:
+  typedef std::function<int(void)> BrightnessProvider;
+  typedef std::function<bool(void)> StopProvider;
+
+  FrameSequence(int width, int height);
+
+  int width() const;
+  int height() const;
+  size_t frame_count() const;
+
+  // Add one frame in packed RGB24 format.
+  // byte_count must be width * height * 3.
+  bool AddFrame(const uint8_t *rgb24, size_t byte_count, uint32_t hold_time_us);
+
+  // Write the sequence to a .fseq file.
+  bool WriteToFile(const char *path) const;
+
+  // Read a sequence from a .fseq file.
+  bool ReadFromFile(const char *path);
+
+  void Clear();
+
+  // Play the sequence forever until interrupted.
+  void PlayForever(RGBMatrix *matrix,
+                    const StopProvider &stop_provider = StopProvider(),
+                    const BrightnessProvider &brightness_provider = BrightnessProvider()) const;
+
+  // Play the sequence a fixed number of times.
+  void PlayCount(RGBMatrix *matrix,
+                 uint32_t play_count,
+                 const StopProvider &stop_provider = StopProvider(),
+                 const BrightnessProvider &brightness_provider = BrightnessProvider()) const;
+
+  // Play the sequence for a fixed duration in milliseconds.
+  void PlayDuration(RGBMatrix *matrix,
+                    uint32_t duration_ms,
+                    const StopProvider &stop_provider = StopProvider(),
+                    const BrightnessProvider &brightness_provider = BrightnessProvider()) const;
+
+  // Legacy convenience wrapper kept for compatibility with older callers.
+  void Play(RGBMatrix *matrix,
+            volatile bool *interrupt_received = NULL,
+            const BrightnessProvider &brightness_provider = BrightnessProvider()) const;
+
+private:
+  struct Frame {
+    std::vector<uint8_t> rgb24;
+    uint32_t hold_time_us;
+  };
+
+  int width_;
+  int height_;
+  size_t frame_size_;
+  std::vector<Frame> frames_;
+
+  bool PlayOneSequence(RGBMatrix *matrix,
+                      const StopProvider &stop_provider,
+                      const BrightnessProvider &brightness_provider,
+                      const std::function<bool(void)> &should_stop) const;
+};
+
+}  // namespace rgb_matrix
+
+#endif  // RPI_FRAME_SEQUENCE_H

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,6 +18,8 @@ set(RGBMATRIX_RP1_PIO_VENDOR_DIR
 set(RGBMATRIX_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/canvas.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/content-streamer.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/frame-sequence-c.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/frame-sequence.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/graphics.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/led-matrix.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../include/led-matrix-c.h
@@ -31,6 +33,8 @@ cmake_print_variables(RGBMATRIX_HEADERS)
 set(RGBMATRIX_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/bdf-font.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/content-streamer.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/frame-sequence.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/frame-sequence-c.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/framebuffer.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/gpio.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/graphics.cc

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -7,8 +7,8 @@ include ../config.mk
 
 OBJECTS=gpio.o led-matrix.o options-initialize.o framebuffer.o \
 	thread.o bdf-font.o graphics.o led-matrix-c.o hardware-mapping.o \
-	pixel-mapper.o multiplex-mappers.o \
-	content-streamer.o content-streamer-c.o \
+	pixel-mapper.o multiplex-mappers.o frame-sequence.o \
+	content-streamer.o content-streamer-c.o frame-sequence-c.o \
 	rp1/rp1_pio_backend.o rp1/rp1_pio_support.o rp1/rp1_rio_backend.o
 
 TARGET=librgbmatrix

--- a/lib/frame-sequence-c.cc
+++ b/lib/frame-sequence-c.cc
@@ -1,0 +1,127 @@
+// C wrapper implementations for frame-sequence C API
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+
+#include "frame-sequence-c.h"
+
+#include "frame-sequence.h"
+#include "led-matrix.h"
+
+extern "C" {
+
+FrameSequenceHandle frame_sequence_create(int width, int height) {
+  if (width <= 0 || height <= 0) return nullptr;
+  return reinterpret_cast<FrameSequenceHandle>(new rgb_matrix::FrameSequence(width, height));
+}
+
+void frame_sequence_destroy(FrameSequenceHandle sequence) {
+  delete reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+}
+
+int frame_sequence_width(FrameSequenceHandle sequence) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  if (s == nullptr) return 0;
+  return s->width();
+}
+
+int frame_sequence_height(FrameSequenceHandle sequence) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  if (s == nullptr) return 0;
+  return s->height();
+}
+
+size_t frame_sequence_frame_count(FrameSequenceHandle sequence) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  if (s == nullptr) return 0;
+  return s->frame_count();
+}
+
+int frame_sequence_add_frame(FrameSequenceHandle sequence,
+                             const uint8_t *rgb24,
+                             size_t byte_count,
+                             uint32_t hold_time_us) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  if (s == nullptr) return 0;
+  return s->AddFrame(rgb24, byte_count, hold_time_us) ? 1 : 0;
+}
+
+void frame_sequence_clear(FrameSequenceHandle sequence) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  if (s == nullptr) return;
+  s->Clear();
+}
+
+int frame_sequence_write_to_file(FrameSequenceHandle sequence, const char *path) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  if (s == nullptr || path == nullptr) return 0;
+  return s->WriteToFile(path) ? 1 : 0;
+}
+
+int frame_sequence_read_from_file(FrameSequenceHandle sequence, const char *path) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  if (s == nullptr || path == nullptr) return 0;
+  return s->ReadFromFile(path) ? 1 : 0;
+}
+
+static rgb_matrix::FrameSequence::StopProvider BuildStopProvider(const volatile int *interrupt_received) {
+  rgb_matrix::FrameSequence::StopProvider stop_provider;
+  if (interrupt_received != nullptr) {
+    stop_provider = [interrupt_received]() {
+      return *interrupt_received != 0;
+    };
+  }
+  return stop_provider;
+}
+
+static rgb_matrix::FrameSequence::BrightnessProvider BuildBrightnessProvider(const int *brightness_percent) {
+  rgb_matrix::FrameSequence::BrightnessProvider brightness_provider;
+  if (brightness_percent != nullptr) {
+    brightness_provider = [brightness_percent]() {
+      return *brightness_percent;
+    };
+  }
+  return brightness_provider;
+}
+
+void frame_sequence_play_forever(FrameSequenceHandle sequence,
+                                 struct RGBLedMatrix *matrix,
+                                 const volatile int *interrupt_received,
+                                 const int *brightness_percent) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  auto m = reinterpret_cast<rgb_matrix::RGBMatrix*>(matrix);
+  if (s == nullptr || m == nullptr) return;
+
+  s->PlayForever(m, BuildStopProvider(interrupt_received), BuildBrightnessProvider(brightness_percent));
+}
+
+void frame_sequence_play_count(FrameSequenceHandle sequence,
+                               struct RGBLedMatrix *matrix,
+                               uint32_t play_count,
+                               const volatile int *interrupt_received,
+                               const int *brightness_percent) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  auto m = reinterpret_cast<rgb_matrix::RGBMatrix*>(matrix);
+  if (s == nullptr || m == nullptr) return;
+
+  s->PlayCount(m, play_count, BuildStopProvider(interrupt_received), BuildBrightnessProvider(brightness_percent));
+}
+
+void frame_sequence_play_duration(FrameSequenceHandle sequence,
+                                  struct RGBLedMatrix *matrix,
+                                  uint32_t duration_ms,
+                                  const volatile int *interrupt_received,
+                                  const int *brightness_percent) {
+  auto s = reinterpret_cast<rgb_matrix::FrameSequence*>(sequence);
+  auto m = reinterpret_cast<rgb_matrix::RGBMatrix*>(matrix);
+  if (s == nullptr || m == nullptr) return;
+
+  s->PlayDuration(m, duration_ms, BuildStopProvider(interrupt_received), BuildBrightnessProvider(brightness_percent));
+}
+
+void frame_sequence_play(FrameSequenceHandle sequence,
+                         struct RGBLedMatrix *matrix,
+                         const volatile int *interrupt_received,
+                         const int *brightness_percent) {
+  frame_sequence_play_forever(sequence, matrix, interrupt_received, brightness_percent);
+}
+
+}  // extern "C"

--- a/lib/frame-sequence.cc
+++ b/lib/frame-sequence.cc
@@ -1,0 +1,309 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+
+#include "frame-sequence.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+
+#include "led-matrix.h"
+
+namespace rgb_matrix {
+
+namespace {
+static const uint32_t kFseqMagic = 0x51455346;  // "FSEQ"
+static const useconds_t kStopPollIntervalUs = 10000;
+
+struct FseqHeader {
+  uint32_t magic;
+  uint32_t version;
+  uint32_t width;
+  uint32_t height;
+  uint32_t frame_count;
+  uint32_t frame_size;
+};
+
+struct FseqFrameHeader {
+  uint32_t hold_time_us;
+};
+
+static inline uint8_t ClampBrightness(int value) {
+  if (value < 1) return 1;
+  if (value > 100) return 100;
+  return value;
+}
+
+}  // namespace
+
+FrameSequence::FrameSequence(int width, int height)
+    : width_(width), height_(height), frame_size_(0) {
+  if (width_ > 0 && height_ > 0) {
+    frame_size_ = static_cast<size_t>(width_) * static_cast<size_t>(height_) * 3;
+  }
+}
+
+int FrameSequence::width() const { return width_; }
+int FrameSequence::height() const { return height_; }
+size_t FrameSequence::frame_count() const { return frames_.size(); }
+
+bool FrameSequence::AddFrame(const uint8_t *rgb24,
+                             size_t byte_count,
+                             uint32_t hold_time_us) {
+  if (rgb24 == NULL || frame_size_ == 0 || byte_count != frame_size_) {
+    return false;
+  }
+
+  Frame frame;
+  frame.rgb24.resize(frame_size_);
+  memcpy(frame.rgb24.data(), rgb24, frame_size_);
+  frame.hold_time_us = hold_time_us;
+  frames_.push_back(frame);
+  return true;
+}
+
+bool FrameSequence::WriteToFile(const char *path) const {
+  if (path == NULL || frame_size_ == 0) {
+    return false;
+  }
+  if (frames_.size() > 0xFFFFFFFFu) {
+    return false;
+  }
+
+  FILE *f = fopen(path, "wb");
+  if (f == NULL) {
+    perror("Unable to open output file");
+    return false;
+  }
+
+  FseqHeader header = {};
+  header.magic = kFseqMagic;
+  header.version = 1;
+  header.width = static_cast<uint32_t>(width_);
+  header.height = static_cast<uint32_t>(height_);
+  header.frame_count = static_cast<uint32_t>(frames_.size());
+  header.frame_size = static_cast<uint32_t>(frame_size_);
+
+  if (fwrite(&header, sizeof(header), 1, f) != 1) {
+    fclose(f);
+    return false;
+  }
+
+  for (std::vector<Frame>::const_iterator it = frames_.begin();
+       it != frames_.end(); ++it) {
+    FseqFrameHeader fh = {};
+    fh.hold_time_us = it->hold_time_us;
+    if (fwrite(&fh, sizeof(fh), 1, f) != 1) {
+      fclose(f);
+      return false;
+    }
+    if (fwrite(it->rgb24.data(), 1, frame_size_, f) != frame_size_) {
+      fclose(f);
+      return false;
+    }
+  }
+
+  const bool ok = (fclose(f) == 0);
+  return ok;
+}
+
+bool FrameSequence::ReadFromFile(const char *path) {
+  if (path == NULL || frame_size_ == 0) {
+    return false;
+  }
+
+  FILE *f = fopen(path, "rb");
+  if (f == NULL) {
+    perror("Unable to open input file");
+    return false;
+  }
+
+  FseqHeader header = {};
+  if (fread(&header, sizeof(header), 1, f) != 1) {
+    fclose(f);
+    return false;
+  }
+
+  if (header.magic != kFseqMagic || header.version != 1) {
+    fclose(f);
+    fprintf(stderr, "Unsupported .fseq format in '%s'\n", path);
+    return false;
+  }
+
+  if ((int) header.width != width_ || (int) header.height != height_) {
+    fclose(f);
+    fprintf(stderr,
+            "Input .fseq is %ux%u but current matrix target is %dx%d\n",
+            header.width, header.height, width_, height_);
+    return false;
+  }
+
+  if (header.frame_size != frame_size_) {
+    fclose(f);
+    fprintf(stderr,
+            "Input .fseq frame payload size %u does not match expected %u\n",
+            header.frame_size, (unsigned) frame_size_);
+    return false;
+  }
+
+  std::vector<Frame> loaded;
+  loaded.reserve(header.frame_count);
+  for (uint32_t i = 0; i < header.frame_count; ++i) {
+    FseqFrameHeader fh = {};
+    if (fread(&fh, sizeof(fh), 1, f) != 1) {
+      fclose(f);
+      return false;
+    }
+
+    Frame frame;
+    frame.hold_time_us = fh.hold_time_us;
+    frame.rgb24.resize(frame_size_);
+    if (fread(frame.rgb24.data(), 1, frame_size_, f) != frame_size_) {
+      fclose(f);
+      return false;
+    }
+    loaded.push_back(frame);
+  }
+
+  if (fclose(f) != 0) {
+    return false;
+  }
+
+  frames_.swap(loaded);
+  return true;
+}
+
+void FrameSequence::Clear() {
+  frames_.clear();
+}
+
+void FrameSequence::PlayForever(
+    RGBMatrix *matrix,
+    const StopProvider &stop_provider,
+    const BrightnessProvider &brightness_provider) const {
+  auto always_continue = []() {
+    return false;
+  };
+  while (!stop_provider || !stop_provider()) {
+    if (!PlayOneSequence(matrix, stop_provider, brightness_provider, always_continue)) {
+      break;
+    }
+  }
+}
+
+void FrameSequence::PlayCount(
+    RGBMatrix *matrix,
+    uint32_t play_count,
+    const StopProvider &stop_provider,
+    const BrightnessProvider &brightness_provider) const {
+  if (play_count == 0) {
+    return;
+  }
+  auto always_continue = []() {
+    return false;
+  };
+  for (uint32_t i = 0; i < play_count; ++i) {
+    if (stop_provider && stop_provider()) {
+      break;
+    }
+    if (!PlayOneSequence(matrix, stop_provider, brightness_provider, always_continue)) {
+      break;
+    }
+  }
+}
+
+void FrameSequence::PlayDuration(
+    RGBMatrix *matrix,
+    uint32_t duration_ms,
+    const StopProvider &stop_provider,
+    const BrightnessProvider &brightness_provider) const {
+  if (duration_ms == 0) {
+    return;
+  }
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(duration_ms);
+  auto should_stop = [&deadline]() {
+    return std::chrono::steady_clock::now() >= deadline;
+  };
+
+  while ((!stop_provider || !stop_provider()) && !should_stop()) {
+    if (!PlayOneSequence(matrix, stop_provider, brightness_provider, should_stop)) {
+      break;
+    }
+  }
+}
+
+void FrameSequence::Play(
+    RGBMatrix *matrix,
+    volatile bool *interrupt_received,
+    const BrightnessProvider &brightness_provider) const {
+  auto stop_provider = [interrupt_received]() {
+    return interrupt_received != NULL && *interrupt_received;
+  };
+  PlayForever(matrix, stop_provider, brightness_provider);
+}
+
+bool FrameSequence::PlayOneSequence(
+    RGBMatrix *matrix,
+    const StopProvider &stop_provider,
+    const BrightnessProvider &brightness_provider,
+    const std::function<bool(void)> &should_stop) const {
+  if (matrix == NULL || frames_.empty()) {
+    return false;
+  }
+
+  if (matrix->width() != width_ || matrix->height() != height_) {
+    fprintf(stderr, "FrameSequence is %dx%d but matrix is %dx%d\n",
+            width_, height_, matrix->width(), matrix->height());
+    return false;
+  }
+
+  FrameCanvas *offscreen = matrix->SwapOnVSync(NULL);
+  if (offscreen == NULL) {
+    return false;
+  }
+
+  int last_brightness = -1;
+  for (std::vector<Frame>::const_iterator it = frames_.begin();
+       it != frames_.end(); ++it) {
+    if ((stop_provider && stop_provider()) || (should_stop && should_stop())) {
+      break;
+    }
+
+    if (brightness_provider) {
+      const int wanted = ClampBrightness(brightness_provider());
+      if (wanted != last_brightness) {
+        matrix->SetBrightness(wanted);
+        last_brightness = wanted;
+      }
+    }
+
+    const uint8_t *p = it->rgb24.data();
+    for (int y = 0; y < height_; ++y) {
+      for (int x = 0; x < width_; ++x) {
+        offscreen->SetPixel(x, y, p[0], p[1], p[2]);
+        p += 3;
+      }
+    }
+
+    offscreen = matrix->SwapOnVSync(offscreen);
+    if (it->hold_time_us > 0) {
+      uint32_t remaining_us = it->hold_time_us;
+      while (remaining_us > 0) {
+        if ((stop_provider && stop_provider()) || (should_stop && should_stop())) {
+          break;
+        }
+
+        const useconds_t sleep_us = remaining_us > kStopPollIntervalUs ? kStopPollIntervalUs : remaining_us;
+        usleep(sleep_us);
+        remaining_us -= sleep_us;
+      }
+    }
+  }
+
+  return true;
+}
+
+}  // namespace rgb_matrix

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,8 +1,8 @@
 include ../config.mk
 
 CXXFLAGS=-O3 $(CPU_ARCH_FLAGS) $(LTO_FLAGS) -W -Wall -Wextra -Wno-unused-parameter -D_FILE_OFFSET_BITS=64
-OBJECTS=led-image-viewer.o text-scroller.o
-BINARIES=led-image-viewer text-scroller
+OBJECTS=led-image-viewer.o text-scroller.o frame-sequence-player.o
+BINARIES=led-image-viewer text-scroller frame-sequence-player
 
 OPTIONAL_OBJECTS=video-viewer.o
 OPTIONAL_BINARIES=video-viewer
@@ -38,6 +38,9 @@ text-scroller: text-scroller.o $(RGB_LIBRARY)
 led-image-viewer: led-image-viewer.o $(RGB_LIBRARY)
 	$(CXX) $(CXXFLAGS) led-image-viewer.o -o $@ $(LDFLAGS) $(RGB_LDFLAGS) $(MAGICK_LDFLAGS)
 
+frame-sequence-player: frame-sequence-player.o $(RGB_LIBRARY)
+	$(CXX) $(CXXFLAGS) frame-sequence-player.o -o $@ $(LDFLAGS) $(RGB_LDFLAGS) $(MAGICK_LDFLAGS)
+
 video-viewer: video-viewer.o $(RGB_LIBRARY)
 	$(CXX) $(CXXFLAGS) video-viewer.o -o $@ $(LDFLAGS) $(RGB_LDFLAGS) $(AV_LDFLAGS)
 
@@ -45,6 +48,9 @@ video-viewer: video-viewer.o $(RGB_LIBRARY)
 	$(CXX) -I$(RGB_INCDIR) $(CXXFLAGS) -c -o $@ $<
 
 led-image-viewer.o : led-image-viewer.cc
+	$(CXX) -I$(RGB_INCDIR) $(CXXFLAGS) $(MAGICK_CXXFLAGS) -c -o $@ $<
+
+frame-sequence-player.o : frame-sequence-player.cc
 	$(CXX) -I$(RGB_INCDIR) $(CXXFLAGS) $(MAGICK_CXXFLAGS) -c -o $@ $<
 
 clean:

--- a/utils/README.md
+++ b/utils/README.md
@@ -242,6 +242,56 @@ sudo ./text-scroller -f ../fonts/9x18.bdf -B0,0,255 -O0,0,100 -C255,0,0 --led-ch
 sudo ./text-scroller -f ../fonts/texgyre-27.bdf --led-chain=4 -y-11 "Large Font"
 ```
 
+### Frame Sequence Player ###
+
+`frame-sequence-player` can either:
+
+1. Load and play an image/animation through the in-memory FrameSequence API.
+2. Export an image/animation to a `.fseq` file for fast later playback.
+3. Load and play an existing `.fseq` file.
+
+##### Building
+
+The utility requires GraphicsMagick, similar to `led-image-viewer`:
+
+```bash
+sudo apt-get update
+sudo apt-get install libgraphicsmagick++-dev libwebp-dev -y
+make frame-sequence-player
+```
+
+##### Usage
+
+```bash
+./frame-sequence-player [led-matrix-options] <image-or-fseq> [-O<output.fseq> | -O <output.fseq>]
+```
+
+##### Examples
+
+```bash
+# Play an image or animated gif
+sudo ./frame-sequence-player animation.gif
+
+# Convert gif to .fseq (no root needed for file conversion)
+./frame-sequence-player animation.gif -Oanimation.fseq
+
+# Play a prebuilt .fseq
+sudo ./frame-sequence-player animation.fseq
+```
+
+While playing, keyboard controls are available when stdin is a tty:
+
+- `+` / `=` increase brightness
+- `-` / `_` decrease brightness
+- `q` quit
+
+#### FrameSequence notes
+When outputting an `.fseq` file (Using `-O`), only options which govern geometry are important, ie  
+--led-cols  
+--led-rows  
+--led-chain  
+--led-parallel  
+
 ### Video Viewer ###
 
 The video viewer allows to play common video formats on the RGB matrix (just

--- a/utils/frame-sequence-player.cc
+++ b/utils/frame-sequence-player.cc
@@ -1,0 +1,281 @@
+// -*- mode: c++; c-basic-offset: 2; indent-tabs-mode: nil; -*-
+//
+// Utility showing how to decode an image/animation and play it from an
+// in-memory frame sequence.
+
+#include "frame-sequence.h"
+#include "led-matrix.h"
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include <exception>
+#include <Magick++.h>
+
+using rgb_matrix::FrameSequence;
+using rgb_matrix::RGBMatrix;
+
+volatile bool interrupt_received = false;
+static void InterruptHandler(int signo) {
+  interrupt_received = true;
+}
+
+class ConsoleBrightnessControl {
+ public:
+  explicit ConsoleBrightnessControl(int initial)
+      : initialized_(false), brightness_(Clamp(initial)), old_flags_(0) {
+    memset(&old_termios_, 0, sizeof(old_termios_));
+  }
+
+  bool Init() {
+    if (!isatty(STDIN_FILENO)) {
+      fprintf(stderr, "stdin is not a tty; interactive brightness disabled.\n");
+      return false;
+    }
+
+    if (tcgetattr(STDIN_FILENO, &old_termios_) != 0) {
+      perror("tcgetattr");
+      return false;
+    }
+    old_flags_ = fcntl(STDIN_FILENO, F_GETFL, 0);
+    if (old_flags_ < 0) {
+      perror("fcntl(F_GETFL)");
+      return false;
+    }
+
+    struct termios raw = old_termios_;
+    raw.c_lflag &= ~(ICANON | ECHO);
+    raw.c_cc[VMIN] = 0;
+    raw.c_cc[VTIME] = 0;
+
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &raw) != 0) {
+      perror("tcsetattr");
+      return false;
+    }
+    if (fcntl(STDIN_FILENO, F_SETFL, old_flags_ | O_NONBLOCK) != 0) {
+      perror("fcntl(F_SETFL)");
+      tcsetattr(STDIN_FILENO, TCSANOW, &old_termios_);
+      return false;
+    }
+
+    initialized_ = true;
+    fprintf(stderr,
+            "Brightness keys: '+' up, '-' down, 'q' quit (current: %d)\n",
+            brightness_);
+    return true;
+  }
+
+  ~ConsoleBrightnessControl() {
+    Restore();
+  }
+
+  int PollAndGetBrightness() {
+    if (!initialized_) return brightness_;
+
+    char c = 0;
+    while (read(STDIN_FILENO, &c, 1) == 1) {
+      if (c == '+' || c == '=') {
+        brightness_ = Clamp(brightness_ + 5);
+        fprintf(stderr, "\rBrightness: %d   ", brightness_);
+      } else if (c == '-' || c == '_') {
+        brightness_ = Clamp(brightness_ - 5);
+        fprintf(stderr, "\rBrightness: %d   ", brightness_);
+      } else if (c == 'q' || c == 'Q') {
+        interrupt_received = true;
+      }
+    }
+    return brightness_;
+  }
+
+ private:
+  static int Clamp(int value) {
+    if (value < 1) return 1;
+    if (value > 100) return 100;
+    return value;
+  }
+
+  void Restore() {
+    if (!initialized_) return;
+    fcntl(STDIN_FILENO, F_SETFL, old_flags_);
+    tcsetattr(STDIN_FILENO, TCSANOW, &old_termios_);
+    fprintf(stderr, "\n");
+    initialized_ = false;
+  }
+
+  bool initialized_;
+  int brightness_;
+  struct termios old_termios_;
+  int old_flags_;
+};
+
+using ImageVector = std::vector<Magick::Image>;
+
+static bool HasSuffix(const char *value, const char *suffix) {
+  if (value == NULL || suffix == NULL) return false;
+  const size_t value_len = strlen(value);
+  const size_t suffix_len = strlen(suffix);
+  if (suffix_len > value_len) return false;
+  return strcmp(value + value_len - suffix_len, suffix) == 0;
+}
+
+static ImageVector LoadAndScaleFrames(const char *filename,
+                                      int target_width,
+                                      int target_height) {
+  ImageVector result;
+  ImageVector frames;
+  try {
+    readImages(&frames, filename);
+  } catch (std::exception &e) {
+    if (e.what()) {
+      fprintf(stderr, "%s\n", e.what());
+    }
+    return result;
+  }
+
+  if (frames.empty()) {
+    fprintf(stderr, "No image found.\n");
+    return result;
+  }
+
+  if (frames.size() > 1) {
+    Magick::coalesceImages(&result, frames.begin(), frames.end());
+  } else {
+    result.push_back(frames[0]);
+  }
+
+  for (ImageVector::iterator it = result.begin(); it != result.end(); ++it) {
+    it->scale(Magick::Geometry(target_width, target_height));
+  }
+  return result;
+}
+
+static int usage(const char *progname) {
+  fprintf(stderr,
+          "Usage: %s [led-matrix-options] <image-or-fseq> "
+          "[-O<output.fseq> | -O <output.fseq>]\n",
+          progname);
+  rgb_matrix::PrintMatrixFlags(stderr);
+  return 1;
+}
+
+int main(int argc, char *argv[]) {
+  Magick::InitializeMagick(*argv);
+  const char *progname = argv[0];
+
+  RGBMatrix::Options matrix_options;
+  matrix_options.cols = 128;
+  matrix_options.rows = 64;
+  matrix_options.row_address_type = 5;
+  matrix_options.parallel = 2;
+  matrix_options.brightness = 50;
+
+  rgb_matrix::RuntimeOptions runtime_options;
+  runtime_options.gpio_slowdown = 5;
+  if (!rgb_matrix::ParseOptionsFromFlags(&argc, &argv,
+                                         &matrix_options, &runtime_options)) {
+    return usage(progname);
+  }
+
+  if (argc != 2 && argc != 3 && argc != 4) {
+    return usage(progname);
+  }
+
+  const char *filename = argv[1];
+  const char *output_fseq = NULL;
+  if (argc == 3) {
+    if (strncmp(argv[2], "-O", 2) != 0 || argv[2][2] == '\0') {
+      return usage(progname);
+    }
+    output_fseq = argv[2] + 2;
+  } else if (argc == 4) {
+    if (strcmp(argv[2], "-O") != 0) {
+      return usage(progname);
+    }
+    output_fseq = argv[3];
+  }
+
+  signal(SIGTERM, InterruptHandler);
+  signal(SIGINT, InterruptHandler);
+
+  // Decode frames before matrix creation, as matrix init may drop privileges.
+  const int target_width = matrix_options.cols * matrix_options.chain_length;
+  const int target_height = matrix_options.rows * matrix_options.parallel;
+  FrameSequence sequence(target_width, target_height);
+
+  if (HasSuffix(filename, ".fseq")) {
+    if (!sequence.ReadFromFile(filename)) {
+      fprintf(stderr, "Failed to read frame sequence from '%s'\n", filename);
+      return 1;
+    }
+  } else {
+    ImageVector images = LoadAndScaleFrames(filename, target_width, target_height);
+    if (images.empty()) {
+      return 1;
+    }
+
+    const size_t frame_bytes =
+        static_cast<size_t>(target_width) * static_cast<size_t>(target_height) * 3;
+    std::vector<uint8_t> rgb(frame_bytes);
+    for (ImageVector::const_iterator image = images.begin(); image != images.end(); ++image) {
+      uint8_t *out = rgb.data();
+      for (size_t y = 0; y < image->rows(); ++y) {
+        for (size_t x = 0; x < image->columns(); ++x) {
+          const Magick::Color &c = image->pixelColor(x, y);
+          if (c.alphaQuantum() < 256) {
+            *out++ = ScaleQuantumToChar(c.redQuantum());
+            *out++ = ScaleQuantumToChar(c.greenQuantum());
+            *out++ = ScaleQuantumToChar(c.blueQuantum());
+          } else {
+            *out++ = 0;
+            *out++ = 0;
+            *out++ = 0;
+          }
+        }
+      }
+
+      const uint32_t hold_us = image->animationDelay() > 0
+                                   ? image->animationDelay() * 10000u
+                                   : 100000u;
+      if (!sequence.AddFrame(rgb.data(), rgb.size(), hold_us)) {
+        fprintf(stderr, "Failed to add frame to sequence.\n");
+        return 1;
+      }
+    }
+  }
+
+  if (output_fseq != NULL) {
+    if (!sequence.WriteToFile(output_fseq)) {
+      fprintf(stderr, "Failed to write frame sequence to '%s'\n", output_fseq);
+      return 1;
+    }
+    fprintf(stderr, "Wrote %zu frames to %s\n", sequence.frame_count(), output_fseq);
+    return 0;
+  }
+
+  RGBMatrix *matrix = RGBMatrix::CreateFromOptions(matrix_options,
+                                                   runtime_options);
+  if (matrix == NULL) {
+    return 1;
+  }
+
+  ConsoleBrightnessControl brightness_control(matrix_options.brightness);
+  const bool brightness_enabled = brightness_control.Init();
+  auto stop_provider = []() {
+    return interrupt_received;
+  };
+  if (brightness_enabled) {
+    sequence.PlayForever(matrix, stop_provider, [&brightness_control]() {
+      return brightness_control.PollAndGetBrightness();
+    });
+  } else {
+    sequence.PlayForever(matrix, stop_provider);
+  }
+
+  matrix->Clear();
+  delete matrix;
+  return 0;
+}


### PR DESCRIPTION
Adds support for "Frame Sequences" ("fseq" for short)
These are similar to streams, but are not matrix options specific.
They are slightly more compute intensive, but more flexible.

* Adds a frame-sequence C++ API for playing back fseqs
  - Supports dynamic brightness control during playback via a
    BrightnessProvider callback: the player polls it each loop and
    calls matrix->SetBrightness() only when the value changes
* Adds a C API wrapping the same functionality (takes a
  brightness_percent pointer instead of a callback)
* Adds a frame-sequence-player util for command-line playing of fseqs.
  This also allows conversion of files to the fseq format.
  This is analogous to the led-image-viewer util for streams, and the
  command-line switches are identical
* Adds C# bindings and examples for the frame-sequence API